### PR TITLE
fix(filters): extract member badge tooltip from sponsorBadgeA11y

### DIFF
--- a/app/src/source/utils/dom.ts
+++ b/app/src/source/utils/dom.ts
@@ -1,4 +1,5 @@
-import Mark, { MarkOptions } from 'mark.js';
+import Mark from 'mark.js';
+import type { MarkOptions } from 'mark.js';
 
 import { GlobalStore, getCleanUrlVideo, getRandomInt, getVideoId, oIsEmpty, wrapTryCatch } from './common';
 

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -2,7 +2,7 @@
 import objectScan from 'object-scan';
 import Queue from 'p-queue';
 
-import { ChatContinuationResult, GetParams } from './interfaces/i_assist';
+import type { ChatContinuationResult, GetParams } from './interfaces/i_assist';
 import { fetchR } from './libs';
 import { GlobalStore, deepFindObjKey, getCleanUrlVideo, getObj, getVideoId, wrapTryCatch } from './common';
 import { parseFormattedNumber } from './formatting';
@@ -321,13 +321,27 @@ function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: 
                     commentObj.commentRenderer.authorIsChannelOwner = true;
                 }
                 const sponsorBadgeUrl = wrapTryCatch(() => update.author?.sponsorBadgeUrl);
+                const sponsorBadgeA11y = wrapTryCatch(() => update.author?.sponsorBadgeA11y);
                 if (sponsorBadgeUrl) {
                     commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.sponsorCommentBadge = {
+
+                    // Preserve existing tooltip if frameworkUpdates doesn't provide one
+                    const existingTooltip = wrapTryCatch(
+                        () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
+                    );
+
+                    const badge: any = {
                         sponsorCommentBadgeRenderer: {
                             customBadge: { thumbnails: [{ url: sponsorBadgeUrl }] }
                         }
                     };
+
+                    const tooltip = sponsorBadgeA11y || existingTooltip;
+                    if (tooltip) {
+                        badge.sponsorCommentBadgeRenderer.tooltip = tooltip;
+                    }
+
+                    commentObj.commentRenderer.sponsorCommentBadge = badge;
                 }
             }
         }
@@ -543,10 +557,18 @@ function generateCommentObjectFromFW(params: {
             } as any;
         }
 
-        if (wrapTryCatch(() => author.sponsorBadgeUrl)) {
-            comment.commentRenderer.sponsorCommentBadge = {
-                sponsorCommentBadgeRenderer: { customBadge: { thumbnails: [{ url: author.sponsorBadgeUrl }] } }
+        const sponsorBadgeUrl = wrapTryCatch(() => author.sponsorBadgeUrl);
+        const sponsorBadgeA11y = wrapTryCatch(() => author.sponsorBadgeA11y);
+        if (sponsorBadgeUrl) {
+            const badge: any = {
+                sponsorCommentBadgeRenderer: {
+                    customBadge: { thumbnails: [{ url: sponsorBadgeUrl }] }
+                }
             };
+            if (sponsorBadgeA11y) {
+                badge.sponsorCommentBadgeRenderer.tooltip = sponsorBadgeA11y;
+            }
+            comment.commentRenderer.sponsorCommentBadge = badge;
         }
         if (wrapTryCatch(() => author.isVerified)) {
             comment.commentRenderer.verifiedAuthor = true;
@@ -3185,5 +3207,8 @@ export {
     getParamsForChat,
     getChatComments,
     getInitYtData,
-    extractNextContinuation
+    extractNextContinuation,
+    // Test exports
+    applyFrameworkUpdatesToComment,
+    generateCommentObjectFromFW
 };

--- a/app/src/source/utils/libs.ts
+++ b/app/src/source/utils/libs.ts
@@ -30,10 +30,16 @@ const fetchR = Fetch(fetch, {
 const IDB_YCS = 'IDB_YCS';
 const STORE_CACHE_YCS = 'STORE_CACHE_YCS';
 
-const idb = openDB(IDB_YCS, 1, {
-    upgrade(db) {
-        db.createObjectStore(STORE_CACHE_YCS);
-    }
-});
+// Only initialize idb if indexedDB is available (browser environment)
+// This allows tests to run in Node.js without indexedDB
+// In non-browser environments, idb will be null and should not be awaited
+const idb =
+    typeof indexedDB !== 'undefined'
+        ? openDB(IDB_YCS, 1, {
+              upgrade(db) {
+                  db.createObjectStore(STORE_CACHE_YCS);
+              }
+          })
+        : (null as any);
 
 export { fetchR, idb };

--- a/app/tests/formatting.test.ts
+++ b/app/tests/formatting.test.ts
@@ -4,7 +4,7 @@ import test from 'node:test';
 import { esc, safeUrl, sanitizeHtml } from '../src/source/utils/formatting';
 
 test('esc converts special characters into HTML entities', () => {
-    const raw = "<div>&'\"";
+    const raw = '<div>&\'"';
     const encoded = esc(raw);
     assert.equal(encoded, '&lt;div&gt;&amp;&#39;&quot;');
 });
@@ -23,7 +23,8 @@ test('safeUrl normalizes common URLs and blocks non-http/https schemes', () => {
 });
 
 test('sanitizeHtml removes dangerous tags and normalizes href/src schemes', () => {
-    const raw = '<div onclick="alert(1)"><a href="javascript:alert(1)">link</a><img src="/image.png" /></div><script>alert(1)</script>';
+    const raw =
+        '<div onclick="alert(1)"><a href="javascript:alert(1)">link</a><img src="/image.png" /></div><script>alert(1)</script>';
     const sanitized = sanitizeHtml(raw);
     assert.equal(
         sanitized,

--- a/app/tests/innertube.test.ts
+++ b/app/tests/innertube.test.ts
@@ -1,0 +1,190 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import { applyFrameworkUpdatesToComment, generateCommentObjectFromFW } from '../src/source/utils/innertube';
+
+/**
+ * Helper: Create minimal frameworkUpdate payload for testing
+ */
+const createMockFrameworkUpdate = (options: {
+    commentId: string;
+    sponsorBadgeUrl?: string;
+    sponsorBadgeA11y?: string;
+}) => ({
+    properties: {
+        commentId: options.commentId,
+        content: { content: 'Test comment content' }
+    },
+    author: {
+        displayName: 'Test User',
+        channelId: 'UCTestChannel123',
+        ...(options.sponsorBadgeUrl && { sponsorBadgeUrl: options.sponsorBadgeUrl }),
+        ...(options.sponsorBadgeA11y && { sponsorBadgeA11y: options.sponsorBadgeA11y })
+    }
+});
+
+/**
+ * Helper: Create fwById lookup object
+ */
+const createFwById = (commentId: string, update: any) => ({
+    [commentId]: update
+});
+
+test('applyFrameworkUpdatesToComment extracts sponsorBadgeA11y to tooltip', () => {
+    // Setup: Create mock data with member badge
+    const commentId = 'test-member-comment';
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        sponsorBadgeUrl: 'https://example.com/member-badge.png',
+        sponsorBadgeA11y: '會員 (1 年 8 個月)'
+    });
+
+    const fwById = createFwById(commentId, mockUpdate);
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId
+        }
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            commentId
+        }
+    };
+
+    // Execute: Apply frameworkUpdates
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    // Assert: Verify sponsorCommentBadge structure
+    assert.ok(commentObj.commentRenderer?.sponsorCommentBadge, 'Expected sponsorCommentBadge to be created');
+
+    const badge = commentObj.commentRenderer.sponsorCommentBadge.sponsorCommentBadgeRenderer;
+
+    // Verify customBadge with URL
+    assert.ok(badge?.customBadge?.thumbnails?.[0]?.url, 'Expected badge URL to be set');
+    assert.equal(
+        badge.customBadge.thumbnails[0].url,
+        'https://example.com/member-badge.png',
+        'Expected badge URL to match mock data'
+    );
+
+    // Verify tooltip is extracted from sponsorBadgeA11y
+    assert.ok(badge?.tooltip, 'Expected tooltip to be set');
+    assert.equal(badge.tooltip, '會員 (1 年 8 個月)', 'Expected tooltip to match sponsorBadgeA11y from mock data');
+});
+
+test('applyFrameworkUpdatesToComment handles comments without member badge', () => {
+    // Setup: Create mock data for non-member comment
+    const commentId = 'test-non-member-comment';
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId
+        // No sponsorBadgeUrl or sponsorBadgeA11y
+    });
+
+    const fwById = createFwById(commentId, mockUpdate);
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId
+        }
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            commentId
+        }
+    };
+
+    // Execute: Apply frameworkUpdates
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    // Assert: Verify sponsorCommentBadge is not created
+    assert.equal(
+        commentObj.commentRenderer?.sponsorCommentBadge,
+        undefined,
+        'Expected sponsorCommentBadge to not be created for non-member'
+    );
+});
+
+test('applyFrameworkUpdatesToComment preserves existing tooltip when A11y missing', () => {
+    // Setup: Create comment object with existing tooltip
+    const commentId = 'test-preserve-tooltip';
+    const existingTooltip = '會員 (6 個月)';
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId,
+            sponsorCommentBadge: {
+                sponsorCommentBadgeRenderer: {
+                    customBadge: { thumbnails: [{ url: 'https://old-badge.png' }] },
+                    tooltip: existingTooltip
+                }
+            }
+        }
+    };
+
+    // Create mock update with URL but NO A11y
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        sponsorBadgeUrl: 'https://new-badge.png'
+        // Note: No sponsorBadgeA11y provided
+    });
+
+    const fwById = createFwById(commentId, mockUpdate);
+
+    const vmSource = {
+        commentViewModel: {
+            commentId
+        }
+    };
+
+    // Execute: Apply frameworkUpdates
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    // Assert: Verify tooltip is preserved
+    const badge = commentObj.commentRenderer.sponsorCommentBadge.sponsorCommentBadgeRenderer;
+
+    assert.ok(badge?.tooltip, 'Expected tooltip to exist');
+    assert.equal(
+        badge.tooltip,
+        existingTooltip,
+        'Expected existing tooltip to be preserved when frameworkUpdates lacks sponsorBadgeA11y'
+    );
+
+    // Verify URL is updated
+    assert.equal(badge.customBadge.thumbnails[0].url, 'https://new-badge.png', 'Expected badge URL to be updated');
+});
+
+test('generateCommentObjectFromFW extracts sponsorBadgeA11y to tooltip', () => {
+    // Setup: Create mock data with member badge
+    const commentId = 'test-generate-member';
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        sponsorBadgeUrl: 'https://example.com/generated-badge.png',
+        sponsorBadgeA11y: '會員 (2 年 3 個月)'
+    });
+
+    // Execute: Generate comment object from frameworkUpdates
+    const comment = generateCommentObjectFromFW({
+        update: mockUpdate,
+        commentId
+    });
+
+    // Assert: Verify sponsorCommentBadge structure
+    assert.ok(comment?.commentRenderer?.sponsorCommentBadge, 'Expected sponsorCommentBadge to be created');
+
+    const badge = comment.commentRenderer.sponsorCommentBadge.sponsorCommentBadgeRenderer;
+
+    // Verify customBadge with URL
+    assert.ok(badge?.customBadge?.thumbnails?.[0]?.url, 'Expected badge URL to be set');
+    assert.equal(
+        badge.customBadge.thumbnails[0].url,
+        'https://example.com/generated-badge.png',
+        'Expected badge URL to match mock data'
+    );
+
+    // Verify tooltip is extracted from sponsorBadgeA11y
+    assert.ok(badge?.tooltip, 'Expected tooltip to be set');
+    assert.equal(badge.tooltip, '會員 (2 年 3 個月)', 'Expected tooltip to match sponsorBadgeA11y from mock data');
+});

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -65,5 +65,8 @@
     /* Advanced Options */
     "skipLibCheck": true /* Skip type checking of declaration files. */,
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
-  }
+  },
+  "exclude": [
+    "tests/**/*"
+  ]
 }


### PR DESCRIPTION
- Extract sponsorBadgeA11y to tooltip field in member badge processing
- Preserve existing tooltip when frameworkUpdates lacks A11y data
- Add comprehensive tests for member badge tooltip extraction
- Enable test execution in Node.js by conditionally initializing IndexedDB
- Export test-only functions from innertube.ts for verification
- Use type-only imports for better tree-shaking