### PR TITLE
fix(badge): use window.postMessage for badge updates

### DIFF
--- a/app/manifest.firefox.json
+++ b/app/manifest.firefox.json
@@ -41,7 +41,7 @@
   "web_accessible_resources": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "resources": ["web-resources/*.js"]
+      "resources": ["web-resources/*.js", "web-resources/*.js.map"]
     }
   ],
   "browser_specific_settings": {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -41,7 +41,7 @@
   "web_accessible_resources": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "resources": ["web-resources/*.js"]
+      "resources": ["web-resources/*.js", "web-resources/*.js.map"]
     }
   ]
 }

--- a/app/src/source/utils/dom.ts
+++ b/app/src/source/utils/dom.ts
@@ -280,15 +280,11 @@ function sendGetCacheInIDB(url: string): void {
 
 function sendMsgToBadge(typeMsg: string, msg: string | number): void {
     try {
-        chrome.runtime.sendMessage({
-            action: 'ACTION_BADGE',
-            payload: {
-                typeMsg,
-                msg
-            }
-        });
-    } catch (err) {
-        console.error(err);
+        if ((typeof msg === 'string' || typeof msg === 'number') && typeof typeMsg === 'string') {
+            window.postMessage({ type: typeMsg.toString(), text: msg.toString() }, window.location.origin);
+        }
+    } catch (e) {
+        console.error(e);
     }
 }
 


### PR DESCRIPTION
## Summary

Fix badge count update mechanism by switching from chrome.runtime.sendMessage to window.postMessage, resolving communication failures in the MV3 architecture. This bug was introduced in #55 refactor.

## Key Changes

### Badge Update Communication Fix
- **Changed message passing method**: Replaced chrome.runtime.sendMessage with window.postMessage for badge updates
- **Why**: chrome.runtime.sendMessage from web-resources layer causes "Extension context invalidated" errors in MV3 due to isolated world restrictions
- **Impact**: Badge count now updates reliably without runtime errors

### Source Map Support
- **Added source maps to web_accessible_resources**: Both Chrome and Firefox manifests now include web-resources/*.js.map
- **Purpose**: Enable better debugging in development builds
