### PR TITLE
fix(ui): make extension insertion point selector more specific

### DIFF
--- a/app/src/source/web-resources/wresources.ts
+++ b/app/src/source/web-resources/wresources.ts
@@ -228,8 +228,8 @@ import {
             removeNodeList('.ycs-app');
 
             // Try new insertion points first (between expandable-metadata and ticket-shelf)
-            if (document.querySelector('#expandable-metadata')) {
-                renderLoadComments('#expandable-metadata', 'insertAfter');
+            if (document.querySelector('#expandable-metadata.ytd-watch-flexy')) {
+                renderLoadComments('#expandable-metadata.ytd-watch-flexy', 'insertAfter');
             } else if (document.querySelector('#ticket-shelf')) {
                 renderLoadComments('#ticket-shelf', 'insertAfter');
             } else if (document.querySelector('#meta.style-scope.ytd-watch-flexy')) {


### PR DESCRIPTION
## Summary

This PR fixes the extension UI insertion point selector to be more specific by adding the `ytd-watch-flexy` context to the `#expandable-metadata` selector. This prevents potential conflicts with other elements that may have the same ID but exist in different contexts on the YouTube page.

## Main Changes

- Updated the insertion point selector from `#expandable-metadata` to `#expandable-metadata.ytd-watch-flexy`
- Ensures the extension UI is inserted at the correct location within the YouTube watch page structure
- Improves selector specificity to avoid DOM query ambiguity

