### PR TITLE
refactor(innertube): centralize request construction helpers

### DIFF
--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -940,18 +940,11 @@ async function getParamsForComments(
         const ytcfgData = await getPageCfgData(w, signal, params?.url);
 
         const clickTrackingParams = params?.clickTrackingParams ?? params?.clickTracking;
-        const bodyPayload = buildInnertubeBody(
-            clickTrackingParams
-                ? {
-                      ytcfgData,
-                      continuation: params?.continue,
-                      clickTrackingParams
-                  }
-                : {
-                      ytcfgData,
-                      continuation: params?.continue
-                  }
-        );
+        const bodyPayload = buildInnertubeBody({
+            ytcfgData,
+            continuation: params?.continue,
+            clickTrackingParams: clickTrackingParams ?? undefined
+        });
 
         return {
             headers: buildInnertubeHeaders(ytcfgData),
@@ -976,18 +969,11 @@ async function getParamsForReplies(
         const ytcfgData = await getPageCfgData(w, signal, params?.url);
 
         const clickTrackingParams = params?.clickTracking ?? params?.clickTrackingParams;
-        const bodyPayload = buildInnertubeBody(
-            clickTrackingParams
-                ? {
-                      ytcfgData,
-                      continuation: params?.continue,
-                      clickTrackingParams
-                  }
-                : {
-                      ytcfgData,
-                      continuation: params?.continue
-                  }
-        );
+        const bodyPayload = buildInnertubeBody({
+            ytcfgData,
+            continuation: params?.continue,
+            clickTrackingParams: clickTrackingParams ?? undefined
+        });
 
         return {
             headers: buildInnertubeHeaders(ytcfgData),

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -7,6 +7,7 @@ import { fetchR } from './libs';
 import { GlobalStore, deepFindObjKey, getCleanUrlVideo, getObj, getVideoId, wrapTryCatch } from './common';
 import { parseFormattedNumber } from './formatting';
 import { showLoadComments } from './dom';
+import { buildInnertubeBody, buildInnertubeHeaders } from './innertube/request';
 
 async function findInitYParams(initData: [object]): Promise<string | undefined> {
     try {
@@ -825,27 +826,18 @@ async function getParamsForChat(
     try {
         const ytcfgData = await getPageCfgData(w, signal);
 
-        const bodyPayload: any = {
-            context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client },
-            continuation: cLiveChat.continuation
-        };
-
-        if (useLegacyApi) {
-            bodyPayload.currentPlayerState = {
-                playerOffsetMs: playerOffsetMs.toString()
-            };
-        }
+        const bodyPayload = buildInnertubeBody({
+            ytcfgData,
+            continuation: cLiveChat.continuation,
+            currentPlayerState: useLegacyApi
+                ? {
+                      playerOffsetMs: playerOffsetMs.toString()
+                  }
+                : undefined
+        });
 
         return {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
-                'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION
-            },
+            headers: buildInnertubeHeaders(ytcfgData),
             referrerPolicy: 'strict-origin-when-cross-origin',
             body: JSON.stringify(bodyPayload),
             method: 'POST',
@@ -868,23 +860,16 @@ async function getDetailsVideoIDV2(
 
         const ytcfgData = await getPageCfgData(w, signal, url);
         const videoId = getVideoId(url);
-
         const params: RequestInit = {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
-                'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION
-            },
+            headers: buildInnertubeHeaders(ytcfgData),
             referrer: url,
             referrerPolicy: 'strict-origin-when-cross-origin',
-            body: JSON.stringify({
-                context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client },
-                videoId
-            }),
+            body: JSON.stringify(
+                buildInnertubeBody({
+                    ytcfgData,
+                    videoId
+                })
+            ),
             method: 'POST',
             mode: 'cors',
             credentials: 'include'
@@ -916,22 +901,16 @@ async function getDetailsCommentsVideoIDV2(
         const ytcfgData = await getPageCfgData(w, signal, ps?.url);
 
         const params: RequestInit = {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
-                'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION
-            },
+            headers: buildInnertubeHeaders(ytcfgData),
             referrer: ps.url,
             referrerPolicy: 'strict-origin-when-cross-origin',
-            body: JSON.stringify({
-                context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client },
-                clickTracking: { clickTrackingParams: '' },
-                continuation: ps.continue
-            }),
+            body: JSON.stringify(
+                buildInnertubeBody({
+                    ytcfgData,
+                    continuation: ps.continue,
+                    clickTrackingParams: ''
+                })
+            ),
             method: 'POST',
             mode: 'cors',
             credentials: 'include'
@@ -959,28 +938,25 @@ async function getParamsForComments(
 ): Promise<object | undefined> {
     try {
         const ytcfgData = await getPageCfgData(w, signal, params?.url);
-        const body: Record<string, unknown> = {
-            context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client },
-            continuation: params?.continue
-        };
 
         const clickTrackingParams = params?.clickTrackingParams ?? params?.clickTracking;
-        if (clickTrackingParams) {
-            body.clickTracking = { clickTrackingParams };
-        }
+        const bodyPayload = buildInnertubeBody(
+            clickTrackingParams
+                ? {
+                      ytcfgData,
+                      continuation: params?.continue,
+                      clickTrackingParams
+                  }
+                : {
+                      ytcfgData,
+                      continuation: params?.continue
+                  }
+        );
 
         return {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
-                'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION
-            },
+            headers: buildInnertubeHeaders(ytcfgData),
             referrerPolicy: 'strict-origin-when-cross-origin',
-            body: JSON.stringify(body),
+            body: JSON.stringify(bodyPayload),
             method: 'POST',
             mode: 'cors',
             credentials: 'include'
@@ -998,28 +974,25 @@ async function getParamsForReplies(
 ): Promise<object | undefined> {
     try {
         const ytcfgData = await getPageCfgData(w, signal, params?.url);
-        const body: Record<string, unknown> = {
-            context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client },
-            continuation: params?.continue
-        };
 
         const clickTrackingParams = params?.clickTracking ?? params?.clickTrackingParams;
-        if (clickTrackingParams) {
-            body.clickTracking = { clickTrackingParams };
-        }
+        const bodyPayload = buildInnertubeBody(
+            clickTrackingParams
+                ? {
+                      ytcfgData,
+                      continuation: params?.continue,
+                      clickTrackingParams
+                  }
+                : {
+                      ytcfgData,
+                      continuation: params?.continue
+                  }
+        );
 
         return {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
-                'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION
-            },
+            headers: buildInnertubeHeaders(ytcfgData),
             referrerPolicy: 'strict-origin-when-cross-origin',
-            body: JSON.stringify(body),
+            body: JSON.stringify(bodyPayload),
             method: 'POST',
             mode: 'cors',
             credentials: 'include'
@@ -1041,20 +1014,14 @@ async function getParamsForLiveChat(
         const ytcfgData = await getPageCfgData(w, signal);
 
         return {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
-                'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION
-            },
+            headers: buildInnertubeHeaders(ytcfgData),
             referrerPolicy: 'strict-origin-when-cross-origin',
-            body: JSON.stringify({
-                context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client },
-                continuation: cLiveChat.continuation
-            }),
+            body: JSON.stringify(
+                buildInnertubeBody({
+                    ytcfgData,
+                    continuation: cLiveChat.continuation
+                })
+            ),
             method: 'POST',
             mode: 'cors',
             credentials: 'include'
@@ -1075,18 +1042,18 @@ async function getParamsForTranscript(
         const cleanUrl = getCleanUrlVideo(w.location.href) ?? w.location.href;
 
         return {
-            headers: {
-                accept: '*/*',
-                'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
-                'content-type': 'application/json',
-                pragma: 'no-cache',
-                'cache-control': 'no-store',
-                'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
+            headers: buildInnertubeHeaders(ytcfgData, {
                 'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION || ''
-            },
+            }),
             referrer: cleanUrl,
             referrerPolicy: 'origin-when-cross-origin',
-            body: JSON.stringify({ context: { client: ytcfgData?.INNERTUBE_CONTEXT?.client || {} }, params: param }),
+            body: JSON.stringify(
+                buildInnertubeBody({
+                    ytcfgData,
+                    params: param,
+                    clientFallback: {}
+                })
+            ),
             method: 'POST',
             mode: 'cors',
             credentials: 'include'

--- a/app/src/source/utils/innertube/request.ts
+++ b/app/src/source/utils/innertube/request.ts
@@ -1,0 +1,84 @@
+export interface BuildInnertubeHeadersOverrides {
+    [header: string]: string | undefined;
+}
+
+export interface BuildInnertubeBodyOptions {
+    ytcfgData: any | undefined;
+    continuation?: string | null;
+    clickTrackingParams?: string | null;
+    videoId?: string;
+    params?: string;
+    currentPlayerState?: Record<string, unknown>;
+    clientOverride?: Record<string, unknown>;
+    clientFallback?: Record<string, unknown>;
+    extra?: Record<string, unknown>;
+}
+
+export function buildInnertubeHeaders(
+    ytcfgData: any | undefined,
+    overrides: BuildInnertubeHeadersOverrides = {}
+): Record<string, string> {
+    const headers: Record<string, string | undefined> = {
+        accept: '*/*',
+        'accept-language': ytcfgData?.GOOGLE_FEEDBACK_PRODUCT_DATA?.accept_language || 'en-US,en;q=0.9',
+        'content-type': 'application/json',
+        pragma: 'no-cache',
+        'cache-control': 'no-store',
+        'x-youtube-client-name': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_NAME || '1',
+        'x-youtube-client-version': ytcfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION,
+        ...overrides
+    };
+
+    const normalizedHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+        if (value !== undefined) {
+            normalizedHeaders[key] = value;
+        }
+    }
+
+    return normalizedHeaders;
+}
+
+export function buildInnertubeBody({
+    ytcfgData,
+    continuation,
+    clickTrackingParams,
+    videoId,
+    params,
+    currentPlayerState,
+    clientOverride,
+    clientFallback,
+    extra
+}: BuildInnertubeBodyOptions): Record<string, unknown> {
+    const client = clientOverride ?? ytcfgData?.INNERTUBE_CONTEXT?.client ?? clientFallback;
+
+    const payload: Record<string, unknown> = {
+        context: { client }
+    };
+
+    if (continuation !== undefined) {
+        payload.continuation = continuation;
+    }
+
+    if (clickTrackingParams !== undefined) {
+        payload.clickTracking = { clickTrackingParams };
+    }
+
+    if (videoId !== undefined) {
+        payload.videoId = videoId;
+    }
+
+    if (params !== undefined) {
+        payload.params = params;
+    }
+
+    if (currentPlayerState !== undefined) {
+        payload.currentPlayerState = currentPlayerState;
+    }
+
+    if (extra) {
+        Object.assign(payload, extra);
+    }
+
+    return payload;
+}

--- a/app/src/source/utils/innertube/request.ts
+++ b/app/src/source/utils/innertube/request.ts
@@ -26,11 +26,11 @@ export interface BuildInnertubeBodyOptions {
 }
 
 /**
- * 產生向 Innertube API 發送請求時所需的預設標頭，並允許以覆寫方式調整個別欄位。
+ * Builds the default headers for Innertube API requests and allows overriding individual fields.
  *
- * @param ytcfgData - 由頁面取得的 ytcfg 設定資料。
- * @param overrides - 自訂標頭覆寫項目，例如調整 x-youtube-client-version。
- * @returns 適用於 fetch 請求的標頭物件。
+ * @param ytcfgData - YTCFG configuration data captured from the page context.
+ * @param overrides - Header overrides, for example to adjust x-youtube-client-version.
+ * @returns Headers object that can be used with fetch requests.
  */
 export function buildInnertubeHeaders(
     ytcfgData: YtcfgData | undefined,
@@ -58,10 +58,10 @@ export function buildInnertubeHeaders(
 }
 
 /**
- * 建立 Innertube API 請求的共用 body，僅保留實際提供的參數並允許附加額外欄位。
+ * Builds a shared Innertube API request body, keeping only provided parameters while allowing additional fields.
  *
- * @param options - 組裝請求 body 所需的參數集合。
- * @returns 已根據提供參數過濾後的請求 payload。
+ * @param options - Collection of parameters used to assemble the request body.
+ * @returns Request payload filtered to include only supplied values.
  */
 export function buildInnertubeBody({
     ytcfgData,

--- a/app/src/source/utils/innertube/request.ts
+++ b/app/src/source/utils/innertube/request.ts
@@ -2,8 +2,19 @@ export interface BuildInnertubeHeadersOverrides {
     [header: string]: string | undefined;
 }
 
+export interface YtcfgData {
+    GOOGLE_FEEDBACK_PRODUCT_DATA?: {
+        accept_language?: string;
+    };
+    INNERTUBE_CONTEXT_CLIENT_NAME?: string;
+    INNERTUBE_CONTEXT_CLIENT_VERSION?: string;
+    INNERTUBE_CONTEXT?: {
+        client?: Record<string, unknown>;
+    };
+}
+
 export interface BuildInnertubeBodyOptions {
-    ytcfgData: any | undefined;
+    ytcfgData: YtcfgData | undefined;
     continuation?: string | null;
     clickTrackingParams?: string | null;
     videoId?: string;
@@ -14,8 +25,15 @@ export interface BuildInnertubeBodyOptions {
     extra?: Record<string, unknown>;
 }
 
+/**
+ * 產生向 Innertube API 發送請求時所需的預設標頭，並允許以覆寫方式調整個別欄位。
+ *
+ * @param ytcfgData - 由頁面取得的 ytcfg 設定資料。
+ * @param overrides - 自訂標頭覆寫項目，例如調整 x-youtube-client-version。
+ * @returns 適用於 fetch 請求的標頭物件。
+ */
 export function buildInnertubeHeaders(
-    ytcfgData: any | undefined,
+    ytcfgData: YtcfgData | undefined,
     overrides: BuildInnertubeHeadersOverrides = {}
 ): Record<string, string> {
     const headers: Record<string, string | undefined> = {
@@ -39,6 +57,12 @@ export function buildInnertubeHeaders(
     return normalizedHeaders;
 }
 
+/**
+ * 建立 Innertube API 請求的共用 body，僅保留實際提供的參數並允許附加額外欄位。
+ *
+ * @param options - 組裝請求 body 所需的參數集合。
+ * @returns 已根據提供參數過濾後的請求 payload。
+ */
 export function buildInnertubeBody({
     ytcfgData,
     continuation,
@@ -56,11 +80,11 @@ export function buildInnertubeBody({
         context: { client }
     };
 
-    if (continuation !== undefined) {
+    if (continuation != null) {
         payload.continuation = continuation;
     }
 
-    if (clickTrackingParams !== undefined) {
+    if (clickTrackingParams != null) {
         payload.clickTracking = { clickTrackingParams };
     }
 


### PR DESCRIPTION
## Summary
- add shared buildInnertubeHeaders and buildInnertubeBody utilities for Innertube requests
- refactor chat, comment, replies, live chat, and transcript parameter builders to use the shared helpers
- update video/comment detail request assembly and review getParamsFor*/getDetails* call sites for consistency

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f89d1c871483299b23aa7727519c37