### PR TITLE
refactor(web-resources): centralize cache and export services

### DIFF
--- a/app/src/source/utils/dom.ts
+++ b/app/src/source/utils/dom.ts
@@ -2,26 +2,7 @@ import Mark from 'mark.js';
 import type { MarkOptions } from 'mark.js';
 
 import { GlobalStore, getCleanUrlVideo, getRandomInt, getVideoId, oIsEmpty, wrapTryCatch } from './common';
-
-function resolveExportMeta(meta: any): { title: string; url: string; generatedAt: string } {
-    const fallbackTitle = typeof document !== 'undefined' ? document.title : '';
-    const fallbackUrl =
-        typeof window !== 'undefined' ? (getCleanUrlVideo(window.location.href) ?? window.location.href) : '';
-
-    let generatedAt = new Date().toString();
-
-    if (meta?.generatedAt instanceof Date) {
-        generatedAt = meta.generatedAt.toString();
-    } else if (typeof meta?.generatedAt === 'string' && meta.generatedAt) {
-        generatedAt = meta.generatedAt;
-    }
-
-    return {
-        title: typeof meta?.title === 'string' && meta.title ? meta.title : fallbackTitle,
-        url: typeof meta?.url === 'string' && meta.url ? meta.url : fallbackUrl,
-        generatedAt
-    };
-}
+import { resolveMeta } from './formatting';
 
 function removeClass(elms: object, s: string): void {
     try {
@@ -63,7 +44,7 @@ function openComments(comments: any): WindowProxy | undefined {
         );
 
         if (commentsNewWindow) {
-            const meta = resolveExportMeta(comments?.meta);
+            const meta = resolveMeta(comments?.meta);
 
             commentsNewWindow.document.title = `Comments, ${meta.title} (${comments.count})`;
             const elWrapPre = document.createElement('pre');
@@ -102,7 +83,7 @@ function openCommentsChat(comments: any): WindowProxy | undefined {
         );
 
         if (commentsNewWindow) {
-            const meta = resolveExportMeta(comments?.meta);
+            const meta = resolveMeta(comments?.meta);
 
             commentsNewWindow.document.title = `Chat, ${meta.title} (${comments.count})`;
             const elWrapPre = document.createElement('pre');
@@ -141,7 +122,7 @@ function openCommentsTrVideo(comments: any): WindowProxy | undefined {
         );
 
         if (commentsNewWindow) {
-            const meta = resolveExportMeta(comments?.meta);
+            const meta = resolveMeta(comments?.meta);
 
             commentsNewWindow.document.title = `Transcript video, ${meta.title} (${comments.count})`;
             const elWrapPre = document.createElement('pre');

--- a/app/src/source/utils/dom.ts
+++ b/app/src/source/utils/dom.ts
@@ -3,6 +3,26 @@ import type { MarkOptions } from 'mark.js';
 
 import { GlobalStore, getCleanUrlVideo, getRandomInt, getVideoId, oIsEmpty, wrapTryCatch } from './common';
 
+function resolveExportMeta(meta: any): { title: string; url: string; generatedAt: string } {
+    const fallbackTitle = typeof document !== 'undefined' ? document.title : '';
+    const fallbackUrl =
+        typeof window !== 'undefined' ? (getCleanUrlVideo(window.location.href) ?? window.location.href) : '';
+
+    let generatedAt = new Date().toString();
+
+    if (meta?.generatedAt instanceof Date) {
+        generatedAt = meta.generatedAt.toString();
+    } else if (typeof meta?.generatedAt === 'string' && meta.generatedAt) {
+        generatedAt = meta.generatedAt;
+    }
+
+    return {
+        title: typeof meta?.title === 'string' && meta.title ? meta.title : fallbackTitle,
+        url: typeof meta?.url === 'string' && meta.url ? meta.url : fallbackUrl,
+        generatedAt
+    };
+}
+
 function removeClass(elms: object, s: string): void {
     try {
         if (oIsEmpty(elms) || typeof s !== 'string') return;
@@ -43,7 +63,9 @@ function openComments(comments: any): WindowProxy | undefined {
         );
 
         if (commentsNewWindow) {
-            commentsNewWindow.document.title = `Comments, ${document.title} (${comments.count})`;
+            const meta = resolveExportMeta(comments?.meta);
+
+            commentsNewWindow.document.title = `Comments, ${meta.title} (${comments.count})`;
             const elWrapPre = document.createElement('pre');
             elWrapPre.style.cssText = 'word-wrap: break-word; white-space: pre-wrap;';
             elWrapPre.insertAdjacentText(
@@ -52,9 +74,9 @@ function openComments(comments: any): WindowProxy | undefined {
 YCS - YouTube Comment Search
 
 Comments
-File created by ${new Date().toString()}
-Video URL: ${getCleanUrlVideo(window.location.href)}
-Title: ${document.title}
+File created by ${meta.generatedAt}
+Video URL: ${meta.url}
+Title: ${meta.title}
 Total comments: ${comments.count}\n${comments.html}`
             );
             commentsNewWindow.document.body.textContent = '';
@@ -80,7 +102,9 @@ function openCommentsChat(comments: any): WindowProxy | undefined {
         );
 
         if (commentsNewWindow) {
-            commentsNewWindow.document.title = `Chat, ${document.title} (${comments.count})`;
+            const meta = resolveExportMeta(comments?.meta);
+
+            commentsNewWindow.document.title = `Chat, ${meta.title} (${comments.count})`;
             const elWrapPre = document.createElement('pre');
             elWrapPre.style.cssText = 'word-wrap: break-word; white-space: pre-wrap;';
             elWrapPre.insertAdjacentText(
@@ -89,9 +113,9 @@ function openCommentsChat(comments: any): WindowProxy | undefined {
 YCS - YouTube Comment Search
 
 Chat replay
-File created by ${new Date().toString()}
-Video URL: ${getCleanUrlVideo(window.location.href)}
-Title: ${document.title}
+File created by ${meta.generatedAt}
+Video URL: ${meta.url}
+Title: ${meta.title}
 Total: ${comments.count}\n${comments.html}`
             );
             commentsNewWindow.document.body.textContent = '';
@@ -117,7 +141,9 @@ function openCommentsTrVideo(comments: any): WindowProxy | undefined {
         );
 
         if (commentsNewWindow) {
-            commentsNewWindow.document.title = `Transcript video, ${document.title} (${comments.count})`;
+            const meta = resolveExportMeta(comments?.meta);
+
+            commentsNewWindow.document.title = `Transcript video, ${meta.title} (${comments.count})`;
             const elWrapPre = document.createElement('pre');
             elWrapPre.style.cssText = 'word-wrap: break-word; white-space: pre-wrap;';
             elWrapPre.insertAdjacentText(
@@ -126,9 +152,9 @@ function openCommentsTrVideo(comments: any): WindowProxy | undefined {
 YCS - YouTube Comment Search
 
 Transcript video
-File created by ${new Date().toString()}
-Video URL: ${getCleanUrlVideo(window.location.href)}
-Title: ${document.title}
+File created by ${meta.generatedAt}
+Video URL: ${meta.url}
+Title: ${meta.title}
 Total: ${comments.count}\n${comments.html}`
             );
             commentsNewWindow.document.body.textContent = '';

--- a/app/src/source/utils/formatting.ts
+++ b/app/src/source/utils/formatting.ts
@@ -1,4 +1,38 @@
-import { escapeHtml, wrapTryCatch } from './common';
+import { escapeHtml, wrapTryCatch, getCleanUrlVideo } from './common';
+
+interface ExportMeta {
+    url?: string;
+    title?: string;
+    generatedAt?: Date | string;
+}
+
+interface ResolvedExportMeta {
+    url: string;
+    title: string;
+    generatedAt: string;
+}
+
+function resolveMeta(meta?: ExportMeta): ResolvedExportMeta {
+    const fallbackTitle = typeof document !== 'undefined' ? document.title : '';
+    const fallbackUrl =
+        typeof window !== 'undefined' ? (getCleanUrlVideo(window.location.href) ?? window.location.href) : '';
+
+    let generatedAt = new Date();
+    if (meta?.generatedAt instanceof Date) {
+        generatedAt = meta.generatedAt;
+    } else if (typeof meta?.generatedAt === 'string') {
+        const parsed = new Date(meta.generatedAt);
+        if (!Number.isNaN(parsed.getTime())) {
+            generatedAt = parsed;
+        }
+    }
+
+    return {
+        title: typeof meta?.title === 'string' && meta.title ? meta.title : fallbackTitle,
+        url: typeof meta?.url === 'string' && meta.url ? meta.url : fallbackUrl,
+        generatedAt: generatedAt.toString()
+    };
+}
 
 function esc(input: unknown): string {
     try {
@@ -392,6 +426,7 @@ start offset: ${wrapTryCatch(() => c.transcriptCueGroupRenderer.cues[0].transcri
 }
 
 export {
+    resolveMeta,
     esc,
     safeUrl,
     sanitizeHtml,
@@ -405,3 +440,5 @@ export {
     getCommentsChatHtmlText,
     getCommentsTrVideoHtmlText
 };
+
+export type { ExportMeta, ResolvedExportMeta };

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -3,27 +3,23 @@
 import 'abort-controller/polyfill';
 
 import { GlobalStore, extractChannelId, wrapTryCatch, getCleanUrlVideo, isVideoPage } from '../utils/common';
-import {
-    downloadFile,
-    initShowBarFAQ,
-    initShowViewMode,
-    openComments,
-    openCommentsChat,
-    openCommentsTrVideo,
-    removeClass,
-    removeNodeList,
-    sendGetCacheInIDB,
-    sendMsgToBadge,
-    setCacheToIDB,
-    showLoadComments
-} from '../utils/dom';
+import { initShowBarFAQ, initShowViewMode, removeClass, removeNodeList, showLoadComments } from '../utils/dom';
 import { getAllCommentsModeV2, getChatComments, getTranscriptVideo } from '../utils/innertube';
-import { getCommentsChatHtmlText, getCommentsHtmlText, getCommentsTrVideoHtmlText } from '../utils/formatting';
 
 import { ICommentsFuseResult, IParamSearch, ISelectedSearch } from '../utils/interfaces/i_types';
 
 import { iconCollapse, iconExpand, iconOk, iconReload } from '../utils/icons';
 import { renderComment, renderLoadComments, renderSearch } from '../utils/renderView';
+import { loadFromCache, saveToCache, updateBadge } from './services/cacheService';
+import {
+    downloadChatFile,
+    downloadCommentsFile,
+    downloadTranscriptFile,
+    openChatWindow,
+    openCommentsWindow,
+    openTranscriptWindow,
+    ExportMeta
+} from './services/exportService';
 import {
     clearComments,
     clearCommentsChat,
@@ -95,7 +91,7 @@ export function initApp(): void {
 
         state = createState();
 
-        sendMsgToBadge('NUMBER_COMMENTS', '');
+        updateBadge('NUMBER_COMMENTS', '');
 
         removeNodeList('.ycs-app');
 
@@ -402,6 +398,21 @@ export function initApp(): void {
             }
         };
 
+        const buildCacheMeta = () => ({
+            url: window.location.href,
+            title: document.title
+        });
+
+        const buildExportMeta = (): ExportMeta => {
+            const videoUrl = getCleanUrlVideo(window.location.href);
+
+            return {
+                url: videoUrl ?? window.location.href,
+                title: document.title,
+                generatedAt: new Date()
+            };
+        };
+
         const appendCachedInfo = (timestamp: number | string | null | undefined): void => {
             const cacheTitle = new Date(timestamp as number | string);
             const targets: (HTMLElement | null)[] = [elCountComments, elCountCommentsCollapsed];
@@ -449,15 +460,14 @@ export function initApp(): void {
 
                     if (comments.length > 0) {
                         elStatusCmnts.innerHTML = iconOk();
-                        setCacheToIDB(
+                        saveToCache(
                             {
                                 comments,
                                 commentsChat: JSON.stringify(Array.from(getCommentsChat(state).entries())),
                                 commentsTrVideo: getCommentsTrVideo(state),
                                 channelId: extractChannelId()
                             },
-                            window.location.href,
-                            document.title
+                            buildCacheMeta()
                         );
                     }
                 }
@@ -468,7 +478,7 @@ export function initApp(): void {
 
                 const counts = getCounts(state);
                 const totalCount = counts.comments + counts.commentsChat + counts.commentsTrVideo;
-                sendMsgToBadge('NUMBER_COMMENTS', totalCount);
+                updateBadge('NUMBER_COMMENTS', totalCount);
 
                 if (elLoadCmnts) {
                     elLoadCmnts.textContent = `${comments.length}`;
@@ -510,15 +520,14 @@ export function initApp(): void {
                     if (commentsChat.size > 0) {
                         elLoadChat.textContent = commentsChat.size.toString();
                         elStatusChat.innerHTML = iconOk();
-                        setCacheToIDB(
+                        saveToCache(
                             {
                                 comments: getComments(state),
                                 commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
                                 commentsTrVideo: getCommentsTrVideo(state),
                                 channelId: extractChannelId()
                             },
-                            window.location.href,
-                            document.title
+                            buildCacheMeta()
                         );
                     }
                 }
@@ -529,7 +538,7 @@ export function initApp(): void {
 
                 const counts = getCounts(state);
                 const totalCount = counts.comments + counts.commentsChat + counts.commentsTrVideo;
-                sendMsgToBadge('NUMBER_COMMENTS', totalCount);
+                updateBadge('NUMBER_COMMENTS', totalCount);
 
                 updateTitleCount(totalCount);
 
@@ -584,15 +593,14 @@ export function initApp(): void {
                                     .body.transcriptBodyRenderer.cueGroups.length,
                                 elLoadTrVideo
                             );
-                            setCacheToIDB(
+                            saveToCache(
                                 {
                                     comments: getComments(state),
                                     commentsChat: JSON.stringify(Array.from(getCommentsChat(state).entries())),
                                     commentsTrVideo: transcript,
                                     channelId: extractChannelId()
                                 },
-                                window.location.href,
-                                document.title
+                                buildCacheMeta()
                             );
                         } else {
                             state = clearCommentsTrVideo(state);
@@ -635,7 +643,7 @@ export function initApp(): void {
 
                 const counts = getCounts(state);
                 const totalCount = counts.comments + counts.commentsChat + counts.commentsTrVideo;
-                sendMsgToBadge('NUMBER_COMMENTS', totalCount);
+                updateBadge('NUMBER_COMMENTS', totalCount);
 
                 updateTitleCount(totalCount);
 
@@ -725,7 +733,7 @@ export function initApp(): void {
             if (comments.length === 0) return;
 
             try {
-                openComments(getCommentsHtmlText(comments));
+                openCommentsWindow(comments, buildExportMeta());
             } catch (e) {
                 console.error(e);
                 return;
@@ -738,17 +746,7 @@ export function initApp(): void {
             if (comments.length === 0) return;
 
             try {
-                const c = getCommentsHtmlText(comments);
-                const htmlText = `
-YCS - YouTube Comment Search
-
-Comments
-File created by ${new Date().toString()}
-Video URL: ${getCleanUrlVideo(window.location.href)}
-Title: ${document.title}
-Total: ${c.count}\n${c.html}`;
-
-                downloadFile(htmlText, `Comments, ${document.title} (${c.count}).txt`, 'text/plain');
+                downloadCommentsFile(comments, buildExportMeta());
             } catch (e) {
                 console.error(e);
                 return;
@@ -761,7 +759,7 @@ Total: ${c.count}\n${c.html}`;
             if (commentsChat.size === 0) return;
 
             try {
-                openCommentsChat(getCommentsChatHtmlText([...commentsChat.values()]));
+                openChatWindow([...commentsChat.values()], buildExportMeta());
             } catch (e) {
                 console.error(e);
                 return;
@@ -774,17 +772,7 @@ Total: ${c.count}\n${c.html}`;
             if (commentsChat.size === 0) return;
 
             try {
-                const c = getCommentsChatHtmlText([...commentsChat.values()]);
-                const htmlText = `
-YCS - YouTube Comment Search
-
-Comments chat
-File created by ${new Date().toString()}
-Video URL: ${getCleanUrlVideo(window.location.href)}
-Title: ${document.title}
-Total: ${c.count}\n${c.html}`;
-
-                downloadFile(htmlText, `Comments chat, ${document.title} (${c.count}).txt`, 'text/plain');
+                downloadChatFile([...commentsChat.values()], buildExportMeta());
             } catch (e) {
                 console.error(e);
                 return;
@@ -803,11 +791,10 @@ Total: ${c.count}\n${c.html}`;
                     (commentsTrVideo as any)?.actions[0]?.updateEngagementPanelAction?.content?.transcriptRenderer?.body
                         ?.transcriptBodyRenderer?.cueGroups?.length > 0
                 ) {
-                    openCommentsTrVideo(
-                        getCommentsTrVideoHtmlText(
-                            (commentsTrVideo as any).actions[0].updateEngagementPanelAction.content.transcriptRenderer
-                                .body.transcriptBodyRenderer.cueGroups
-                        )
+                    openTranscriptWindow(
+                        (commentsTrVideo as any).actions[0].updateEngagementPanelAction.content.transcriptRenderer.body
+                            .transcriptBodyRenderer.cueGroups,
+                        buildExportMeta()
                     );
                 }
             } catch (e) {
@@ -826,21 +813,11 @@ Total: ${c.count}\n${c.html}`;
                     (commentsTrVideo as any).actions[0]?.updateEngagementPanelAction?.content?.transcriptRenderer?.body
                         ?.transcriptBodyRenderer?.cueGroups?.length > 0
                 ) {
-                    const c = getCommentsTrVideoHtmlText(
+                    downloadTranscriptFile(
                         (commentsTrVideo as any).actions[0].updateEngagementPanelAction.content.transcriptRenderer.body
-                            .transcriptBodyRenderer.cueGroups
+                            .transcriptBodyRenderer.cueGroups,
+                        buildExportMeta()
                     );
-
-                    const htmlText = `
-YCS - YouTube Comment Search
-
-Transcript video
-File created by ${new Date().toString()}
-Video URL: ${getCleanUrlVideo(window.location.href)}
-Title: ${document.title}
-Total: ${c.count}\n${c.html}`;
-
-                    downloadFile(htmlText, `Transcript video, ${document.title} (${c.count}).txt`, 'text/plain');
                 }
             } catch (e) {
                 console.error(e);
@@ -1216,7 +1193,7 @@ Total: ${c.count}\n${c.html}`;
                     try {
                         if (!value) return;
 
-                        sendGetCacheInIDB(window.location.href);
+                        loadFromCache(window.location.href);
                     } catch (err) {
                         console.error(err);
                     }
@@ -1390,7 +1367,7 @@ Total: ${c.count}\n${c.html}`;
 
                     const counts = getCounts(state);
                     const totalCount = counts.comments + counts.commentsChat + counts.commentsTrVideo;
-                    sendMsgToBadge('NUMBER_COMMENTS', totalCount);
+                    updateBadge('NUMBER_COMMENTS', totalCount);
 
                     updateTitleCount(totalCount);
                     appendCachedInfo(crdate);

--- a/app/src/source/web-resources/services/cacheService.ts
+++ b/app/src/source/web-resources/services/cacheService.ts
@@ -1,0 +1,32 @@
+import { sendGetCacheInIDB, setCacheToIDB, sendMsgToBadge } from '../../utils/dom';
+
+interface CacheMeta {
+    url: string;
+    title: string;
+}
+
+interface CacheData {
+    comments: any[];
+    commentsChat: string;
+    commentsTrVideo: unknown;
+    channelId?: string | null;
+}
+
+export function loadFromCache(url: string): void {
+    if (!url) return;
+    sendGetCacheInIDB(url);
+}
+
+export function saveToCache(data: CacheData, meta: CacheMeta): void {
+    if (!meta?.url || !meta?.title) return;
+
+    setCacheToIDB(data, meta.url, meta.title);
+}
+
+export function updateBadge(type: string, value: string | number): void {
+    if (!type) return;
+
+    sendMsgToBadge(type, value);
+}
+
+export type { CacheMeta, CacheData };

--- a/app/src/source/web-resources/services/exportService.ts
+++ b/app/src/source/web-resources/services/exportService.ts
@@ -1,43 +1,14 @@
-import { getCleanUrlVideo } from '../../utils/common';
 import { downloadFile, openComments, openCommentsChat, openCommentsTrVideo } from '../../utils/dom';
-import { getCommentsChatHtmlText, getCommentsHtmlText, getCommentsTrVideoHtmlText } from '../../utils/formatting';
-
-interface ExportMeta {
-    url?: string;
-    title?: string;
-    generatedAt?: Date | string;
-}
-
-interface ResolvedExportMeta {
-    url: string;
-    title: string;
-    generatedAt: string;
-}
-
-function resolveMeta(meta?: ExportMeta): ResolvedExportMeta {
-    const fallbackTitle = typeof document !== 'undefined' ? document.title : '';
-    const fallbackUrl =
-        typeof window !== 'undefined' ? (getCleanUrlVideo(window.location.href) ?? window.location.href) : '';
-
-    let generatedAt = new Date();
-    if (meta?.generatedAt instanceof Date) {
-        generatedAt = meta.generatedAt;
-    } else if (typeof meta?.generatedAt === 'string') {
-        const parsed = new Date(meta.generatedAt);
-        if (!Number.isNaN(parsed.getTime())) {
-            generatedAt = parsed;
-        }
-    }
-
-    return {
-        title: meta?.title ?? fallbackTitle,
-        url: meta?.url ?? fallbackUrl,
-        generatedAt: generatedAt.toString()
-    };
-}
+import {
+    getCommentsChatHtmlText,
+    getCommentsHtmlText,
+    getCommentsTrVideoHtmlText,
+    resolveMeta
+} from '../../utils/formatting';
+import type { ExportMeta, ResolvedExportMeta } from '../../utils/formatting';
 
 function buildDocument(sectionTitle: string, meta: ResolvedExportMeta, count: number, body: string): string {
-    return `YCS - YouTube Comment Search\n\n${sectionTitle}\nFile created by ${meta.generatedAt}\nVideo URL: ${meta.url}\nTitle: ${meta.title}\nTotal: ${count}\\n${body}`;
+    return `YCS - YouTube Comment Search\n\n${sectionTitle}\nFile created by ${meta.generatedAt}\nVideo URL: ${meta.url}\nTitle: ${meta.title}\nTotal: ${count}\n${body}`;
 }
 
 export function openCommentsWindow(comments: any[], meta?: ExportMeta): void {

--- a/app/src/source/web-resources/services/exportService.ts
+++ b/app/src/source/web-resources/services/exportService.ts
@@ -1,0 +1,100 @@
+import { getCleanUrlVideo } from '../../utils/common';
+import { downloadFile, openComments, openCommentsChat, openCommentsTrVideo } from '../../utils/dom';
+import { getCommentsChatHtmlText, getCommentsHtmlText, getCommentsTrVideoHtmlText } from '../../utils/formatting';
+
+interface ExportMeta {
+    url?: string;
+    title?: string;
+    generatedAt?: Date | string;
+}
+
+interface ResolvedExportMeta {
+    url: string;
+    title: string;
+    generatedAt: string;
+}
+
+function resolveMeta(meta?: ExportMeta): ResolvedExportMeta {
+    const fallbackTitle = typeof document !== 'undefined' ? document.title : '';
+    const fallbackUrl =
+        typeof window !== 'undefined' ? (getCleanUrlVideo(window.location.href) ?? window.location.href) : '';
+
+    let generatedAt = new Date();
+    if (meta?.generatedAt instanceof Date) {
+        generatedAt = meta.generatedAt;
+    } else if (typeof meta?.generatedAt === 'string') {
+        const parsed = new Date(meta.generatedAt);
+        if (!Number.isNaN(parsed.getTime())) {
+            generatedAt = parsed;
+        }
+    }
+
+    return {
+        title: meta?.title ?? fallbackTitle,
+        url: meta?.url ?? fallbackUrl,
+        generatedAt: generatedAt.toString()
+    };
+}
+
+function buildDocument(sectionTitle: string, meta: ResolvedExportMeta, count: number, body: string): string {
+    return `YCS - YouTube Comment Search\n\n${sectionTitle}\nFile created by ${meta.generatedAt}\nVideo URL: ${meta.url}\nTitle: ${meta.title}\nTotal: ${count}\\n${body}`;
+}
+
+export function openCommentsWindow(comments: any[], meta?: ExportMeta): void {
+    const formatted = getCommentsHtmlText(comments);
+    if (!formatted) return;
+
+    const resolved = resolveMeta(meta);
+
+    openComments({ ...formatted, meta: resolved });
+}
+
+export function downloadCommentsFile(comments: any[], meta?: ExportMeta): void {
+    const formatted = getCommentsHtmlText(comments);
+    if (!formatted) return;
+
+    const resolved = resolveMeta(meta);
+    const documentBody = buildDocument('Comments', resolved, formatted.count, formatted.html);
+
+    downloadFile(documentBody, `Comments, ${resolved.title} (${formatted.count}).txt`, 'text/plain');
+}
+
+export function openChatWindow(chatMessages: any[], meta?: ExportMeta): void {
+    const formatted = getCommentsChatHtmlText(chatMessages);
+    if (!formatted) return;
+
+    const resolved = resolveMeta(meta);
+
+    openCommentsChat({ ...formatted, meta: resolved });
+}
+
+export function downloadChatFile(chatMessages: any[], meta?: ExportMeta): void {
+    const formatted = getCommentsChatHtmlText(chatMessages);
+    if (!formatted) return;
+
+    const resolved = resolveMeta(meta);
+    const documentBody = buildDocument('Comments chat', resolved, formatted.count, formatted.html);
+
+    downloadFile(documentBody, `Comments chat, ${resolved.title} (${formatted.count}).txt`, 'text/plain');
+}
+
+export function openTranscriptWindow(cueGroups: any[], meta?: ExportMeta): void {
+    const formatted = getCommentsTrVideoHtmlText(cueGroups);
+    if (!formatted) return;
+
+    const resolved = resolveMeta(meta);
+
+    openCommentsTrVideo({ ...formatted, meta: resolved });
+}
+
+export function downloadTranscriptFile(cueGroups: any[], meta?: ExportMeta): void {
+    const formatted = getCommentsTrVideoHtmlText(cueGroups);
+    if (!formatted) return;
+
+    const resolved = resolveMeta(meta);
+    const documentBody = buildDocument('Transcript video', resolved, formatted.count, formatted.html);
+
+    downloadFile(documentBody, `Transcript video, ${resolved.title} (${formatted.count}).txt`, 'text/plain');
+}
+
+export type { ExportMeta };


### PR DESCRIPTION
## Summary
- extract cache utilities into a dedicated cacheService with load, save, and badge helpers
- centralize export formatting and delivery logic inside exportService using supplied meta data
- update app controller flow and DOM helpers to consume the new services and keep window exports meta-aware

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7867a6ca483299d62589b1c94f97a