### PR TITLE
feat(filters): add donated comment filter with chip badge rendering

### DIFF
--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -207,6 +207,7 @@ html[dark] .ycs_btn_active {
   border: 0;
   background-color: #34495e1c;
   vertical-align: text-bottom;
+  margin-left: 6px;
 }
 
 .ycs-open-reply * {
@@ -247,7 +248,8 @@ html[dark] .ycs-open-reply {
   width: 18px;
   border: 0;
   background-color: #34495e1c;
-  vertical-align: text-top;
+  vertical-align: text-bottom;
+  margin-left: 6px;
 }
 
 .ycs-open-comment * {
@@ -1034,4 +1036,20 @@ html[dark] .ycs-ext-search_link {
 #ycs_title_information {
   position: relative;
   top: 5px;
+}
+
+.ycs-chip.ytd-comment-view-model {
+  display: inline-block;
+}
+.ycs-chip .ycs-yt-icon {
+  display: inline-block;
+  vertical-align: text-top;
+
+  color: var(--yt-pdg-comment-chip-font-color);
+  height: 12px;
+  padding-bottom: 2px;
+  width: 12px;
+}
+.ycs-chip .ycs-yt-icon > .yt-icon {
+  height: 12px;
 }

--- a/app/src/source/utils/common.ts
+++ b/app/src/source/utils/common.ts
@@ -251,6 +251,35 @@ async function delayMs(ms: number): Promise<void> {
     return await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Converts YouTube's 32-bit RGBA integer color to CSS rgba() string
+ * Format: 0xRRGGBBAA (Red, Green, Blue, Alpha in hex)
+ *
+ * @param color - 32-bit unsigned integer representing RGBA color
+ * @returns CSS rgba() string, e.g., "rgba(255,229,0,0.694)"
+ *
+ * @example
+ * convertColorToRgba(4293296689) // returns "rgba(255,229,0,0.694)"
+ * convertColorToRgba(4294967295) // returns "rgba(255,255,255,1.000)"
+ */
+function convertColorToRgba(color: number): string {
+    const r = (color & 0xff0000) >>> 16; // Red channel
+    const g = (color & 0x00ff00) >>> 8; // Green channel
+    const b = color & 0x0000ff; // Blue channel
+    const a = (color & 0xff000000) >>> 24; // Alpha channel
+
+    // Validate that all components are in valid range (0-255)
+    const components = [r, g, b, a];
+    if (!components.every((c) => c === (c & 0xff))) {
+        throw new Error(`Invalid color value: ${color} (components: ${components.join(',')})`);
+    }
+
+    // Convert alpha from 0-255 to 0-1 range with 3 decimal places
+    const alphaDecimal = (a / 255).toFixed(3);
+
+    return `rgba(${r},${g},${b},${alphaDecimal})`;
+}
+
 export {
     GlobalStore,
     randomString,
@@ -267,5 +296,6 @@ export {
     getCleanUrlVideo,
     isWatchVideo,
     isVideoPage,
-    getPaginate
+    getPaginate,
+    convertColorToRgba
 };

--- a/app/src/source/utils/filters/comments.ts
+++ b/app/src/source/utils/filters/comments.ts
@@ -119,6 +119,27 @@ function filterMemberComments(comments: any): [] {
     }
 }
 
+function filterDonatedComments(comments: any): [] {
+    if (comments.length === 0) return [];
+
+    try {
+        const fDonated: any = [];
+
+        for (const [, c] of comments.entries()) {
+            const donated = c?.commentRenderer?.donatedChip;
+
+            if (donated) {
+                fDonated.push({ item: c, refIndex: (c as any)._index });
+            }
+        }
+
+        return fDonated;
+    } catch (err) {
+        console.error(err);
+        return [];
+    }
+}
+
 function filterHeartComments(comments: any): [] {
     if (comments.length === 0) return [];
 
@@ -266,6 +287,7 @@ export {
     filterLikesComments,
     filterRepliedComments,
     filterMemberComments,
+    filterDonatedComments,
     filterHeartComments,
     filterVerifiedComments,
     filterLinksComments,

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -262,6 +262,30 @@ function normalizeCommentFromViewModel(item: any): any | undefined {
     }
 }
 
+/**
+ * Extracts donate chip information from liveChatPaidMessageRenderer
+ * and adds it to the renderer as donatedChip structure for unified chip badge rendering
+ */
+function addDonatedChipFromPaidRenderer(renderer: any): void {
+    const purchaseAmount =
+        wrapTryCatch(() => renderer.purchaseAmountText?.simpleText) ??
+        wrapTryCatch(() => (renderer.purchaseAmountText?.runs || []).map((run: any) => run?.text || '').join(''));
+
+    if (!purchaseAmount) return;
+
+    renderer.donatedChip = {
+        pdgCommentChipRenderer: {
+            chipText: {
+                simpleText: purchaseAmount
+            },
+            chipColorPalette: {
+                backgroundColor: renderer.headerBackgroundColor ?? renderer.bodyBackgroundColor,
+                foregroundTitleColor: renderer.headerTextColor ?? renderer.bodyTextColor
+            }
+        }
+    };
+}
+
 function getFrameworkUpdatesById(response: any): Record<string, any> {
     try {
         const mutations: any[] = wrapTryCatch(() => response.frameworkUpdates.entityBatchUpdate.mutations) || [];
@@ -1318,6 +1342,12 @@ async function getChatComments(
                                     comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
                                         comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatPaidMessageRenderer;
                                     console.log('Done! Added liveChatPaidMessageRenderer: ', comment);
+
+                                    // Extract donate chip information from liveChatPaidMessageRenderer
+                                    addDonatedChipFromPaidRenderer(
+                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
+                                            .liveChatTextMessageRenderer
+                                    );
                                 } else if (
                                     wrapTryCatch(
                                         () =>
@@ -1346,6 +1376,12 @@ async function getChatComments(
                                     comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
                                         comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item.liveChatTickerPaidMessageItemRenderer.showItemEndpoint.showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer;
                                     console.log('Done! Added LiveChatTickerItemAction: ', comment);
+
+                                    // Extract donate chip information from liveChatPaidMessageRenderer
+                                    addDonatedChipFromPaidRenderer(
+                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
+                                            .liveChatTextMessageRenderer
+                                    );
                                 } else {
                                     // console.log('deepFindObjKey: ', deepFindObjKey(comment, 'timestampUsec'));
                                     const pathComment = wrapTryCatch(() =>
@@ -1388,17 +1424,8 @@ async function getChatComments(
                                 let fullText = '';
                                 let renderFullTextComment = '';
 
-                                if (
-                                    wrapTryCatch(
-                                        () =>
-                                            comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                .liveChatTextMessageRenderer.purchaseAmountText.simpleText
-                                    )
-                                ) {
-                                    console.log('Added purchaseAmountText for chat');
-                                    renderFullTextComment += `<span class="ycs-chat_donation ycs-chat_donation__title">Donated: </span><span class="ycs-chat_donation ycs-chat_donation__bg">${comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.purchaseAmountText.simpleText}</span><br><br>`;
-                                    fullText += `${comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.purchaseAmountText.simpleText} `;
-                                }
+                                // Removed hardcoded HTML for purchaseAmountText
+                                // Now handled by donatedChip structure and chip badge rendering
 
                                 for (const msg of chatMsgs) {
                                     try {
@@ -1545,6 +1572,12 @@ async function getChatComments(
                                                 comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
                                                     comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatPaidMessageRenderer;
                                                 console.log('Done! Added liveChatPaidMessageRenderer: ', comment);
+
+                                                // Extract donate chip information from liveChatPaidMessageRenderer
+                                                addDonatedChipFromPaidRenderer(
+                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
+                                                        .liveChatTextMessageRenderer
+                                                );
                                             } else if (
                                                 wrapTryCatch(
                                                     () =>
@@ -1575,6 +1608,12 @@ async function getChatComments(
                                                 comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
                                                     comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item.liveChatTickerPaidMessageItemRenderer.showItemEndpoint.showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer;
                                                 console.log('Done! Added LiveChatTickerItemAction: ', comment);
+
+                                                // Extract donate chip information from liveChatPaidMessageRenderer
+                                                addDonatedChipFromPaidRenderer(
+                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
+                                                        .liveChatTextMessageRenderer
+                                                );
                                             } else {
                                                 // console.log('deepFindObjKey: ', deepFindObjKey(comment, 'timestampUsec'));
                                                 const pathComment = wrapTryCatch(() =>
@@ -1631,17 +1670,8 @@ async function getChatComments(
                                             let fullText = '';
                                             let renderFullTextComment = '';
 
-                                            if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer.purchaseAmountText.simpleText
-                                                )
-                                            ) {
-                                                console.log('Added purchaseAmountText for chat');
-                                                renderFullTextComment += `<span class="ycs-chat_donation ycs-chat_donation__title">Donated: </span><span class="ycs-chat_donation ycs-chat_donation__bg">${comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.purchaseAmountText.simpleText}</span><br><br>`;
-                                                fullText += `${comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.purchaseAmountText.simpleText} `;
-                                            }
+                                            // Removed hardcoded HTML for purchaseAmountText
+                                            // Now handled by donatedChip structure and chip badge rendering
 
                                             for (const msg of chatMsgs) {
                                                 try {
@@ -1820,6 +1850,12 @@ async function getChatComments(
                                                 comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
                                                     comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatPaidMessageRenderer;
                                                 console.log('Done! Added liveChatPaidMessageRenderer: ', comment);
+
+                                                // Extract donate chip information from liveChatPaidMessageRenderer
+                                                addDonatedChipFromPaidRenderer(
+                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
+                                                        .liveChatTextMessageRenderer
+                                                );
                                             } else if (
                                                 wrapTryCatch(
                                                     () =>
@@ -1850,6 +1886,12 @@ async function getChatComments(
                                                 comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
                                                     comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item.liveChatTickerPaidMessageItemRenderer.showItemEndpoint.showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer;
                                                 console.log('Done! Added LiveChatTickerItemAction: ', comment);
+
+                                                // Extract donate chip information from liveChatPaidMessageRenderer
+                                                addDonatedChipFromPaidRenderer(
+                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
+                                                        .liveChatTextMessageRenderer
+                                                );
                                             } else {
                                                 const pathComment = wrapTryCatch(() =>
                                                     Object.keys(deepFindObjKey(comment, 'timestampUsec')[0])[0]
@@ -1905,17 +1947,8 @@ async function getChatComments(
                                             let fullText = '';
                                             let renderFullTextComment = '';
 
-                                            if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer.purchaseAmountText.simpleText
-                                                )
-                                            ) {
-                                                console.log('Added purchaseAmountText for chat');
-                                                renderFullTextComment += `<span class="ycs-chat_donation ycs-chat_donation__title">Donated: </span><span class="ycs-chat_donation ycs-chat_donation__bg">${comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.purchaseAmountText.simpleText}</span><br><br>`;
-                                                fullText += `${comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.purchaseAmountText.simpleText} `;
-                                            }
+                                            // Removed hardcoded HTML for purchaseAmountText
+                                            // Now handled by donatedChip structure and chip badge rendering
 
                                             for (const msg of chatMsgs) {
                                                 try {

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -333,43 +333,53 @@ function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: 
 
         const commentId =
             wrapTryCatch(() => vm.commentId) || wrapTryCatch(() => commentObj?.commentRenderer?.commentId);
-        const update = commentId ? fwById[commentId] : undefined;
-        if (commentId && update) {
-            const isVerified = wrapTryCatch(() => update.author?.isVerified);
-            const isCreator = wrapTryCatch(() => update.author?.isCreator);
-            if (isVerified) {
-                commentObj.commentRenderer = commentObj.commentRenderer || {};
-                commentObj.commentRenderer.verifiedAuthor = true;
-            }
-            if (isCreator) {
-                commentObj.commentRenderer = commentObj.commentRenderer || {};
-                commentObj.commentRenderer.authorIsChannelOwner = true;
-            }
-            const sponsorBadge = buildSponsorBadge({
-                sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
-                sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
-                existingTooltip: wrapTryCatch(
-                    () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
-                )
-            });
-            if (sponsorBadge) {
-                commentObj.commentRenderer = commentObj.commentRenderer || {};
-                commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
-            }
-        }
+        if (commentId) {
+            const update = fwById[commentId];
+            if (update) {
+                const isVerified = wrapTryCatch(() => update.author?.isVerified);
+                const isCreator = wrapTryCatch(() => update.author?.isCreator);
+                if (isVerified) {
+                    commentObj.commentRenderer = commentObj.commentRenderer || {};
+                    commentObj.commentRenderer.verifiedAuthor = true;
+                }
+                if (isCreator) {
+                    commentObj.commentRenderer = commentObj.commentRenderer || {};
+                    commentObj.commentRenderer.authorIsChannelOwner = true;
+                }
+                const sponsorBadge = buildSponsorBadge({
+                    sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
+                    sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
+                    existingTooltip: wrapTryCatch(
+                        () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
+                    )
+                });
+                if (sponsorBadge) {
+                    commentObj.commentRenderer = commentObj.commentRenderer || {};
+                    commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
+                }
 
-        const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
-        const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
-        if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
-            commentObj.commentRenderer = commentObj.commentRenderer || {};
+                const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
+                const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
+                if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
+                    commentObj.commentRenderer = commentObj.commentRenderer || {};
 
-            // Preserve existing tooltip if frameworkUpdates doesn't provide one
-            const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
-            const toolbarHeartTooltip = wrapTryCatch(() => toolbarUpdate?.toolbar?.heartActiveTooltip);
-            const commentHeartTooltip = wrapTryCatch(() => update?.toolbar?.heartActiveTooltip);
-            const finalTooltip = toolbarHeartTooltip || commentHeartTooltip || existingHeartTooltip || 'hearted';
+                    // Preserve existing tooltip if frameworkUpdates doesn't provide one
+                    const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
+                    const heartTooltip = wrapTryCatch(() => update.toolbar?.heartActiveTooltip);
+                    const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
 
-            commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
+                    commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
+                }
+
+                // Extract donated chip from surfaceUpdate
+                const surfaceKey = wrapTryCatch(() => vm.commentSurfaceKey);
+                const surfaceUpdate = surfaceKey ? fwById[surfaceKey] : undefined;
+                const donatedChip = wrapTryCatch(() => surfaceUpdate?.pdgCommentChip);
+                if (donatedChip) {
+                    commentObj.commentRenderer = commentObj.commentRenderer || {};
+                    commentObj.commentRenderer.donatedChip = donatedChip;
+                }
+            }
         }
     } catch (e) {
         console.error(e);
@@ -583,6 +593,13 @@ function generateCommentObjectFromFW(params: {
         if (sponsorBadge) {
             comment.commentRenderer.sponsorCommentBadge = sponsorBadge;
         }
+
+        // Extract donated chip from surfaceUpdate
+        const donatedChip = wrapTryCatch(() => surfaceUpdate?.pdgCommentChip);
+        if (donatedChip) {
+            comment.commentRenderer.donatedChip = donatedChip;
+        }
+
         if (wrapTryCatch(() => author.isVerified)) {
             comment.commentRenderer.verifiedAuthor = true;
         }

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -333,53 +333,53 @@ function applyFrameworkUpdatesToComment(commentObj: any, vmSource: any, fwById: 
 
         const commentId =
             wrapTryCatch(() => vm.commentId) || wrapTryCatch(() => commentObj?.commentRenderer?.commentId);
-        if (commentId) {
-            const update = fwById[commentId];
-            if (update) {
-                const isVerified = wrapTryCatch(() => update.author?.isVerified);
-                const isCreator = wrapTryCatch(() => update.author?.isCreator);
-                if (isVerified) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.verifiedAuthor = true;
-                }
-                if (isCreator) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.authorIsChannelOwner = true;
-                }
-                const sponsorBadge = buildSponsorBadge({
-                    sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
-                    sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
-                    existingTooltip: wrapTryCatch(
-                        () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
-                    )
-                });
-                if (sponsorBadge) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
-                }
-
-                const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
-                const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
-                if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-
-                    // Preserve existing tooltip if frameworkUpdates doesn't provide one
-                    const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
-                    const heartTooltip = wrapTryCatch(() => update.toolbar?.heartActiveTooltip);
-                    const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
-
-                    commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
-                }
-
-                // Extract donated chip from surfaceUpdate
-                const surfaceKey = wrapTryCatch(() => vm.commentSurfaceKey);
-                const surfaceUpdate = surfaceKey ? fwById[surfaceKey] : undefined;
-                const donatedChip = wrapTryCatch(() => surfaceUpdate?.pdgCommentChip);
-                if (donatedChip) {
-                    commentObj.commentRenderer = commentObj.commentRenderer || {};
-                    commentObj.commentRenderer.donatedChip = donatedChip;
-                }
+        const update = commentId ? fwById[commentId] : undefined;
+        if (update) {
+            const isVerified = wrapTryCatch(() => update.author?.isVerified);
+            const isCreator = wrapTryCatch(() => update.author?.isCreator);
+            if (isVerified) {
+                commentObj.commentRenderer = commentObj.commentRenderer || {};
+                commentObj.commentRenderer.verifiedAuthor = true;
             }
+            if (isCreator) {
+                commentObj.commentRenderer = commentObj.commentRenderer || {};
+                commentObj.commentRenderer.authorIsChannelOwner = true;
+            }
+            const sponsorBadge = buildSponsorBadge({
+                sponsorBadgeUrl: wrapTryCatch(() => update.author?.sponsorBadgeUrl),
+                sponsorBadgeA11y: wrapTryCatch(() => update.author?.sponsorBadgeA11y),
+                existingTooltip: wrapTryCatch(
+                    () => commentObj.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer?.tooltip
+                )
+            });
+            if (sponsorBadge) {
+                commentObj.commentRenderer = commentObj.commentRenderer || {};
+                commentObj.commentRenderer.sponsorCommentBadge = sponsorBadge;
+            }
+        }
+
+        const toolbarKey = wrapTryCatch(() => vm.toolbarStateKey);
+        const toolbarUpdate = toolbarKey ? fwById[toolbarKey] : undefined;
+        if (toolbarUpdate && wrapTryCatch(() => toolbarUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
+            commentObj.commentRenderer = commentObj.commentRenderer || {};
+
+            // Preserve existing tooltip if frameworkUpdates doesn't provide one
+            const existingHeartTooltip = wrapTryCatch(() => commentObj.commentRenderer?.creatorHeart?.tooltip);
+            const heartTooltip =
+                wrapTryCatch(() => toolbarUpdate.toolbar?.heartActiveTooltip) ||
+                wrapTryCatch(() => update?.toolbar?.heartActiveTooltip);
+            const finalTooltip = heartTooltip || existingHeartTooltip || 'hearted';
+
+            commentObj.commentRenderer.creatorHeart = { tooltip: finalTooltip } as any;
+        }
+
+        // Extract donated chip from surfaceUpdate
+        const surfaceKey = wrapTryCatch(() => vm.commentSurfaceKey);
+        const surfaceUpdate = surfaceKey ? fwById[surfaceKey] : undefined;
+        const donatedChip = wrapTryCatch(() => surfaceUpdate?.pdgCommentChip);
+        if (donatedChip) {
+            commentObj.commentRenderer = commentObj.commentRenderer || {};
+            commentObj.commentRenderer.donatedChip = donatedChip;
         }
     } catch (e) {
         console.error(e);

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -10,7 +10,8 @@ import {
     CommentViewModel,
     ChatMessageViewModel,
     TranscriptViewModel,
-    MemberBadgeViewModel
+    MemberBadgeViewModel,
+    DonatedChipViewModel
 } from './viewModels';
 import { iconExpand, iconExpandShowMore, iconReload, iconSortDown } from './icons';
 
@@ -53,6 +54,62 @@ function createMemberBadgeElement(badge?: MemberBadgeViewModel): HTMLElement | n
     img.loading = 'lazy';
     img.src = badge.thumbnailUrl;
     return img;
+}
+
+function createDonatedChipElement(chip?: DonatedChipViewModel): HTMLElement | null {
+    if (!chip) return null;
+
+    // Create outer wrapper (YouTube Web Component structure)
+    const wrapper = document.createElement('span');
+    wrapper.id = 'paid-comment-chip';
+    wrapper.slot = 'content';
+    wrapper.className = 'style-scope ycs-chip ytd-comment-view-model';
+    wrapper.setAttribute('role', 'button');
+    wrapper.setAttribute('tabindex', '0');
+
+    // Set CSS Variables for dynamic colors
+    if (chip.backgroundColor) {
+        wrapper.style.setProperty('--yt-pdg-comment-chip-background-color', chip.backgroundColor);
+    }
+    if (chip.foregroundColor) {
+        wrapper.style.setProperty('--yt-pdg-comment-chip-font-color', chip.foregroundColor);
+    }
+    wrapper.style.setProperty('--yt-pdg-comment-chip-cursor', 'pointer');
+
+    // Create inner container
+    const container = document.createElement('div');
+    container.id = 'comment-chip-container';
+    container.className = 'style-scope yt-pdg-comment-chip-renderer';
+
+    // Create icon container
+    const iconContainer = document.createElement('span');
+    iconContainer.className = 'style-scope ycs-yt-icon yt-pdg-comment-chip-renderer';
+
+    const iconShape = document.createElement('span');
+    iconShape.className = 'yt-icon-shape style-scope yt-icon ytSpecIconShapeHost';
+
+    const iconDiv = document.createElement('div');
+    iconDiv.style.cssText = 'width: 100%; height: 100%; display: block; fill: currentcolor;';
+
+    // SVG icon for donated chip (heart + dollar sign)
+    iconDiv.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" height="12" viewBox="0 0 12 12" width="12" focusable="false" aria-hidden="true" style="pointer-events: none; display: inherit; width: 100%; height: 100%;"><path d="M8.125 1C7.35 1 6.599 1.267 6 1.758 5.4 1.268 4.65.999 3.875 1c-.895 0-1.754.356-2.386.989C.856 2.62.5 3.479.5 4.375c0 2.249 1.392 3.908 2.604 4.935.74.62 1.551 1.148 2.419 1.571l.048.022.015.007.004.003h.002L6 10l-.407.914.407.18.406-.18L6 10c.134.305.27.61.407.913l.002-.001.005-.002.014-.007.048-.023c.868-.422 1.68-.95 2.42-1.57C10.107 8.283 11.5 6.624 11.5 4.375c0-.895-.356-1.754-.989-2.386C9.88 1.356 9.021 1 8.125 1ZM6 3.25c.133 0 .26.053.354.146.093.094.146.221.146.354v.327c.284.087.54.247.744.464l.008.009.003.004.001.003c.078.102.114.23.1.357-.014.128-.077.245-.175.327-.099.083-.225.124-.353.115-.128-.009-.248-.067-.334-.162l.002.004-.017-.016c-.13-.12-.302-.186-.48-.185-.199 0-.315.052-.37.096-.043.034-.07.078-.07.157 0 .015.002.03.005.046l.002.004.008.009c.013.01.028.02.044.028.113.06.287.098.571.153.237.047.582.111.86.269.15.085.3.207.41.385.112.18.163.386.163.606 0 .621-.477 1.048-1.122 1.192v.308c0 .133-.053.26-.146.354-.094.093-.221.146-.354.146-.133 0-.26-.053-.354-.146-.093-.094-.146-.221-.146-.354v-.306c-.272-.052-.526-.17-.739-.347-.139-.119-.251-.265-.33-.43l-.017-.043-.007-.017-.002-.006-.002-.004v-.002c-.04-.124-.03-.26.028-.376.059-.117.16-.207.284-.249.124-.042.26-.033.377.024.118.057.208.158.252.281l-.001-.004-.005-.014c.019.032.043.06.072.084.066.056.23.162.59.162.295 0 .463-.075.545-.136.078-.058.083-.105.083-.117 0-.061-.015-.08-.015-.081-.003-.004-.014-.022-.057-.046-.108-.062-.281-.102-.558-.157-.232-.045-.574-.105-.847-.25-.167-.085-.31-.211-.415-.367-.115-.178-.175-.387-.171-.599-.003-.18.036-.358.113-.52.077-.162.19-.305.332-.416.145-.114.311-.194.49-.244v-.32c0-.133.053-.26.146-.354.094-.093.221-.146.354-.146Z"></path></svg>`;
+
+    iconShape.appendChild(iconDiv);
+    iconContainer.appendChild(iconShape);
+
+    // Create price text
+    const priceSpan = document.createElement('span');
+    priceSpan.id = 'comment-chip-price';
+    priceSpan.className = 'style-scope yt-pdg-comment-chip-renderer';
+    priceSpan.textContent = ` ${chip.amount} `;
+
+    container.appendChild(iconContainer);
+    container.appendChild(priceSpan);
+
+    // Nest container inside wrapper
+    wrapper.appendChild(container);
+
+    return wrapper;
 }
 
 function createHeartElement(tooltip?: string): HTMLElement | null {
@@ -184,6 +241,11 @@ function createCommentElement(model: CommentViewModel, index: number): HTMLEleme
         meta.appendChild(badge);
     }
 
+    const donatedChip = createDonatedChipElement(model.donatedChip);
+    if (donatedChip) {
+        meta.appendChild(donatedChip);
+    }
+
     const publishedLink = document.createElement('a');
     publishedLink.className = 'ycs-datetime-goto';
     publishedLink.href = safeUrl(model.publishedUrl);
@@ -284,6 +346,11 @@ function createChatElement(model: ChatMessageViewModel, index: number): HTMLElem
     const badge = createMemberBadgeElement(model.memberBadge);
     if (badge) {
         meta.appendChild(badge);
+    }
+
+    const donatedChip = createDonatedChipElement(model.donatedChip);
+    if (donatedChip) {
+        meta.appendChild(donatedChip);
     }
 
     const timestampLink = document.createElement('a');

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1023,6 +1023,7 @@ function renderSearch(node: HTMLElement): void {
                         ${iconSortDown()}
                     </button>
                     <button id="ycs_btn_donated"
+                        data-sort="newest"
                         data-sort-chat="newest"
                         class="ycs-btn-search ycs-title"
                         name="donated" type="button"

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -117,7 +117,7 @@ function sanitizeHtml(html: unknown): string {
             return safe ? `src='${escapeHtml(safe)}'` : "src=''";
         });
 
-        const allowedTags = new Set(['a', 'br', 'img']);
+        const allowedTags = new Set(['a', 'br', 'img', 'span']);
         value = value.replace(/<(\/)?([a-z0-9-]+)([^>]*)>/gi, (match, closingSlash, tag, attrs) => {
             const lower = tag.toLowerCase();
             if (!allowedTags.has(lower)) {

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -1,11 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { decodeHtml, escapeHtml, wrapTryCatch } from './common';
+import { decodeHtml, escapeHtml, wrapTryCatch, convertColorToRgba } from './common';
 import { msToShareVideo, tmUsecToDateTime } from './formatting';
 
 export interface MemberBadgeViewModel {
     tooltip: string;
     thumbnailUrl: string;
+}
+
+export interface DonatedChipViewModel {
+    amount: string;
+    backgroundColor?: string;
+    foregroundColor?: string;
+    iconType?: string;
 }
 
 export interface CommentViewModel {
@@ -14,6 +21,7 @@ export interface CommentViewModel {
     authorAvatarUrl: string;
     isVerified: boolean;
     memberBadge?: MemberBadgeViewModel;
+    donatedChip?: DonatedChipViewModel;
     publishedText: string;
     publishedUrl: string;
     likeCountText?: string;
@@ -32,6 +40,7 @@ export interface ChatMessageViewModel {
     authorAvatarUrl: string;
     isVerified: boolean;
     memberBadge?: MemberBadgeViewModel;
+    donatedChip?: DonatedChipViewModel;
     timestampGmtText: string;
     timestampLabel: string;
     gotoVideoUrl?: string;
@@ -173,6 +182,47 @@ function resolveChatBadge(renderer: any): MemberBadgeViewModel | undefined {
     }
 
     return undefined;
+}
+
+function resolveDonatedChip(renderer: any): DonatedChipViewModel | undefined {
+    const chip = wrapTryCatch(() => renderer?.donatedChip?.pdgCommentChipRenderer);
+    if (!chip) return undefined;
+
+    const amount = coerceString(wrapTryCatch(() => chip.chipText?.simpleText));
+    if (!amount) return undefined;
+
+    // Extract color palette
+    const bgColorInt = wrapTryCatch(() => chip.chipColorPalette?.backgroundColor);
+    const fgColorInt = wrapTryCatch(() => chip.chipColorPalette?.foregroundTitleColor);
+
+    let backgroundColor: string | undefined;
+    let foregroundColor: string | undefined;
+
+    try {
+        if (typeof bgColorInt === 'number') {
+            backgroundColor = convertColorToRgba(bgColorInt);
+        }
+    } catch (err) {
+        console.error('Failed to convert backgroundColor:', bgColorInt, err);
+    }
+
+    try {
+        if (typeof fgColorInt === 'number') {
+            foregroundColor = convertColorToRgba(fgColorInt);
+        }
+    } catch (err) {
+        console.error('Failed to convert foregroundColor:', fgColorInt, err);
+    }
+
+    // Extract icon type
+    const iconType = coerceString(wrapTryCatch(() => chip.chipIcon?.iconType));
+
+    return {
+        amount,
+        backgroundColor,
+        foregroundColor,
+        iconType: iconType || undefined
+    };
 }
 
 function buildChatRunsHtml(runs: any[]): string {
@@ -323,6 +373,7 @@ export function buildCommentViewModels(items: any[], options: { isReply?: boolea
             authorAvatarUrl,
             isVerified: Boolean(wrapTryCatch(() => renderer.verifiedAuthor)),
             memberBadge: resolveCommentBadge(renderer),
+            donatedChip: resolveDonatedChip(renderer),
             publishedText,
             publishedUrl,
             likeCountText: likeCountText || undefined,
@@ -372,6 +423,7 @@ export function buildChatMessageViewModels(items: any[]): ChatMessageViewModel[]
             authorAvatarUrl,
             isVerified: Boolean(wrapTryCatch(() => renderer.verifiedAuthor)),
             memberBadge: resolveChatBadge(renderer),
+            donatedChip: resolveDonatedChip(renderer),
             timestampGmtText,
             timestampLabel,
             gotoVideoUrl: gotoVideoUrl || undefined,

--- a/app/src/source/web-resources/wresources.ts
+++ b/app/src/source/web-resources/wresources.ts
@@ -27,6 +27,7 @@ import {
     filterLikesComments,
     filterLinksTrpVideoComments,
     filterMemberComments,
+    filterDonatedComments,
     filterNewestFirst,
     filterRepliedComments,
     filterLinksComments,
@@ -1144,7 +1145,7 @@ Total: ${c.count}\n${c.html}`;
 
             const searchComments = (selector: string, param?: IParamSearch): void => {
                 try {
-                    if (comments.length === 0 || param?.donated) return;
+                    if (comments.length === 0) return;
 
                     const inputSearch = document.getElementById('ycs-input-search') as HTMLInputElement;
                     const querySearch: string = inputSearch?.value;
@@ -1273,6 +1274,39 @@ Total: ${c.count}\n${c.html}`;
                             }
 
                             console.log('cmntsMembers: ', cmntsMembers);
+                        }
+                    } else if (param?.donated) {
+                        const cmntsDonated = filterDonatedComments(comments);
+                        resultSearch = cmntsDonated;
+                        if (textMatchedSet) resultSearch = resultSearch.filter((r: any) => textMatchedSet?.has(r.item));
+
+                        if (resultSearch.length > 0) {
+                            console.log('donated before: ', resultSearch);
+
+                            resultSearch?.sort((firstItem, secondItem) => {
+                                return firstItem.refIndex - secondItem.refIndex;
+                            });
+
+                            console.log('donated after: ', resultSearch);
+
+                            const elSortDonated = document.getElementById('ycs_btn_donated') as HTMLElement;
+                            // Use sortOrder from param if provided (from text search), otherwise use button's dataset
+                            const sortType = param?.sortOrder || (elSortDonated.dataset.sort as 'newest' | 'oldest');
+
+                            if (sortType === 'newest') {
+                                renderComment(selector, resultSearch, true, querySearch);
+                                elSortDonated.innerHTML = `Donated ${iconSortDown()}`;
+                                elSortDonated.title = 'Show comments from users who have donated (Newest)';
+                            } else if (sortType === 'oldest') {
+                                renderComment(selector, resultSearch?.reverse(), true, querySearch);
+                                elSortDonated.innerHTML = `Donated ${iconSortUp()}`;
+                                elSortDonated.title = 'Show comments from users who have donated (Oldest)';
+                            } else {
+                                renderComment(selector, resultSearch, true, querySearch);
+                                elSortDonated.innerHTML = `Donated ${iconSortDown()}`;
+                            }
+
+                            console.log('cmntsDonated: ', cmntsDonated);
                         }
                     } else if (param?.replied) {
                         const cmntsReplied = filterRepliedComments(comments);

--- a/app/src/source/web-resources/wresources.ts
+++ b/app/src/source/web-resources/wresources.ts
@@ -595,6 +595,8 @@ import {
 
                             // Toggle sort only if button was already active
                             if (wasActive) {
+                                const currentSort = currentTarget.dataset.sort;
+                                currentTarget.dataset.sort = currentSort === 'newest' ? 'oldest' : 'newest';
                                 const currentSortChat = currentTarget.dataset.sortChat;
                                 currentTarget.dataset.sortChat = currentSortChat === 'newest' ? 'oldest' : 'newest';
                             }


### PR DESCRIPTION
## Summary

Add donated comment and chat message filtering with unified chip badge rendering. This feature enables users to filter comments and chat replays from users who have made donations, displaying donation amounts as visual badges using YouTube's native color palette system.

## Key Changes

### Core Infrastructure

- Add color conversion utility for YouTube's 32-bit RGBA integer format to CSS rgba strings
- Implement unified donated chip data structure across comments and chat messages
- Add donated comment filter with newest/oldest sorting support

### Innertube API Integration

- Extract donation information from liveChatPaidMessageRenderer
- Transform paid message data into donatedChip structure for consistent rendering
- Apply donated chip from frameworkUpdates surfaceUpdate entities
- Remove legacy hardcoded HTML for donation display in chat replay

### UI Components

- Implement chip badge rendering matching YouTube's Web Component structure
- Add dynamic color styling using CSS variables for donation badges
- Add donated filter button with sort toggle functionality
- Fix icon vertical alignment and spacing for member and heart badges
- Allow span tags in HTML sanitization for chip badge support

### Bug Fixes

- Add missing data-sort toggle attribute for donated button
- Refactor nested conditionals in applyFrameworkUpdatesToComment for better readability

---

Comments
<img src=https://github.com/user-attachments/assets/cbe88225-c945-42db-b88e-082b59ad4d66  width=500>

Chat Replay
<img src=https://github.com/user-attachments/assets/4a371821-7743-468e-bd4e-811fb1415cff  width=500>

