### PR TITLE
fix(filters): extract heart tooltip from creatorHeart.tooltip

### DIFF
--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -357,19 +357,19 @@ function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: 
                     commentObj.commentRenderer = commentObj.commentRenderer || {};
                     commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
                 }
+            }
 
-                const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
-                const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
-                if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
+            const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
+            const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
+            if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
+                commentObj.commentRenderer = commentObj.commentRenderer || {};
 
-                    // Preserve existing tooltip if frameworkUpdates doesn't provide one
-                    const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
-                    const heartTooltip = wrapTryCatch(() => update.toolbar?.heartActiveTooltip);
-                    const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
+                // Preserve existing tooltip if frameworkUpdates doesn't provide one
+                const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
+                const heartTooltip = wrapTryCatch(() => update?.toolbar?.heartActiveTooltip);
+                const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
 
-                    commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
-                }
+                commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
             }
         }
     } catch (e) {

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -297,6 +297,32 @@ function getFrameworkUpdatesById(response: any): Record<string, any> {
     }
 }
 
+/**
+ * Build sponsor badge object from frameworkUpdates data
+ * @param options - Badge configuration with optional existing tooltip preservation
+ * @returns Sponsor badge object or undefined if no badge URL provided
+ */
+function buildSponsorBadge(options: {
+    sponsorBadgeUrl: string | undefined;
+    sponsorBadgeA11y: string | undefined;
+    existingTooltip?: string | undefined;
+}): any | undefined {
+    if (!options.sponsorBadgeUrl) return undefined;
+
+    const badge: any = {
+        sponsorCommentBadgeRenderer: {
+            customBadge: { thumbnails: [{ url: options.sponsorBadgeUrl }] }
+        }
+    };
+
+    const tooltip = options.sponsorBadgeA11y || options.existingTooltip;
+    if (tooltip) {
+        badge.sponsorCommentBadgeRenderer.tooltip = tooltip;
+    }
+
+    return badge;
+}
+
 function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: Record<string, any>): void {
     try {
         if (!commentObj || !fwById) return;
@@ -320,37 +346,31 @@ function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: 
                     commentObj.commentRenderer = commentObj.commentRenderer || {};
                     commentObj.commentRenderer.authorIsChannelOwner = true;
                 }
-                const sponsorBadgeUrl = wrapTryCatch(() => update.author?.sponsorBadgeUrl);
-                const sponsorBadgeA11y = wrapTryCatch(() => update.author?.sponsorBadgeA11y);
-                if (sponsorBadgeUrl) {
+                const sponsorBadge = buildSponsorBadge({
+                    sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
+                    sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
+                    existingTooltip: wrapTryCatch(
+                        () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
+                    )
+                });
+                if (sponsorBadge) {
+                    commentObj.commentRenderer = commentObj.commentRenderer || {};
+                    commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
+                }
+
+                const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
+                const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
+                if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
                     commentObj.commentRenderer = commentObj.commentRenderer || {};
 
                     // Preserve existing tooltip if frameworkUpdates doesn't provide one
-                    const existingTooltip = wrapTryCatch(
-                        () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
-                    );
+                    const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
+                    const heartTooltip = wrapTryCatch(() => update.toolbar?.heartActiveTooltip);
+                    const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
 
-                    const badge: any = {
-                        sponsorCommentBadgeRenderer: {
-                            customBadge: { thumbnails: [{ url: sponsorBadgeUrl }] }
-                        }
-                    };
-
-                    const tooltip = sponsorBadgeA11y || existingTooltip;
-                    if (tooltip) {
-                        badge.sponsorCommentBadgeRenderer.tooltip = tooltip;
-                    }
-
-                    commentObj.commentRenderer.sponsorCommentBadge = badge;
+                    commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
                 }
             }
-        }
-
-        const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
-        const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
-        if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
-            commentObj.commentRenderer = commentObj.commentRenderer || {};
-            commentObj.commentRenderer.creatorHeart = { tooltip: 'hearted' } as any;
         }
     } catch (e) {
         console.error(e);
@@ -557,18 +577,12 @@ function generateCommentObjectFromFW(params: {
             } as any;
         }
 
-        const sponsorBadgeUrl = wrapTryCatch(() => author.sponsorBadgeUrl);
-        const sponsorBadgeA11y = wrapTryCatch(() => author.sponsorBadgeA11y);
-        if (sponsorBadgeUrl) {
-            const badge: any = {
-                sponsorCommentBadgeRenderer: {
-                    customBadge: { thumbnails: [{ url: sponsorBadgeUrl }] }
-                }
-            };
-            if (sponsorBadgeA11y) {
-                badge.sponsorCommentBadgeRenderer.tooltip = sponsorBadgeA11y;
-            }
-            comment.commentRenderer.sponsorCommentBadge = badge;
+        const sponsorBadge = buildSponsorBadge({
+            sponsorBadgeUrl: wrapTryCatch(() => author.sponsorBadgeUrl),
+            sponsorBadgeA11y: wrapTryCatch(() => author.sponsorBadgeA11y)
+        });
+        if (sponsorBadge) {
+            comment.commentRenderer.sponsorCommentBadge = sponsorBadge;
         }
         if (wrapTryCatch(() => author.isVerified)) {
             comment.commentRenderer.verifiedAuthor = true;
@@ -2303,7 +2317,7 @@ async function getAllCommentsModeV2(
             if (wrapTryCatch(() => cmnt.commentRenderer.actionButtons.commentActionButtonsRenderer.creatorHeart)) {
                 try {
                     cmnt.commentRenderer.creatorHeart = {
-                        name: wrapTryCatch(
+                        tooltip: wrapTryCatch(
                             () =>
                                 cmnt.commentRenderer.actionButtons.commentActionButtonsRenderer.creatorHeart
                                     .creatorHeartRenderer.creatorThumbnail.accessibility.accessibilityData.label

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -333,44 +333,43 @@ function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: 
 
         const commentId =
             wrapTryCatch(() => vm.commentId) || wrapTryCatch(() => commentObj?.commentRenderer?.commentId);
-        if (commentId) {
-            const update = fwById[commentId];
-            if (update) {
-                const isVerified = wrapTryCatch(() => update.author?.isVerified);
-                const isCreator = wrapTryCatch(() => update.author?.isCreator);
-                if (isVerified) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.verifiedAuthor = true;
-                }
-                if (isCreator) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.authorIsChannelOwner = true;
-                }
-                const sponsorBadge = buildSponsorBadge({
-                    sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
-                    sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
-                    existingTooltip: wrapTryCatch(
-                        () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
-                    )
-                });
-                if (sponsorBadge) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
-                }
-            }
-
-            const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
-            const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
-            if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
+        const update = commentId ? fwById[commentId] : undefined;
+        if (commentId && update) {
+            const isVerified = wrapTryCatch(() => update.author?.isVerified);
+            const isCreator = wrapTryCatch(() => update.author?.isCreator);
+            if (isVerified) {
                 commentObj.commentRenderer = commentObj.commentRenderer || {};
-
-                // Preserve existing tooltip if frameworkUpdates doesn't provide one
-                const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
-                const heartTooltip = wrapTryCatch(() => update?.toolbar?.heartActiveTooltip);
-                const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
-
-                commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
+                commentObj.commentRenderer.verifiedAuthor = true;
             }
+            if (isCreator) {
+                commentObj.commentRenderer = commentObj.commentRenderer || {};
+                commentObj.commentRenderer.authorIsChannelOwner = true;
+            }
+            const sponsorBadge = buildSponsorBadge({
+                sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
+                sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
+                existingTooltip: wrapTryCatch(
+                    () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
+                )
+            });
+            if (sponsorBadge) {
+                commentObj.commentRenderer = commentObj.commentRenderer || {};
+                commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
+            }
+        }
+
+        const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
+        const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
+        if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
+            commentObj.commentRenderer = commentObj.commentRenderer || {};
+
+            // Preserve existing tooltip if frameworkUpdates doesn't provide one
+            const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
+            const toolbarHeartTooltip = wrapTryCatch(() => toolbarUpdate?.toolbar?.heartActiveTooltip);
+            const commentHeartTooltip = wrapTryCatch(() => update?.toolbar?.heartActiveTooltip);
+            const finalTooltip = toolbarHeartTooltip || commentHeartTooltip || existingHeartTooltip || 'hearted';
+
+            commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
         }
     } catch (e) {
         console.error(e);

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -305,7 +305,7 @@ export function buildCommentViewModels(items: any[], options: { isReply?: boolea
         const replyCount = Number.isFinite(replyCountValue) && replyCountValue > 0 ? replyCountValue : undefined;
 
         const commentId = coerceString(wrapTryCatch(() => renderer.commentId));
-        const heartName = coerceString(wrapTryCatch(() => renderer.creatorHeart?.name));
+        const heartTooltip = coerceString(wrapTryCatch(() => renderer.creatorHeart?.tooltip));
         const renderFullText = coerceString(wrapTryCatch(() => renderer.contentText?.renderFullText));
         const fallbackText =
             coerceString(wrapTryCatch(() => renderer.contentText?.simpleText)) ||
@@ -328,7 +328,7 @@ export function buildCommentViewModels(items: any[], options: { isReply?: boolea
             likeCountText: likeCountText || undefined,
             replyCount,
             commentId: commentId || undefined,
-            heartTooltip: heartName ? `Liked by the author: ${heartName}` : undefined,
+            heartTooltip: heartTooltip || undefined,
             isReply,
             isReplyType: coerceString(wrapTryCatch(() => item?.item?.typeComment)).toUpperCase() === 'R',
             refIndex: coerceString(wrapTryCatch(() => item?.refIndex)) || undefined,

--- a/app/tests/innertube.test.ts
+++ b/app/tests/innertube.test.ts
@@ -39,9 +39,11 @@ const createFwById = (commentId: string, update: any) => ({
  */
 const createMockToolbarState = (options: {
     heartState: 'TOOLBAR_HEART_STATE_HEARTED' | 'TOOLBAR_HEART_STATE_UNHEARTED';
+    heartActiveTooltip?: string;
 }) => ({
     heartState: options.heartState,
-    likeState: 'TOOLBAR_LIKE_STATE_INDIFFERENT'
+    likeState: 'TOOLBAR_LIKE_STATE_INDIFFERENT',
+    ...(options.heartActiveTooltip && { toolbar: { heartActiveTooltip: options.heartActiveTooltip } })
 });
 
 test('applyFrameworkUpdatesToComment extracts sponsorBadgeA11y to tooltip', () => {
@@ -324,6 +326,38 @@ test('applyFrameworkUpdatesToComment creates creatorHeart when only toolbar upda
         commentObj.commentRenderer.creatorHeart.tooltip,
         'hearted',
         'Expected tooltip to fall back to default when no tooltip provided'
+    );
+});
+
+test('applyFrameworkUpdatesToComment creates creatorHeart when commentId missing but toolbar hearted', () => {
+    const toolbarStateKey = 'test-toolbar-state-key-missing-comment-id';
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_HEARTED',
+        heartActiveTooltip: 'Autor hat ❤ vergeben'
+    });
+
+    const fwById = {
+        [toolbarStateKey]: mockToolbarState
+    };
+
+    const commentObj: any = {
+        commentRenderer: {}
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            toolbarStateKey
+        }
+    };
+
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    assert.ok(commentObj.commentRenderer?.creatorHeart, 'Expected creatorHeart to be created');
+    assert.equal(
+        commentObj.commentRenderer.creatorHeart.tooltip,
+        'Autor hat ❤ vergeben',
+        'Expected tooltip to use toolbar heartActiveTooltip when commentId missing'
     );
 });
 

--- a/app/tests/innertube.test.ts
+++ b/app/tests/innertube.test.ts
@@ -10,6 +10,7 @@ const createMockFrameworkUpdate = (options: {
     commentId: string;
     sponsorBadgeUrl?: string;
     sponsorBadgeA11y?: string;
+    heartActiveTooltip?: string;
 }) => ({
     properties: {
         commentId: options.commentId,
@@ -20,6 +21,9 @@ const createMockFrameworkUpdate = (options: {
         channelId: 'UCTestChannel123',
         ...(options.sponsorBadgeUrl && { sponsorBadgeUrl: options.sponsorBadgeUrl }),
         ...(options.sponsorBadgeA11y && { sponsorBadgeA11y: options.sponsorBadgeA11y })
+    },
+    toolbar: {
+        ...(options.heartActiveTooltip && { heartActiveTooltip: options.heartActiveTooltip })
     }
 });
 
@@ -28,6 +32,16 @@ const createMockFrameworkUpdate = (options: {
  */
 const createFwById = (commentId: string, update: any) => ({
     [commentId]: update
+});
+
+/**
+ * Helper: Create toolbar state for testing heart functionality
+ */
+const createMockToolbarState = (options: {
+    heartState: 'TOOLBAR_HEART_STATE_HEARTED' | 'TOOLBAR_HEART_STATE_UNHEARTED';
+}) => ({
+    heartState: options.heartState,
+    likeState: 'TOOLBAR_LIKE_STATE_INDIFFERENT'
 });
 
 test('applyFrameworkUpdatesToComment extracts sponsorBadgeA11y to tooltip', () => {
@@ -187,4 +201,200 @@ test('generateCommentObjectFromFW extracts sponsorBadgeA11y to tooltip', () => {
     // Verify tooltip is extracted from sponsorBadgeA11y
     assert.ok(badge?.tooltip, 'Expected tooltip to be set');
     assert.equal(badge.tooltip, '會員 (2 年 3 個月)', 'Expected tooltip to match sponsorBadgeA11y from mock data');
+});
+
+test('applyFrameworkUpdatesToComment extracts heartActiveTooltip to creatorHeart.tooltip', () => {
+    // Setup: Create mock data with heart
+    const commentId = 'test-hearted-comment';
+    const toolbarStateKey = 'test-toolbar-state-key';
+
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        heartActiveTooltip: '@yuzu_zuyuzu給了 ❤'
+    });
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_HEARTED'
+    });
+
+    const fwById = {
+        [commentId]: mockUpdate,
+        [toolbarStateKey]: mockToolbarState
+    };
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId
+        }
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            commentId,
+            toolbarStateKey
+        }
+    };
+
+    // Execute: Apply frameworkUpdates
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    // Assert: Verify creatorHeart structure
+    assert.ok(commentObj.commentRenderer?.creatorHeart, 'Expected creatorHeart to be created');
+    assert.ok(commentObj.commentRenderer.creatorHeart?.tooltip, 'Expected creatorHeart.tooltip to be set');
+    assert.equal(
+        commentObj.commentRenderer.creatorHeart.tooltip,
+        '@yuzu_zuyuzu給了 ❤',
+        'Expected tooltip to match heartActiveTooltip from mock data'
+    );
+});
+
+test('applyFrameworkUpdatesToComment uses fallback when heartActiveTooltip missing', () => {
+    // Setup: Create mock data with heartState but no heartActiveTooltip
+    const commentId = 'test-hearted-no-tooltip';
+    const toolbarStateKey = 'test-toolbar-state-key-2';
+
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId
+        // Note: No heartActiveTooltip provided
+    });
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_HEARTED'
+    });
+
+    const fwById = {
+        [commentId]: mockUpdate,
+        [toolbarStateKey]: mockToolbarState
+    };
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId
+        }
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            commentId,
+            toolbarStateKey
+        }
+    };
+
+    // Execute: Apply frameworkUpdates
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    // Assert: Verify creatorHeart uses fallback value
+    assert.ok(commentObj.commentRenderer?.creatorHeart, 'Expected creatorHeart to be created');
+    assert.equal(
+        commentObj.commentRenderer.creatorHeart.tooltip,
+        'hearted',
+        'Expected tooltip to use fallback value "hearted"'
+    );
+});
+
+test('applyFrameworkUpdatesToComment does not create creatorHeart when not hearted', () => {
+    // Setup: Create mock data with UNHEARTED state
+    const commentId = 'test-unhearted-comment';
+    const toolbarStateKey = 'test-toolbar-state-key-3';
+
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        heartActiveTooltip: '@author gave ❤'
+    });
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_UNHEARTED'
+    });
+
+    const fwById = {
+        [commentId]: mockUpdate,
+        [toolbarStateKey]: mockToolbarState
+    };
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId
+        }
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            commentId,
+            toolbarStateKey
+        }
+    };
+
+    // Execute: Apply frameworkUpdates
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    // Assert: Verify creatorHeart is not created
+    assert.equal(
+        commentObj.commentRenderer?.creatorHeart,
+        undefined,
+        'Expected creatorHeart to not be created when not hearted'
+    );
+});
+
+test('generateCommentObjectFromFW extracts heartActiveTooltip to creatorHeart.tooltip', () => {
+    // Setup: Create mock data with heart
+    const commentId = 'test-generate-heart';
+    const toolbarStateKey = 'test-toolbar-state-key-4';
+
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        heartActiveTooltip: '@author gave ❤'
+    });
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_HEARTED'
+    });
+
+    const fwById = {
+        [toolbarStateKey]: mockToolbarState
+    };
+
+    // Execute: Generate comment object from frameworkUpdates
+    const comment = generateCommentObjectFromFW({
+        update: mockUpdate,
+        commentId,
+        toolbarStateUpdate: mockToolbarState
+    });
+
+    // Assert: Verify creatorHeart structure
+    assert.ok(comment?.commentRenderer?.creatorHeart, 'Expected creatorHeart to be created');
+    assert.ok(comment.commentRenderer.creatorHeart?.tooltip, 'Expected creatorHeart.tooltip to be set');
+    assert.equal(
+        comment.commentRenderer.creatorHeart.tooltip,
+        '@author gave ❤',
+        'Expected tooltip to match heartActiveTooltip from mock data'
+    );
+});
+
+test('generateCommentObjectFromFW does not create creatorHeart when not hearted', () => {
+    // Setup: Create mock data with UNHEARTED state
+    const commentId = 'test-generate-unhearted';
+    const toolbarStateKey = 'test-toolbar-state-key-5';
+
+    const mockUpdate = createMockFrameworkUpdate({
+        commentId,
+        heartActiveTooltip: '@author gave ❤'
+    });
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_UNHEARTED'
+    });
+
+    // Execute: Generate comment object from frameworkUpdates
+    const comment = generateCommentObjectFromFW({
+        update: mockUpdate,
+        commentId,
+        toolbarStateUpdate: mockToolbarState
+    });
+
+    // Assert: Verify creatorHeart is not created
+    assert.equal(
+        comment?.commentRenderer?.creatorHeart,
+        undefined,
+        'Expected creatorHeart to not be created when not hearted'
+    );
 });

--- a/app/tests/innertube.test.ts
+++ b/app/tests/innertube.test.ts
@@ -292,6 +292,41 @@ test('applyFrameworkUpdatesToComment uses fallback when heartActiveTooltip missi
     );
 });
 
+test('applyFrameworkUpdatesToComment creates creatorHeart when only toolbar update present', () => {
+    const commentId = 'test-hearted-toolbar-only';
+    const toolbarStateKey = 'test-toolbar-state-key-4';
+
+    const mockToolbarState = createMockToolbarState({
+        heartState: 'TOOLBAR_HEART_STATE_HEARTED'
+    });
+
+    const fwById = {
+        [toolbarStateKey]: mockToolbarState
+    };
+
+    const commentObj: any = {
+        commentRenderer: {
+            commentId
+        }
+    };
+
+    const vmSource = {
+        commentViewModel: {
+            commentId,
+            toolbarStateKey
+        }
+    };
+
+    applyFrameworkUpdatesToComment(commentObj, vmSource, fwById);
+
+    assert.ok(commentObj.commentRenderer?.creatorHeart, 'Expected creatorHeart to be created');
+    assert.equal(
+        commentObj.commentRenderer.creatorHeart.tooltip,
+        'hearted',
+        'Expected tooltip to fall back to default when no tooltip provided'
+    );
+});
+
 test('applyFrameworkUpdatesToComment does not create creatorHeart when not hearted', () => {
     // Setup: Create mock data with UNHEARTED state
     const commentId = 'test-unhearted-comment';

--- a/app/tests/viewModels.test.ts
+++ b/app/tests/viewModels.test.ts
@@ -71,3 +71,67 @@ test('buildChatMessageViewModels decodes run text HTML entities once', () => {
     assert.equal(model !== undefined, true, 'expected a chat model');
     assert.equal(model.messageHtml, '&gt; Wow');
 });
+
+test('buildCommentViewModels extracts heartTooltip from creatorHeart.tooltip', () => {
+    const items = [
+        {
+            item: {
+                commentRenderer: {
+                    authorText: { simpleText: 'Test Author' },
+                    contentText: { simpleText: 'Test comment' },
+                    creatorHeart: {
+                        tooltip: '@author gave ❤'
+                    }
+                }
+            }
+        }
+    ];
+
+    const [model] = buildCommentViewModels(items);
+    assert.equal(model !== undefined, true, 'expected a comment model');
+    assert.ok(model.heartTooltip, 'expected heartTooltip to be set');
+    assert.equal(model.heartTooltip, '@author gave ❤', 'expected heartTooltip to match creatorHeart.tooltip');
+});
+
+test('buildCommentViewModels preserves multilingual tooltip text', () => {
+    const items = [
+        {
+            item: {
+                commentRenderer: {
+                    authorText: { simpleText: 'Test Author' },
+                    contentText: { simpleText: 'Test comment' },
+                    creatorHeart: {
+                        tooltip: '@yuzu_zuyuzu給了 ❤'
+                    }
+                }
+            }
+        }
+    ];
+
+    const [model] = buildCommentViewModels(items);
+    assert.equal(model !== undefined, true, 'expected a comment model');
+    assert.ok(model.heartTooltip, 'expected heartTooltip to be set');
+    assert.equal(
+        model.heartTooltip,
+        '@yuzu_zuyuzu給了 ❤',
+        'expected multilingual tooltip to be preserved without prefix'
+    );
+});
+
+test('buildCommentViewModels handles comments without creatorHeart', () => {
+    const items = [
+        {
+            item: {
+                commentRenderer: {
+                    authorText: { simpleText: 'Test Author' },
+                    contentText: { simpleText: 'Test comment' }
+                    // No creatorHeart
+                }
+            }
+        }
+    ];
+
+    const [model] = buildCommentViewModels(items);
+    assert.equal(model !== undefined, true, 'expected a comment model');
+    assert.equal(model.heartTooltip, undefined, 'expected heartTooltip to be undefined when creatorHeart missing');
+});


### PR DESCRIPTION
Extract and preserve original heart tooltip text instead of constructing it from creatorHeart.name. This ensures multilingual tooltip support and proper display of creator heart icons.

Changes:
- Extract buildSponsorBadge helper in innertube.ts
- Change creatorHeart structure from name to tooltip field
- Preserve heartActiveTooltip from frameworkUpdates
- Remove "Liked by the author:" prefix from viewModels
- Add comprehensive test coverage for heart tooltip handling