### PR TITLE
refactor(timestamp): extract navigation logic and fix backward compatibility

### DIFF
--- a/app/src/source/utils/assist.ts
+++ b/app/src/source/utils/assist.ts
@@ -53,7 +53,8 @@ export {
     getPiP,
     initShowBarFAQ,
     initShowViewMode,
-    getRandomComment
+    getRandomComment,
+    navigateVideoToTimestamp
 } from './dom';
 
 export {

--- a/app/src/source/utils/dom.ts
+++ b/app/src/source/utils/dom.ts
@@ -513,6 +513,31 @@ function getRandomComment(comments: any): [] {
     }
 }
 
+/**
+ * Navigate video to timestamp with backward compatibility
+ * @param target - Click target element containing timestamp data
+ * @param video - Video element to navigate
+ * @returns true if navigation succeeded, false otherwise
+ */
+function navigateVideoToTimestamp(target: HTMLElement, video: HTMLVideoElement): boolean {
+    const timeValue = target.dataset.offsetvideo;
+    if (!timeValue) return false;
+
+    const parsed = Number.parseInt(timeValue, 10);
+    if (!Number.isFinite(parsed)) return false;
+
+    // Backward compatibility logic:
+    // - ycs_goto_chat: Chat "Go to" button (milliseconds)
+    // - Others: Old cached timestamp links or new timestamp links (seconds)
+    if (target.classList.contains('ycs_goto_chat')) {
+        video.currentTime = parsed / 1000;
+    } else {
+        video.currentTime = parsed;
+    }
+
+    return true;
+}
+
 export {
     removeClass,
     showLoadComments,
@@ -528,5 +553,6 @@ export {
     getPiP,
     initShowBarFAQ,
     initShowViewMode,
-    getRandomComment
+    getRandomComment,
+    navigateVideoToTimestamp
 };

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1,7 +1,14 @@
 import 'abort-controller/polyfill';
 
 import { GlobalStore, extractChannelId, getCleanUrlVideo, isVideoPage } from '../utils/common';
-import { initShowBarFAQ, initShowViewMode, removeClass, removeNodeList, showLoadComments } from '../utils/dom';
+import {
+    initShowBarFAQ,
+    initShowViewMode,
+    navigateVideoToTimestamp,
+    removeClass,
+    removeNodeList,
+    showLoadComments
+} from '../utils/dom';
 import { getAllCommentsModeV2, getChatComments, getTranscriptVideo } from '../utils/innertube';
 
 import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
@@ -922,13 +929,7 @@ export function initApp(): void {
 
                         const elFrameVideo = document.getElementsByTagName('video')[0];
                         if (elFrameVideo) {
-                            const timeValue = target.dataset.offsetvideo;
-                            if (timeValue) {
-                                // Chat video uses milliseconds, comment time uses seconds
-                                elFrameVideo.currentTime = isChatVideo
-                                    ? parseInt(timeValue, 10) / 1000
-                                    : parseInt(timeValue, 10);
-                            }
+                            navigateVideoToTimestamp(target, elFrameVideo);
                         }
                     } catch (error) {
                         console.error(error);

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -197,12 +197,19 @@ function handleGotoChatVideo(event: Event): void {
     const video = document.getElementsByTagName('video')[0];
     if (!video) return;
 
-    const ms = target.dataset.offsetvideo;
-    if (!ms) return;
+    const timeValue = target.dataset.offsetvideo;
+    if (!timeValue) return;
 
-    const msValue = Number.parseInt(ms, 10);
-    if (Number.isFinite(msValue)) {
-        video.currentTime = msValue / 1000;
+    const parsed = Number.parseInt(timeValue, 10);
+    if (!Number.isFinite(parsed)) return;
+
+    // Backward compatibility logic:
+    // - ycs_goto_chat: Chat "Go to" button (milliseconds)
+    // - Others: Old cached timestamp links (seconds)
+    if (target.classList.contains('ycs_goto_chat')) {
+        video.currentTime = parsed / 1000;
+    } else {
+        video.currentTime = parsed;
     }
 }
 

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -1,4 +1,4 @@
-import { removeNodeList } from '../../utils/dom';
+import { removeNodeList, navigateVideoToTimestamp } from '../../utils/dom';
 import { iconCollapse, iconExpand } from '../../utils/icons';
 import { ICommentsFuseResult } from '../../utils/interfaces/i_types';
 import { renderComment } from '../../utils/renderView';
@@ -197,20 +197,7 @@ function handleGotoChatVideo(event: Event): void {
     const video = document.getElementsByTagName('video')[0];
     if (!video) return;
 
-    const timeValue = target.dataset.offsetvideo;
-    if (!timeValue) return;
-
-    const parsed = Number.parseInt(timeValue, 10);
-    if (!Number.isFinite(parsed)) return;
-
-    // Backward compatibility logic:
-    // - ycs_goto_chat: Chat "Go to" button (milliseconds)
-    // - Others: Old cached timestamp links (seconds)
-    if (target.classList.contains('ycs_goto_chat')) {
-        video.currentTime = parsed / 1000;
-    } else {
-        video.currentTime = parsed;
-    }
+    navigateVideoToTimestamp(target, video);
 }
 
 function handleGotoCommentTime(event: Event): void {
@@ -222,13 +209,7 @@ function handleGotoCommentTime(event: Event): void {
     const video = document.getElementsByTagName('video')[0];
     if (!video) return;
 
-    const seconds = target.dataset.offsetvideo;
-    if (!seconds) return;
-
-    const secondsValue = Number.parseInt(seconds, 10);
-    if (Number.isFinite(secondsValue)) {
-        video.currentTime = secondsValue;
-    }
+    navigateVideoToTimestamp(target, video);
 }
 
 function collectRepliesForComment(


### PR DESCRIPTION
## Summary

Refactors timestamp navigation logic and fixes backward compatibility issues for cached timestamp links in comments and chat replays.

## Main Changes

- Extract video timestamp navigation logic into a shared utility function `navigateVideoToTimestamp()` in `utils/dom.ts`
- Handle backward compatibility for cached timestamp links:
  - Chat "Go to" button continues to use milliseconds (`.ycs_goto_chat` class)
  - Other timestamp links (both old cached and new) use seconds
- Remove duplicated timestamp navigation code from `appController.ts` and `commentInteractions.ts`
- Add proper validation for timestamp values (check for undefined and finite numbers)

