### PR TITLE
refactor(web-resources): extract comment interactions and unify timestamp navigation

### DIFF
--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -228,13 +228,15 @@ html[dark] .ycs-open-reply {
 .ycs-comment-link,
 .ycs-open-comment,
 .ycs-gotochat-video,
+.ycs-goto-comment-time,
 .ycs-goto-video {
   cursor: pointer;
   color: #065fd4;
   text-decoration: none;
 }
 
-.ycs-gotochat-video * {
+.ycs-gotochat-video *,
+.ycs-goto-comment-time * {
   vertical-align: unset !important;
   pointer-events: none;
 }
@@ -266,11 +268,13 @@ html[dark='true'] .ycs-open-reply,
 html[dark='true'] .ycs-comment-link,
 html[dark='true'] .ycs-open-comment,
 html[dark='true'] .ycs-gotochat-video,
+html[dark='true'] .ycs-goto-comment-time,
 html[dark='true'] .ycs-goto-video,
 html[dark] .ycs-open-reply,
 html[dark] .ycs-comment-link,
 html[dark] .ycs-open-comment,
 html[dark] .ycs-gotochat-video,
+html[dark] .ycs-goto-comment-time,
 html[dark] .ycs-goto-video {
   color: #3ea6ff;
 }

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -1439,7 +1439,7 @@ async function getChatComments(
                                             const isSameVideo =
                                                 String(linkVideoId || '') === String(currentVideoId || '');
 
-                                            renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}" data-video-id="${linkVideoId}">${msg?.text || ''}</a>`;
+                                            renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}" data-video-id="${linkVideoId}">${msg?.text || ''}</a>`;
 
                                             if (
                                                 isSameVideo &&
@@ -1682,7 +1682,7 @@ async function getChatComments(
                                                             msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds
                                                         ) >= 0
                                                     ) {
-                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${msg?.navigationEndpoint?.watchEndpoint?.videoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}">${msg?.text || ''}</a>`;
+                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${msg?.navigationEndpoint?.watchEndpoint?.videoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}">${msg?.text || ''}</a>`;
 
                                                         const currentVideoId = (getVideoId(window.location.href) ||
                                                             '') as string;
@@ -1959,7 +1959,7 @@ async function getChatComments(
                                                             msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds
                                                         ) >= 0
                                                     ) {
-                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${msg?.navigationEndpoint?.watchEndpoint?.videoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}">${msg?.text || ''}</a>`;
+                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${msg?.navigationEndpoint?.watchEndpoint?.videoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}">${msg?.text || ''}</a>`;
 
                                                         const currentVideoId = (getVideoId(window.location.href) ||
                                                             '') as string;
@@ -2548,7 +2548,7 @@ async function getAllCommentsModeV2(
                                     wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds) as any
                                 ) >= 0
                             ) {
-                                renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.videoId)}&t=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}s" data-offsetvideo="${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}">${text || ''}</a>`;
+                                renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.videoId)}&t=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}s" data-offsetvideo="${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}">${text || ''}</a>`;
 
                                 if (c.commentThreadRenderer?.comment?.commentRenderer) {
                                     c.commentThreadRenderer.comment.commentRenderer.isTimeLine = 'timeline';
@@ -2619,7 +2619,7 @@ async function getAllCommentsModeV2(
                                     ) || '') as string;
                                     const isSameVideo = String(linkVideoId || '') === String(currentVideoId || '');
 
-                                    renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}" data-video-id="${linkVideoId}">${partTextComment?.text || ''}</a>`;
+                                    renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}" data-video-id="${linkVideoId}">${partTextComment?.text || ''}</a>`;
                                     try {
                                         if (isSameVideo) normalized.commentRenderer.isTimeLine = 'timeline';
                                     } catch {
@@ -2762,7 +2762,7 @@ async function getAllCommentsModeV2(
                                                 const isSameVideo =
                                                     String(linkVideoId || '') === String(currentVideoId || '');
 
-                                                renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}s" data-offsetvideo="${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}" data-video-id="${linkVideoId}">${textStr || ''}</a>`;
+                                                renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}s" data-offsetvideo="${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}" data-video-id="${linkVideoId}">${textStr || ''}</a>`;
 
                                                 if (isSameVideo && comment.commentRenderer) {
                                                     comment.commentRenderer.isTimeLine = 'timeline';
@@ -2913,7 +2913,7 @@ async function getAllCommentsModeV2(
                                                     const isSameVideo =
                                                         String(linkVideoId || '') === String(currentVideoId || '');
 
-                                                    renderFullTextComment += `<a class="ycs-cpointer ycs-gotochat-video" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}s" data-offsetvideo="${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}" data-video-id="${linkVideoId}">${text || ''}</a>`;
+                                                    renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}s" data-offsetvideo="${wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds)}" data-video-id="${linkVideoId}">${text || ''}</a>`;
 
                                                     if (isSameVideo && comment.commentRenderer) {
                                                         comment.commentRenderer.isTimeLine = 'timeline';

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -267,7 +267,7 @@ function buildChatRunsHtml(runs: any[]): string {
                         : '';
                     const safeHref = href ? ` href="${escapeHtml(href)}"` : '';
                     parts.push(
-                        `<a class="ycs-cpointer ycs-gotochat-video"${safeHref}${offsetAttr}>${escapeHtml(text)}</a>`
+                        `<a class="ycs-cpointer ycs-goto-comment-time"${safeHref}${offsetAttr}>${escapeHtml(text)}</a>`
                     );
                 } else {
                     const href =

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -6,10 +6,10 @@ import { GlobalStore, extractChannelId, wrapTryCatch, getCleanUrlVideo, isVideoP
 import { initShowBarFAQ, initShowViewMode, removeClass, removeNodeList, showLoadComments } from '../utils/dom';
 import { getAllCommentsModeV2, getChatComments, getTranscriptVideo } from '../utils/innertube';
 
-import { ICommentsFuseResult, IParamSearch, ISelectedSearch } from '../utils/interfaces/i_types';
+import { IParamSearch, ISelectedSearch } from '../utils/interfaces/i_types';
 
-import { iconCollapse, iconExpand, iconOk, iconReload } from '../utils/icons';
-import { renderComment, renderLoadComments, renderSearch } from '../utils/renderView';
+import { iconOk, iconReload } from '../utils/icons';
+import { renderLoadComments, renderSearch } from '../utils/renderView';
 import { loadFromCache, saveToCache, updateBadge } from './services/cacheService';
 import {
     downloadChatFile,
@@ -41,6 +41,7 @@ import {
     WebResourcesState
 } from './state';
 import { FilterButtonConfig, registerFilterButtons } from './ui/filters';
+import { registerCommentInteractions } from './ui/commentInteractions';
 import { runSearch as runCommentsSearch } from './search/commentsSearch';
 import { runSearch as runChatSearch } from './search/chatSearch';
 import { runSearch as runTranscriptSearch } from './search/transcriptSearch';
@@ -832,142 +833,16 @@ export function initApp(): void {
 
             state = setSearchCount(state, 'comments', result.total);
 
-            const elsCommentOpenReply = document.getElementById('ycs_wrap_comments');
+            const commentsContainer = document.getElementById('ycs_wrap_comments');
 
-            if (elsCommentOpenReply) {
-                elsCommentOpenReply.addEventListener('click', (event) => {
-                    try {
-                        const target = event.target as HTMLElement | null;
-                        if (!target) return;
-
-                        const comments = getComments(state);
-
-                        if (target.classList.contains('ycs-open-comment')) {
-                            const refID = parseInt(target.getAttribute('id') || '', 10);
-                            const reply = target.closest('.ycs-render-comment');
-
-                            if (reply && refID && !document.getElementById(`ycs-com-${refID}`)) {
-                                const origin = comments.find((item: any) => (item as any)?._index === refID);
-                                const com = origin
-                                    ? { item: (origin as any).originComment, refIndex: refID }
-                                    : undefined;
-
-                                const wrap = document.createElement('div');
-                                wrap.id = `ycs-com-${refID}`;
-                                wrap.className = wrap.id;
-
-                                reply.insertAdjacentElement('beforebegin', wrap);
-
-                                if (com) renderComment(`#${wrap.id}`, [com], true, query);
-
-                                reply.classList.add('ycs-oc-ml');
-
-                                let toReplyAuthor: string | undefined;
-
-                                if ((origin as any)?.commentRenderer?.contentText?.runs?.length > 0) {
-                                    for (const msg of (origin as any).commentRenderer.contentText.runs) {
-                                        if (msg.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl) {
-                                            toReplyAuthor = msg.navigationEndpoint.browseEndpoint.canonicalBaseUrl;
-                                            break;
-                                        }
-                                    }
-                                }
-
-                                const replyAuthor: ICommentsFuseResult[] = [];
-
-                                if (toReplyAuthor) {
-                                    for (const auth of comments) {
-                                        if (
-                                            (auth as any).typeComment === 'R' &&
-                                            (auth as any).originComment === (origin as any).originComment &&
-                                            (auth as any).commentRenderer?.authorEndpoint?.browseEndpoint
-                                                ?.canonicalBaseUrl === toReplyAuthor
-                                        ) {
-                                            replyAuthor.push({ item: auth, refIndex: refID });
-                                        }
-                                    }
-                                }
-
-                                if (replyAuthor.length > 0) {
-                                    const wrapToReply = document.createElement('div');
-                                    wrapToReply.id = `ycs-com-rauth-${refID}`;
-                                    wrapToReply.className = `ycs-com-${refID} ycs-oc-ml`;
-                                    reply.insertAdjacentElement('beforebegin', wrapToReply);
-
-                                    renderComment(`#${wrapToReply.id}`, replyAuthor, false, query);
-                                }
-
-                                target.innerHTML = `${iconCollapse()}`;
-                                target.title = 'Close the comment to the reply here.';
-                            } else if (reply && refID && document.getElementById(`ycs-com-${refID}`)) {
-                                removeNodeList(`.ycs-com-${refID}`);
-
-                                reply.classList.remove('ycs-oc-ml');
-                                target.innerHTML = `${iconExpand()}`;
-                                target.title = 'Open the comment to the reply here.';
-                            }
-                        } else if (target.classList.contains('ycs-gotochat-video')) {
-                            event.preventDefault();
-
-                            const elFrameVideo: HTMLVideoElement | undefined =
-                                document.getElementsByTagName('video')[0];
-                            if (elFrameVideo) {
-                                const ms = target.dataset.offsetvideo;
-                                if (ms) {
-                                    elFrameVideo.currentTime = parseInt(ms, 10);
-                                }
-                            }
-                        } else if (target.classList.contains('ycs-open-reply')) {
-                            const id = target.dataset.idcom;
-                            const wrap = target.closest('.ycs-render-comment');
-
-                            if (wrap?.querySelector(`.ycs-com-replies-${id}`)) {
-                                const replies = wrap.querySelector(`.ycs-com-replies-${id}`);
-                                replies?.remove();
-
-                                target.innerHTML = '+';
-                                target.title = 'Open replies to the comment';
-                                return;
-                            }
-
-                            const repls: ICommentsFuseResult[] = [];
-                            if (id) {
-                                let index: number | undefined;
-
-                                for (const [i, comment] of comments.entries()) {
-                                    if ((comment as any).commentRenderer?.commentId === id) {
-                                        index = i;
-                                        break;
-                                    }
-                                }
-
-                                if (Number.isInteger(index) && (index as number) >= 0) {
-                                    for (const comment of comments) {
-                                        if (comments[index as number] === (comment as any).originComment) {
-                                            const refIndex = Number((comment as any)?._index ?? 0);
-                                            repls.push({ item: comment, refIndex });
-                                        }
-                                    }
-                                }
-                            }
-
-                            if (repls.length > 0) {
-                                const replyContainer = target.closest('.ycs-render-comment');
-                                const wrapToReply = document.createElement('div');
-                                wrapToReply.id = `ycs-com-replies-${id}`;
-                                wrapToReply.className = `ycs-com-replies-${id} ycs-oc-ml ycs-com-replies ycs-com-rp`;
-                                replyContainer?.insertAdjacentElement('beforeend', wrapToReply);
-
-                                renderComment(wrapToReply, repls, false, query);
-
-                                target.innerHTML = String.fromCharCode(8722);
-                                target.title = 'Close replies to the comment';
-                            }
-                        }
-                    } catch (error) {
-                        console.error(error);
-                    }
-                });
+            if (commentsContainer instanceof HTMLElement) {
+                registerCommentInteractions(
+                    commentsContainer,
+                    {
+                        getComments: () => getComments(state)
+                    },
+                    () => query
+                );
             }
 
             return result;

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -861,15 +861,23 @@ export function initApp(): void {
                 elsGotoChatVideo.addEventListener('click', (event) => {
                     try {
                         const target = event.target as HTMLElement | null;
-                        if (!target?.classList.contains('ycs-gotochat-video')) return;
+                        if (!target) return;
+
+                        const isChatVideo = target.classList.contains('ycs-gotochat-video');
+                        const isCommentTime = target.classList.contains('ycs-goto-comment-time');
+
+                        if (!isChatVideo && !isCommentTime) return;
 
                         event.preventDefault();
 
                         const elFrameVideo = document.getElementsByTagName('video')[0];
                         if (elFrameVideo) {
-                            const ms = target.dataset.offsetvideo;
-                            if (ms) {
-                                elFrameVideo.currentTime = parseInt(ms, 10) / 1000;
+                            const timeValue = target.dataset.offsetvideo;
+                            if (timeValue) {
+                                // Chat video uses milliseconds, comment time uses seconds
+                                elFrameVideo.currentTime = isChatVideo
+                                    ? parseInt(timeValue, 10) / 1000
+                                    : parseInt(timeValue, 10);
                             }
                         }
                     } catch (error) {

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -1,0 +1,262 @@
+import { removeNodeList } from '../../utils/dom';
+import { iconCollapse, iconExpand } from '../../utils/icons';
+import { ICommentsFuseResult } from '../../utils/interfaces/i_types';
+import { renderComment } from '../../utils/renderView';
+
+type CommentCollection = Array<Record<string, any>>;
+
+export interface CommentStateAccessor {
+    getComments(): CommentCollection;
+}
+
+export type QueryGetter = () => string;
+
+export function registerCommentInteractions(
+    container: HTMLElement,
+    stateAccessor: CommentStateAccessor,
+    queryGetter: QueryGetter
+): void {
+    if (!container || !stateAccessor?.getComments) return;
+    if (container.dataset.ycsInteractionsBound === 'true') {
+        return;
+    }
+
+    container.dataset.ycsInteractionsBound = 'true';
+
+    container.addEventListener('click', (event) => {
+        const target = event.target as HTMLElement | null;
+        if (!target) return;
+
+        if (target.classList.contains('ycs-open-comment')) {
+            handleOpenComment(target, stateAccessor, queryGetter);
+            return;
+        }
+
+        if (target.classList.contains('ycs-gotochat-video')) {
+            handleGotoChatVideo(event);
+            return;
+        }
+
+        if (target.classList.contains('ycs-open-reply')) {
+            handleOpenReply(target, stateAccessor, queryGetter);
+        }
+    });
+}
+
+function safeGetComments(stateAccessor: CommentStateAccessor): CommentCollection {
+    try {
+        const comments = stateAccessor.getComments();
+        return Array.isArray(comments) ? comments : [];
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
+}
+
+function resolveQuery(queryGetter: QueryGetter): string {
+    try {
+        const value = queryGetter?.();
+        return typeof value === 'string' ? value : '';
+    } catch (error) {
+        console.error(error);
+        return '';
+    }
+}
+
+function parseRefId(target: HTMLElement): number | null {
+    const raw = target.getAttribute('id');
+    if (!raw) return null;
+    const refId = Number.parseInt(raw, 10);
+    return Number.isFinite(refId) ? refId : null;
+}
+
+function findCommentByIndex(comments: CommentCollection, refId: number): Record<string, any> | undefined {
+    return comments.find((item) => Number.parseInt(String((item as any)?._index ?? ''), 10) === refId);
+}
+
+function buildOriginResult(origin: Record<string, any> | undefined, refId: number): ICommentsFuseResult | null {
+    if (!origin?.originComment) return null;
+    return {
+        item: origin.originComment,
+        refIndex: refId
+    };
+}
+
+function createOriginWrapper(refId: number): HTMLDivElement {
+    const wrap = document.createElement('div');
+    wrap.id = `ycs-com-${refId}`;
+    wrap.className = wrap.id;
+    return wrap;
+}
+
+function extractReplyAuthorUrl(origin: Record<string, any> | undefined): string | undefined {
+    const runs = origin?.commentRenderer?.contentText?.runs;
+    if (!Array.isArray(runs)) return undefined;
+
+    for (const run of runs) {
+        const url = run?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl;
+        if (url) {
+            return url;
+        }
+    }
+
+    return undefined;
+}
+
+function buildAuthorReplyResults(
+    comments: CommentCollection,
+    origin: Record<string, any> | undefined,
+    refId: number
+): ICommentsFuseResult[] {
+    if (!origin?.originComment) return [];
+
+    const replyUrl = extractReplyAuthorUrl(origin);
+    if (!replyUrl) return [];
+
+    const replies: ICommentsFuseResult[] = [];
+
+    for (const entry of comments) {
+        if (
+            (entry as any)?.typeComment === 'R' &&
+            (entry as any)?.originComment === origin.originComment &&
+            (entry as any)?.commentRenderer?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl === replyUrl
+        ) {
+            replies.push({
+                item: entry,
+                refIndex: Number((entry as any)?._index ?? refId)
+            });
+        }
+    }
+
+    return replies;
+}
+
+function createReplyAuthorWrapper(refId: number): HTMLDivElement {
+    const wrap = document.createElement('div');
+    wrap.id = `ycs-com-rauth-${refId}`;
+    wrap.className = `ycs-com-${refId} ycs-oc-ml`;
+    return wrap;
+}
+
+function collapseOriginComment(refId: number, container: HTMLElement, toggle: HTMLElement): void {
+    removeNodeList(`.ycs-com-${refId}`);
+    container.classList.remove('ycs-oc-ml');
+    toggle.innerHTML = iconExpand();
+    toggle.title = 'Open the comment to the reply here.';
+}
+
+function handleOpenComment(target: HTMLElement, stateAccessor: CommentStateAccessor, queryGetter: QueryGetter): void {
+    const refId = parseRefId(target);
+    if (refId === null) return;
+
+    const commentContainer = target.closest('.ycs-render-comment') as HTMLElement | null;
+    if (!commentContainer) return;
+
+    const existing = document.getElementById(`ycs-com-${refId}`);
+    if (existing) {
+        collapseOriginComment(refId, commentContainer, target);
+        return;
+    }
+
+    const comments = safeGetComments(stateAccessor);
+    const origin = findCommentByIndex(comments, refId);
+    const originResult = buildOriginResult(origin, refId);
+    const query = resolveQuery(queryGetter);
+
+    const wrap = createOriginWrapper(refId);
+    commentContainer.insertAdjacentElement('beforebegin', wrap);
+
+    if (originResult) {
+        renderComment(wrap, [originResult], true, query);
+    }
+
+    commentContainer.classList.add('ycs-oc-ml');
+
+    const replyAuthorResults = buildAuthorReplyResults(comments, origin, refId);
+    if (replyAuthorResults.length > 0) {
+        const replyWrap = createReplyAuthorWrapper(refId);
+        commentContainer.insertAdjacentElement('beforebegin', replyWrap);
+        renderComment(replyWrap, replyAuthorResults, false, query);
+    }
+
+    target.innerHTML = iconCollapse();
+    target.title = 'Close the comment to the reply here.';
+}
+
+function handleGotoChatVideo(event: Event): void {
+    event.preventDefault();
+
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+
+    const video = document.getElementsByTagName('video')[0];
+    if (!video) return;
+
+    const ms = target.dataset.offsetvideo;
+    if (!ms) return;
+
+    const msValue = Number.parseInt(ms, 10);
+    if (Number.isFinite(msValue)) {
+        video.currentTime = msValue / 1000;
+    }
+}
+
+function collectRepliesForComment(
+    comments: CommentCollection,
+    commentId: string | undefined,
+    refId: number
+): ICommentsFuseResult[] {
+    if (!commentId) return [];
+
+    const reference = comments.find((entry) => (entry as any)?.commentRenderer?.commentId === commentId);
+    if (!reference) return [];
+
+    const replies: ICommentsFuseResult[] = [];
+
+    for (const entry of comments) {
+        if ((entry as any)?.originComment === reference) {
+            replies.push({
+                item: entry,
+                refIndex: Number((entry as any)?._index ?? refId)
+            });
+        }
+    }
+
+    return replies;
+}
+
+function createRepliesContainer(commentId: string): HTMLDivElement {
+    const wrapper = document.createElement('div');
+    wrapper.id = `ycs-com-replies-${commentId}`;
+    wrapper.className = `ycs-com-replies-${commentId} ycs-oc-ml ycs-com-replies ycs-com-rp`;
+    return wrapper;
+}
+
+function handleOpenReply(target: HTMLElement, stateAccessor: CommentStateAccessor, queryGetter: QueryGetter): void {
+    const commentId = target.dataset.idcom;
+    if (!commentId) return;
+
+    const commentContainer = target.closest('.ycs-render-comment') as HTMLElement | null;
+    if (!commentContainer) return;
+
+    const existingReplies = commentContainer.querySelector(`.ycs-com-replies-${commentId}`);
+    if (existingReplies) {
+        existingReplies.remove();
+        target.innerHTML = '+';
+        target.title = 'Open replies to the comment';
+        return;
+    }
+
+    const comments = safeGetComments(stateAccessor);
+    const replies = collectRepliesForComment(comments, commentId, 0);
+    if (replies.length === 0) return;
+
+    const query = resolveQuery(queryGetter);
+    const wrapper = createRepliesContainer(commentId);
+    commentContainer.insertAdjacentElement('beforeend', wrapper);
+
+    renderComment(wrapper, replies, false, query);
+
+    target.innerHTML = String.fromCharCode(8722);
+    target.title = 'Close replies to the comment';
+}

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -37,6 +37,11 @@ export function registerCommentInteractions(
             return;
         }
 
+        if (target.classList.contains('ycs-goto-comment-time')) {
+            handleGotoCommentTime(event);
+            return;
+        }
+
         if (target.classList.contains('ycs-open-reply')) {
             handleOpenReply(target, stateAccessor, queryGetter);
         }
@@ -122,7 +127,7 @@ function buildAuthorReplyResults(
             (entry as any)?.commentRenderer?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl === replyUrl
         ) {
             replies.push({
-                item: entry,
+                item: entry as any,
                 refIndex: Number((entry as any)?._index ?? refId)
             });
         }
@@ -201,6 +206,24 @@ function handleGotoChatVideo(event: Event): void {
     }
 }
 
+function handleGotoCommentTime(event: Event): void {
+    event.preventDefault();
+
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+
+    const video = document.getElementsByTagName('video')[0];
+    if (!video) return;
+
+    const seconds = target.dataset.offsetvideo;
+    if (!seconds) return;
+
+    const secondsValue = Number.parseInt(seconds, 10);
+    if (Number.isFinite(secondsValue)) {
+        video.currentTime = secondsValue;
+    }
+}
+
 function collectRepliesForComment(
     comments: CommentCollection,
     commentId: string | undefined,
@@ -216,7 +239,7 @@ function collectRepliesForComment(
     for (const entry of comments) {
         if ((entry as any)?.originComment === reference) {
             replies.push({
-                item: entry,
+                item: entry as any,
                 refIndex: Number((entry as any)?._index ?? refId)
             });
         }


### PR DESCRIPTION
## Summary
- extract the comment toggle, reply loading, and video seek handlers into a dedicated `commentInteractions` helper
- wire `appController` to register the new helper instead of manipulating the DOM directly and pass state/query accessors
- correct the chat video seek handler to convert millisecond offsets to seconds before updating playback

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7acd0427c832984dfdef9af2cbae8