### PR TITLE
YouTube Trusted Type update

### DIFF
--- a/web-resources/wresources.js
+++ b/web-resources/wresources.js
@@ -10,6 +10,15 @@
     return htmlEntities.encode(str);
   }
 
+  // Trusted Types feature testing
+  if (window.trustedTypes && trustedTypes.createPolicy) {
+    // provide a default policy for trusted types
+    trustedTypes.createPolicy('default', {
+      // createHTML() gets called when assigning .innerHTML
+      createHTML: (string) => string,
+    });
+  }
+
   const FORMATTED_NUMBER_CONFIG_ENTRIES = Object.entries({
     k: 1000,
     rb: 1000,


### PR DESCRIPTION
Issue: #26 

Recently, YouTube started rolling out the Trusted Type required header CSP. This breaks HTML insertion using `innerHTML` if the provided HTML content is not marked as "trusted".

Adding a default policy for handling `createHTML` will fix the problem.

References:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for
https://web.dev/articles/trusted-types