### PR TITLE
Remove hidden attribute from #meta.style-scope.ytd-watch-flexy parent

### DIFF
--- a/web-resources/wresources.js
+++ b/web-resources/wresources.js
@@ -10221,6 +10221,7 @@
       Yt() &&
         document.querySelector('#meta.style-scope.ytd-watch-flexy') &&
         (clearInterval(t),
+        document.querySelector('#meta.style-scope.ytd-watch-flexy')?.parentElement.removeAttribute('hidden'),
         (function () {
           let t, n;
           function o() {


### PR DESCRIPTION
Allows YCS to reappear

<img width="1837" height="589" alt="image" src="https://github.com/user-attachments/assets/5be5e9b0-1eb1-49f0-a37c-6e7012eb1566" />

Fixes #49
Fixes #50 
Fixes #51 