### PR TITLE
refactor(search): centralize search context wiring

### DIFF
--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -45,6 +45,7 @@ import { registerCommentInteractions } from './ui/commentInteractions';
 import { runSearch as runCommentsSearch } from './search/commentsSearch';
 import { runSearch as runChatSearch } from './search/chatSearch';
 import { runSearch as runTranscriptSearch } from './search/transcriptSearch';
+import { SearchContext, SortOrder } from './search/types';
 import { renderCommentsResult, renderChatResult, renderTranscriptResult } from './ui/render';
 
 const DEBUG = false;
@@ -60,6 +61,58 @@ const TRANSCRIPT_UNSUPPORTED_FILTERS = [
     'members',
     'verified'
 ] as const;
+
+const SORT_BUTTON_IDS = [
+    'ycs_btn_links',
+    'ycs_btn_members',
+    'ycs_btn_donated',
+    'ycs_btn_author',
+    'ycs_btn_heart',
+    'ycs_btn_verified',
+    'ycs_btn_timestamps',
+    'ycs_btn_sort_first'
+] as const;
+
+type SortAttribute = 'sort' | 'sortChat' | 'sortTrp';
+
+const parseSortOrder = (value: string | undefined): SortOrder | undefined => {
+    if (value === 'newest' || value === 'oldest') {
+        return value;
+    }
+    return undefined;
+};
+
+const readSortOrders = (attribute: SortAttribute): Partial<Record<string, SortOrder>> => {
+    const map: Partial<Record<string, SortOrder>> = {};
+    for (const id of SORT_BUTTON_IDS) {
+        const element = document.getElementById(id) as HTMLElement | null;
+        if (!element) continue;
+        const parsed = parseSortOrder(element.dataset?.[attribute]);
+        if (parsed) {
+            map[id] = parsed;
+        }
+    }
+    return map;
+};
+
+const buildSearchContext = (): SearchContext => {
+    const extendedToggle = document.getElementById('ycs_extended_search') as HTMLInputElement | null;
+    const extendedTitle = document.getElementById('ycs_extended_search_title') as HTMLInputElement | null;
+    const extendedMain = document.getElementById('ycs_extended_search_main') as HTMLInputElement | null;
+
+    return {
+        extendedSearch: {
+            enabled: Boolean(extendedToggle?.checked),
+            title: Boolean(extendedTitle?.checked),
+            main: Boolean(extendedMain?.checked)
+        },
+        sortOrders: {
+            comments: readSortOrders('sort'),
+            chat: readSortOrders('sortChat'),
+            transcript: readSortOrders('sortTrp')
+        }
+    };
+};
 
 let appFunction: (() => void) | null = null;
 let observeIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -827,7 +880,8 @@ export function initApp(): void {
         });
 
         const runCommentsPipeline = (selector: string, query: string, param?: IParamSearch) => {
-            const result = runCommentsSearch(query, param, state);
+            const context = buildSearchContext();
+            const result = runCommentsSearch(query, param, state, context);
 
             renderCommentsResult(selector, result);
 
@@ -849,7 +903,8 @@ export function initApp(): void {
         };
 
         const runChatPipeline = (selector: string, query: string, param?: IParamSearch) => {
-            const result = runChatSearch(query, param, state);
+            const context = buildSearchContext();
+            const result = runChatSearch(query, param, state, context);
 
             renderChatResult(selector, result);
 
@@ -890,7 +945,8 @@ export function initApp(): void {
         };
 
         const runTranscriptPipeline = (selector: string, query: string, param?: IParamSearch) => {
-            const result = runTranscriptSearch(query, param, state);
+            const context = buildSearchContext();
+            const result = runTranscriptSearch(query, param, state, context);
 
             renderTranscriptResult(selector, result);
 

--- a/app/src/source/web-resources/search/chatSearch.ts
+++ b/app/src/source/web-resources/search/chatSearch.ts
@@ -11,6 +11,7 @@ import {
 import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { wrapTryCatch } from '../../utils/common';
 import { getCommentsChat, WebResourcesState } from '../state';
+import { SearchContext } from './types';
 
 export interface SearchButtonState {
     order?: 'newest' | 'oldest';
@@ -58,16 +59,6 @@ function ensureSortOrder(order?: 'newest' | 'oldest'): 'newest' | 'oldest' {
     return order === 'oldest' ? 'oldest' : 'newest';
 }
 
-function resolveSortOrder(buttonId: string): 'newest' | 'oldest' | undefined {
-    const button = document.getElementById(buttonId) as HTMLElement | null;
-    if (!button) return undefined;
-    const value = button.dataset.sortChat;
-    if (value === 'newest' || value === 'oldest') {
-        return value;
-    }
-    return undefined;
-}
-
 function filterWithQuery(
     items: ICommentsFuseResult[],
     query: string,
@@ -87,7 +78,8 @@ function filterWithQuery(
 export function runSearch(
     query: string,
     filters: IParamSearch | undefined,
-    state: WebResourcesState
+    state: WebResourcesState,
+    context: SearchContext
 ): ChatSearchResult {
     const trimmedQuery = query?.trim?.() ?? '';
     const param = filters ?? {};
@@ -115,27 +107,23 @@ export function runSearch(
 
     const cmntsChat = [...commentsChat.values()];
 
-    const elExtSearch = document.getElementById('ycs_extended_search') as HTMLInputElement | null;
-    const elExtSearchTitle = document.getElementById('ycs_extended_search_title') as HTMLInputElement | null;
-    const elExtSearchMain = document.getElementById('ycs_extended_search_main') as HTMLInputElement | null;
-
     let fuseOptions = cloneFuseOptions();
     let fuseKeys = [
         'replayChatItemAction.actions.addChatItemAction.item.liveChatTextMessageRenderer.authorName.simpleText',
         'replayChatItemAction.actions.addChatItemAction.item.liveChatTextMessageRenderer.message.fullText'
     ];
 
-    if (elExtSearch?.checked) {
+    if (context.extendedSearch.enabled) {
         fuseOptions = cloneFuseOptions();
         fuseOptions.useExtendedSearch = true;
 
-        if (elExtSearchTitle?.checked) {
+        if (context.extendedSearch.title) {
             fuseKeys = [
                 'replayChatItemAction.actions.addChatItemAction.item.liveChatTextMessageRenderer.authorName.simpleText'
             ];
         }
 
-        if (elExtSearchMain?.checked) {
+        if (context.extendedSearch.main) {
             fuseKeys = [
                 'replayChatItemAction.actions.addChatItemAction.item.liveChatTextMessageRenderer.message.fullText'
             ];
@@ -168,7 +156,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_author'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_author']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -188,7 +176,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_donated'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_donated']);
             if (resolvedOrder === 'newest') {
                 resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
             } else {
@@ -210,7 +198,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_members'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_members']);
             if (resolvedOrder === 'newest') {
                 resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
             } else {
@@ -238,7 +226,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_timestamps'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_timestamps']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -268,7 +256,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_sort_first'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_sort_first']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -288,7 +276,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_verified'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_verified']);
             if (resolvedOrder === 'newest') {
                 // Use query to further filter if present
                 if (trimmedQuery) {
@@ -312,7 +300,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_links'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_links']);
             if (resolvedOrder === 'newest') {
                 resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
             } else {

--- a/app/src/source/web-resources/search/commentsSearch.ts
+++ b/app/src/source/web-resources/search/commentsSearch.ts
@@ -14,6 +14,7 @@ import {
 } from '../../utils/filters/comments';
 import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getComments, WebResourcesState } from '../state';
+import { SearchContext } from './types';
 
 export interface SearchButtonState {
     order?: 'newest' | 'oldest';
@@ -63,16 +64,6 @@ function applyTextMatches(results: ICommentsFuseResult[], matches: Set<any> | nu
     return results.filter((entry) => matches.has(entry.item));
 }
 
-function resolveSortOrder(buttonId: string): 'newest' | 'oldest' | undefined {
-    const button = document.getElementById(buttonId) as HTMLElement | null;
-    if (!button) return undefined;
-    const value = button.dataset.sort;
-    if (value === 'newest' || value === 'oldest') {
-        return value;
-    }
-    return undefined;
-}
-
 function ensureSortOrder(order?: 'newest' | 'oldest'): 'newest' | 'oldest' {
     return order === 'oldest' ? 'oldest' : 'newest';
 }
@@ -94,7 +85,8 @@ function searchWithinSubset(
 export function runSearch(
     query: string,
     filters: IParamSearch | undefined,
-    state: WebResourcesState
+    state: WebResourcesState,
+    context: SearchContext
 ): CommentsSearchResult {
     const comments = getComments(state);
     const trimmedQuery = query?.trim?.() ?? '';
@@ -109,22 +101,18 @@ export function runSearch(
         };
     }
 
-    const elExtSearch = document.getElementById('ycs_extended_search') as HTMLInputElement | null;
-    const elExtSearchTitle = document.getElementById('ycs_extended_search_title') as HTMLInputElement | null;
-    const elExtSearchMain = document.getElementById('ycs_extended_search_main') as HTMLInputElement | null;
-
     let fuseOptions = cloneFuseOptions();
     let fuseKeys = ['commentRenderer.authorText.simpleText', 'commentRenderer.contentText.fullText'];
 
-    if (elExtSearch?.checked) {
+    if (context.extendedSearch.enabled) {
         fuseOptions = cloneFuseOptions();
         fuseOptions.useExtendedSearch = true;
 
-        if (elExtSearchTitle?.checked) {
+        if (context.extendedSearch.title) {
             fuseKeys = ['commentRenderer.authorText.simpleText'];
         }
 
-        if (elExtSearchMain?.checked) {
+        if (context.extendedSearch.main) {
             fuseKeys = ['commentRenderer.contentText.fullText'];
         }
     }
@@ -164,7 +152,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            let sortOrder = param.sortOrder ?? resolveSortOrder('ycs_btn_links');
+            let sortOrder = param.sortOrder ?? context.sortOrders.comments['ycs_btn_links'];
             if (sortOrder === undefined && trimmedQuery) {
                 resultSearch = searchWithinSubset(resultSearch, options, trimmedQuery);
                 sortOrder = 'newest';
@@ -190,7 +178,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_members'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_members']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -210,7 +198,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_donated'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_donated']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -238,7 +226,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_author'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_author']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -258,7 +246,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_heart'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_heart']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -277,7 +265,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_verified'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_verified']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -320,7 +308,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_timestamps'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_timestamps']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -339,7 +327,7 @@ export function runSearch(
         resultSearch = applyTextMatches(newest, matches);
 
         if (resultSearch.length > 0) {
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortOrder('ycs_btn_sort_first'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_sort_first']);
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }

--- a/app/src/source/web-resources/search/transcriptSearch.ts
+++ b/app/src/source/web-resources/search/transcriptSearch.ts
@@ -4,6 +4,7 @@ import { filterAllTrpVideoComments, filterLinksTrpVideoComments } from '../../ut
 import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { wrapTryCatch } from '../../utils/common';
 import { getCommentsTrVideo, WebResourcesState } from '../state';
+import { SearchContext } from './types';
 
 export interface SearchButtonState {
     order?: 'newest' | 'oldest';
@@ -63,16 +64,6 @@ function ensureSortOrder(order?: 'newest' | 'oldest'): 'newest' | 'oldest' {
     return order === 'oldest' ? 'oldest' : 'newest';
 }
 
-function resolveSortTrp(buttonId: string): 'newest' | 'oldest' | undefined {
-    const button = document.getElementById(buttonId) as HTMLElement | null;
-    if (!button) return undefined;
-    const value = button.dataset.sortTrp;
-    if (value === 'newest' || value === 'oldest') {
-        return value;
-    }
-    return undefined;
-}
-
 function filterByMatches(results: ICommentsFuseResult[], matches: Set<any> | null): ICommentsFuseResult[] {
     if (!matches) return results;
     return results.filter((entry) => matches.has(entry.item));
@@ -81,7 +72,8 @@ function filterByMatches(results: ICommentsFuseResult[], matches: Set<any> | nul
 export function runSearch(
     query: string,
     filters: IParamSearch | undefined,
-    state: WebResourcesState
+    state: WebResourcesState,
+    context: SearchContext
 ): TranscriptSearchResult {
     const trimmedQuery = query?.trim?.() ?? '';
     const param = filters ?? {};
@@ -113,25 +105,21 @@ export function runSearch(
         };
     }
 
-    const elExtSearch = document.getElementById('ycs_extended_search') as HTMLInputElement | null;
-    const elExtSearchTitle = document.getElementById('ycs_extended_search_title') as HTMLInputElement | null;
-    const elExtSearchMain = document.getElementById('ycs_extended_search_main') as HTMLInputElement | null;
-
     let fuseOptions = cloneFuseOptions();
     let fuseKeys = [
         'transcriptCueGroupRenderer.cues.transcriptCueRenderer.cue.simpleText',
         'transcriptCueGroupRenderer.formattedStartOffset.simpleText'
     ];
 
-    if (elExtSearch?.checked) {
+    if (context.extendedSearch.enabled) {
         fuseOptions = cloneFuseOptions();
         fuseOptions.useExtendedSearch = true;
 
-        if (elExtSearchTitle?.checked) {
+        if (context.extendedSearch.title) {
             fuseKeys = ['transcriptCueGroupRenderer.formattedStartOffset.simpleText'];
         }
 
-        if (elExtSearchMain?.checked) {
+        if (context.extendedSearch.main) {
             fuseKeys = ['transcriptCueGroupRenderer.cues.transcriptCueRenderer.cue.simpleText'];
         }
     }
@@ -165,7 +153,7 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortTrp('ycs_btn_links'));
+            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.transcript['ycs_btn_links']);
             if (resolvedOrder === 'newest') {
                 if (trimmedQuery) {
                     const fuse = new Fuse(
@@ -200,7 +188,9 @@ export function runSearch(
         if (resultSearch.length > 0) {
             resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
 
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? resolveSortTrp('ycs_btn_sort_first'));
+            const resolvedOrder = ensureSortOrder(
+                param.sortOrder ?? context.sortOrders.transcript['ycs_btn_sort_first']
+            );
             if (resolvedOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
             }
@@ -239,8 +229,7 @@ export function runSearch(
                         ) || 0
                 }));
 
-            const button = document.getElementById('ycs_btn_timestamps') as HTMLElement | null;
-            const currentOrder = (button?.dataset.sortTrp as 'newest' | 'oldest') || 'newest';
+            const currentOrder = context.sortOrders.transcript['ycs_btn_timestamps'] ?? 'newest';
             if (currentOrder === 'oldest') {
                 resultSearch = Array.from(resultSearch).reverse();
                 updateButtonState(

--- a/app/src/source/web-resources/search/types.ts
+++ b/app/src/source/web-resources/search/types.ts
@@ -1,0 +1,14 @@
+export type SortOrder = 'newest' | 'oldest';
+
+export interface SearchContext {
+    extendedSearch: {
+        enabled: boolean;
+        title: boolean;
+        main: boolean;
+    };
+    sortOrders: {
+        comments: Partial<Record<string, SortOrder>>;
+        chat: Partial<Record<string, SortOrder>>;
+        transcript: Partial<Record<string, SortOrder>>;
+    };
+}


### PR DESCRIPTION
## Summary
- add a SearchContext interface describing extended search toggles and button sort order metadata
- update the comment, chat, and transcript runSearch helpers to consume the provided context instead of querying the DOM
- build and pass the shared context from each run*Pipeline so DOM coupling is limited to one place

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7d06292f8832994ac067106d7d6cf