### PR TITLE
refactor(innertube): extract chat processors

### DIFF
--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -4,10 +4,13 @@ import Queue from 'p-queue';
 
 import type { ChatContinuationResult, GetParams } from './interfaces/i_assist';
 import { fetchR } from './libs';
-import { GlobalStore, deepFindObjKey, getCleanUrlVideo, getObj, getVideoId, wrapTryCatch } from './common';
+import { GlobalStore, deepFindObjKey, getCleanUrlVideo, getVideoId, wrapTryCatch } from './common';
 import { parseFormattedNumber } from './formatting';
 import { showLoadComments } from './dom';
 import { buildInnertubeBody, buildInnertubeHeaders } from './innertube/request';
+import { processLiveChatActions } from './innertube/chat/liveChat';
+import { processReplayBatch } from './innertube/chat/replayChat';
+import type { ChatProcessingContext } from './innertube/chat/utils';
 
 async function findInitYParams(initData: [object]): Promise<string | undefined> {
     try {
@@ -261,30 +264,6 @@ function normalizeCommentFromViewModel(item: any): any | undefined {
         console.error(e);
         return undefined;
     }
-}
-
-/**
- * Extracts donate chip information from liveChatPaidMessageRenderer
- * and adds it to the renderer as donatedChip structure for unified chip badge rendering
- */
-function addDonatedChipFromPaidRenderer(renderer: any): void {
-    const purchaseAmount =
-        wrapTryCatch(() => renderer.purchaseAmountText?.simpleText) ??
-        wrapTryCatch(() => (renderer.purchaseAmountText?.runs || []).map((run: any) => run?.text || '').join(''));
-
-    if (!purchaseAmount) return;
-
-    renderer.donatedChip = {
-        pdgCommentChipRenderer: {
-            chipText: {
-                simpleText: purchaseAmount
-            },
-            chipColorPalette: {
-                backgroundColor: renderer.headerBackgroundColor ?? renderer.bodyBackgroundColor,
-                foregroundTitleColor: renderer.headerTextColor ?? renderer.bodyTextColor
-            }
-        }
-    };
 }
 
 function getFrameworkUpdatesById(response: any): Record<string, any> {
@@ -1205,838 +1184,122 @@ async function getChatComments(
     container: Map<number, object> | undefined = undefined
 ): Promise<Map<number, object> | undefined> {
     try {
-        const _prepareFieldsChatComments = (cmnt: any): object => {
-            try {
-                if (
-                    wrapTryCatch(
-                        () =>
-                            cmnt.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.authorBadges[0].liveChatAuthorBadgeRenderer.icon.iconType.indexOf(
-                                'VERIFIED'
-                            ) >= 0
-                    ) ||
-                    wrapTryCatch(
-                        () =>
-                            cmnt.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.authorBadges[0].liveChatAuthorBadgeRenderer.icon.iconType.indexOf(
-                                'CHECK'
-                            ) >= 0
-                    ) ||
-                    wrapTryCatch(
-                        () =>
-                            cmnt.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.authorBadges[0].liveChatAuthorBadgeRenderer.tooltip.indexOf(
-                                'Verified'
-                            ) >= 0
-                    )
-                ) {
-                    try {
-                        cmnt.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.verifiedAuthor = true;
-                    } catch (err) {
-                        console.error(err);
-                    }
-                }
-
-                return cmnt;
-            } catch (err) {
-                console.error(err);
-                return cmnt;
-            }
-        };
-
         const result = await getCDChat(signal);
         if (!result.continuationData) {
             console.log('STOP CHAT CD!!!! No continuation data available');
             return;
         }
 
-        const cDChat = result.continuationData;
+        const continuationData = result.continuationData;
         const useLegacyApi = result.apiVersion === 'old';
 
-        // Log detected API version
         console.log(`[getChatComments] Detected API version: ${result.apiVersion}`);
         console.log(`[getChatComments] Source path: ${result.sourcePath}`);
 
         const chatCmnts = container || new Map<number, object>();
+        const currentVideoId = (getVideoId(window.location.href) || undefined) as string | undefined;
+
+        const context: ChatProcessingContext = {
+            chatMap: chatCmnts,
+            currentVideoId,
+            onCommentAdded: (count: number) => showLoadComments(count, elShowLoading)
+        };
 
         const liveChatData: any = await getLiveChat(signal);
 
-        if (liveChatData) {
-            try {
-                if (liveChatData?.actions?.length > 0) {
-                    console.log('IS LIVECHAT!!!!!', liveChatData);
+        if (liveChatData?.actions?.length > 0) {
+            console.log('IS LIVECHAT!!!!!', liveChatData);
+            processLiveChatActions(liveChatData.actions, context);
+            return chatCmnts;
+        }
 
-                    for (const c of liveChatData.actions) {
-                        try {
-                            const protoComment = {
-                                replayChatItemAction: {
-                                    actions: [
-                                        {
-                                            addChatItemAction: {}
-                                        }
-                                    ]
-                                }
-                            };
+        if (useLegacyApi) {
+            let currentOffsetTimeMsec = 0;
+            let next = true;
 
-                            protoComment.replayChatItemAction.actions[0] = c;
-                            const comment: any = protoComment;
+            while (next) {
+                console.log('Loop chat comments (Legacy API)');
+                const params = await getParamsForChat(window, continuationData, signal, true, currentOffsetTimeMsec);
 
-                            if (
-                                !wrapTryCatch(
-                                    () =>
-                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                            .liveChatTextMessageRenderer.timestampUsec
-                                )
-                            ) {
-                                if (
-                                    wrapTryCatch(
-                                        () =>
-                                            comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                .liveChatPaidMessageRenderer
-                                    )
-                                ) {
-                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                        comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatPaidMessageRenderer;
-                                    console.log('Done! Added liveChatPaidMessageRenderer: ', comment);
-
-                                    // Extract donate chip information from liveChatPaidMessageRenderer
-                                    addDonatedChipFromPaidRenderer(
-                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                            .liveChatTextMessageRenderer
-                                    );
-                                } else if (
-                                    wrapTryCatch(
-                                        () =>
-                                            comment.replayChatItemAction.actions[0].addBannerToLiveChatCommand
-                                                .bannerRenderer.liveChatBannerRenderer.contents
-                                                .liveChatTextMessageRenderer
-                                    )
-                                ) {
-                                    comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                        item: { liveChatTextMessageRenderer: {} }
-                                    };
-                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                        comment.replayChatItemAction.actions[0].addBannerToLiveChatCommand.bannerRenderer.liveChatBannerRenderer.contents.liveChatTextMessageRenderer;
-                                    console.log('Done! Added liveChatBannerRenderer: ', comment);
-                                } else if (
-                                    wrapTryCatch(
-                                        () =>
-                                            comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item
-                                                .liveChatTickerPaidMessageItemRenderer.showItemEndpoint
-                                                .showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer
-                                    )
-                                ) {
-                                    comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                        item: { liveChatTextMessageRenderer: {} }
-                                    };
-                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                        comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item.liveChatTickerPaidMessageItemRenderer.showItemEndpoint.showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer;
-                                    console.log('Done! Added LiveChatTickerItemAction: ', comment);
-
-                                    // Extract donate chip information from liveChatPaidMessageRenderer
-                                    addDonatedChipFromPaidRenderer(
-                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                            .liveChatTextMessageRenderer
-                                    );
-                                } else {
-                                    // console.log('deepFindObjKey: ', deepFindObjKey(comment, 'timestampUsec'));
-                                    const pathComment = wrapTryCatch(() =>
-                                        Object.keys(deepFindObjKey(comment, 'timestampUsec')[0])[0]
-                                            .split('.')
-                                            .slice(0, -1)
-                                            .join('.')
-                                    ) as string | undefined;
-                                    // console.log('pathComment: ', pathComment);
-                                    if (pathComment) {
-                                        const findedComment = getObj(comment, pathComment, undefined) as any;
-                                        console.log('-----------------> GET OBJECT LIVE CHAT COMMENT: ', findedComment);
-
-                                        if (findedComment && findedComment?.authorName && findedComment?.message) {
-                                            console.log('-----------------> FINDED LIVE CHAT COMMENT: ', findedComment);
-                                            comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                item: { liveChatTextMessageRenderer: {} }
-                                            };
-                                            comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                findedComment;
-                                        }
-                                    }
-                                }
-                            }
-
-                            const timestampUsec: string | undefined = wrapTryCatch(
-                                () =>
-                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                        .liveChatTextMessageRenderer.timestampUsec
-                            ) as any;
-
-                            if (timestampUsec && !chatCmnts.has(parseInt(timestampUsec, 10))) {
-                                const chatMsgs =
-                                    (wrapTryCatch(
-                                        () =>
-                                            comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                .liveChatTextMessageRenderer.message.runs
-                                    ) as any) || [];
-
-                                let fullText = '';
-                                let renderFullTextComment = '';
-
-                                // Removed hardcoded HTML for purchaseAmountText
-                                // Now handled by donatedChip structure and chip badge rendering
-
-                                for (const msg of chatMsgs) {
-                                    try {
-                                        fullText += msg?.text || '';
-
-                                        if (parseInt(msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds) >= 0) {
-                                            const currentVideoId = (getVideoId(window.location.href) || '') as string;
-                                            const linkVideoId = (wrapTryCatch(
-                                                () => msg?.navigationEndpoint?.watchEndpoint?.videoId
-                                            ) || '') as string;
-                                            const isSameVideo =
-                                                String(linkVideoId || '') === String(currentVideoId || '');
-
-                                            renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}" data-video-id="${linkVideoId}">${msg?.text || ''}</a>`;
-
-                                            if (
-                                                isSameVideo &&
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.isTimeLine =
-                                                    'timeline';
-                                            }
-                                        } else if (msg?.navigationEndpoint) {
-                                            renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${msg?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl || msg?.navigationEndpoint?.urlEndpoint?.url || msg?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url || msg?.text || '#'}" target="_blank">${msg?.text || ''}</a>`;
-                                        } else if (wrapTryCatch(() => (msg as any).emoji)) {
-                                            const url =
-                                                wrapTryCatch(() => {
-                                                    const thumbnails = (msg as any).emoji.image.thumbnails;
-                                                    return thumbnails[thumbnails.length - 1].url;
-                                                }) || '';
-                                            const alt =
-                                                (wrapTryCatch(() => (msg as any).emoji.shortcuts?.[0]) as string) || '';
-                                            const style = `margin-left: 2px; margin-right: 2px;`;
-                                            renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
-                                        } else if (wrapTryCatch(() => (msg as any).attachment?.image)) {
-                                            const image: any = wrapTryCatch(() => (msg as any).attachment.image);
-                                            const url = image?.url || '';
-                                            const width = image?.width || 24;
-                                            const height = image?.height || 24;
-                                            const margin = image?.margin || { left: 0, right: 0 };
-                                            const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
-                                            const alt = (msg as any)?.text || '';
-                                            renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
-                                        } else {
-                                            renderFullTextComment += msg?.text || '';
-                                        }
-                                    } catch (e) {
-                                        console.error(e);
-                                        renderFullTextComment += msg?.text || '';
-                                    }
-                                }
-
-                                if (fullText) {
-                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.message.fullText =
-                                        fullText;
-
-                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.message.renderFullText =
-                                        renderFullTextComment || fullText;
-                                }
-
-                                if (
-                                    wrapTryCatch(
-                                        () =>
-                                            comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                .liveChatTextMessageRenderer.authorName
-                                    )
-                                ) {
-                                    chatCmnts.set(parseInt(timestampUsec, 10), _prepareFieldsChatComments(comment));
-                                    showLoadComments(chatCmnts.size, elShowLoading);
-                                }
-                            }
-                        } catch (err) {
-                            console.error(err);
-                            continue;
-                        }
-                    }
+                if (!params) {
+                    next = false;
+                    break;
                 }
-            } catch (e) {
-                console.error(e);
-                return chatCmnts;
+
+                const res = await fetchR(
+                    `https://www.youtube.com/youtubei/v1/live_chat/get_live_chat_replay?key=${getInnertubeApiKey()}`,
+                    { ...params, signal, cache: 'no-store' }
+                );
+
+                const response = await res.json();
+                const cmnts = response?.continuationContents?.liveChatContinuation?.actions;
+                console.log('Chat comments (Legacy): ', cmnts);
+
+                if (cmnts && cmnts.length > 0) {
+                    const lastOffsetTimeInCmnts = wrapTryCatch(() => {
+                        const offsetData = deepFindObjKey(cmnts[cmnts.length - 1], 'videoOffsetTimeMsec')[0];
+                        return (Object as any).entries(offsetData)[0][1];
+                    }) as number | undefined;
+
+                    console.log('lastOffsetTimeInCmnts: ', lastOffsetTimeInCmnts);
+
+                    if (currentOffsetTimeMsec === lastOffsetTimeInCmnts) {
+                        console.log('BREAK! Reached end of chat replay (Legacy API)');
+                        next = false;
+                        break;
+                    }
+
+                    processReplayBatch(cmnts, context);
+
+                    if (lastOffsetTimeInCmnts !== undefined) {
+                        currentOffsetTimeMsec = lastOffsetTimeInCmnts;
+                    }
+                } else {
+                    next = false;
+                }
             }
-        } else {
-            // Chat Replay branch - handle both legacy and new API
-            if (useLegacyApi) {
-                // ========== Legacy API Logic ==========
-                try {
-                    let currentOffsetTimeMsec = 0;
-                    let next = true;
 
-                    while (next) {
-                        console.log('Loop chat comments (Legacy API)');
-                        const params = await getParamsForChat(window, cDChat, signal, true, currentOffsetTimeMsec);
+            return chatCmnts;
+        }
 
-                        if (params) {
-                            const res = await fetchR(
-                                `https://www.youtube.com/youtubei/v1/live_chat/get_live_chat_replay?key=${getInnertubeApiKey()}`,
-                                { ...params, signal, cache: 'no-store' }
-                            );
+        let nextContinuation: any = continuationData;
 
-                            const response = await res.json();
-                            const cmnts = response?.continuationContents?.liveChatContinuation?.actions;
-                            console.log('Chat comments (Legacy): ', cmnts);
+        while (nextContinuation) {
+            console.log('Loop chat comments (New API)');
+            const params = await getParamsForChat(window, nextContinuation, signal, false);
 
-                            if (cmnts && cmnts.length > 0) {
-                                // Extract videoOffsetTimeMsec from last comment
-                                const lastOffsetTimeInCmnts = wrapTryCatch(() => {
-                                    const offsetData = deepFindObjKey(
-                                        cmnts[cmnts.length - 1],
-                                        'videoOffsetTimeMsec'
-                                    )[0];
-                                    return (Object as any).entries(offsetData)[0][1];
-                                }) as number | undefined;
+            if (!params) break;
 
-                                console.log('lastOffsetTimeInCmnts: ', lastOffsetTimeInCmnts);
+            const res = await fetchR(`https://www.youtube.com/youtubei/v1/live_chat/get_live_chat_replay`, {
+                ...params,
+                signal,
+                cache: 'no-store'
+            });
 
-                                // Check if we've reached the end
-                                if (currentOffsetTimeMsec === lastOffsetTimeInCmnts) {
-                                    console.log('BREAK! Reached end of chat replay (Legacy API)');
-                                    next = false;
-                                    break;
-                                }
+            const response = await res.json();
+            const cmnts = response?.continuationContents?.liveChatContinuation?.actions;
+            console.log('Chat comments (New): ', cmnts);
 
-                                // Process all comments
-                                for (const comment of cmnts) {
-                                    try {
-                                        if (
-                                            !wrapTryCatch(
-                                                () =>
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                        .liveChatTextMessageRenderer.timestampUsec
-                                            )
-                                        ) {
-                                            if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatPaidMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatPaidMessageRenderer;
-                                                console.log('Done! Added liveChatPaidMessageRenderer: ', comment);
+            if (Array.isArray(cmnts) && cmnts.length > 0) {
+                processReplayBatch(cmnts, context);
+            }
 
-                                                // Extract donate chip information from liveChatPaidMessageRenderer
-                                                addDonatedChipFromPaidRenderer(
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                        .liveChatTextMessageRenderer
-                                                );
-                                            } else if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0]
-                                                            .addBannerToLiveChatCommand.bannerRenderer
-                                                            .liveChatBannerRenderer.contents.liveChatTextMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                    item: { liveChatTextMessageRenderer: {} }
-                                                };
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                    comment.replayChatItemAction.actions[0].addBannerToLiveChatCommand.bannerRenderer.liveChatBannerRenderer.contents.liveChatTextMessageRenderer;
-                                                console.log('Done! Added liveChatBannerRenderer: ', comment);
-                                            } else if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0]
-                                                            .addLiveChatTickerItemAction.item
-                                                            .liveChatTickerPaidMessageItemRenderer.showItemEndpoint
-                                                            .showLiveChatItemEndpoint.renderer
-                                                            .liveChatPaidMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                    item: { liveChatTextMessageRenderer: {} }
-                                                };
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                    comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item.liveChatTickerPaidMessageItemRenderer.showItemEndpoint.showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer;
-                                                console.log('Done! Added LiveChatTickerItemAction: ', comment);
+            const continuations = response?.continuationContents?.liveChatContinuation?.continuations;
+            const continuationToken = continuations?.[0]?.liveChatReplayContinuationData?.continuation;
 
-                                                // Extract donate chip information from liveChatPaidMessageRenderer
-                                                addDonatedChipFromPaidRenderer(
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                        .liveChatTextMessageRenderer
-                                                );
-                                            } else {
-                                                // console.log('deepFindObjKey: ', deepFindObjKey(comment, 'timestampUsec'));
-                                                const pathComment = wrapTryCatch(() =>
-                                                    Object.keys(deepFindObjKey(comment, 'timestampUsec')[0])[0]
-                                                        .split('.')
-                                                        .slice(0, -1)
-                                                        .join('.')
-                                                ) as string | undefined;
-                                                // console.log('pathComment: ', pathComment);
-                                                if (pathComment) {
-                                                    const findedComment = getObj(
-                                                        comment,
-                                                        pathComment,
-                                                        undefined
-                                                    ) as any;
-                                                    console.log(
-                                                        '-----------------> GET OBJECT CHAT COMMENT: ',
-                                                        findedComment
-                                                    );
-
-                                                    if (
-                                                        findedComment &&
-                                                        findedComment?.authorName &&
-                                                        findedComment?.message
-                                                    ) {
-                                                        console.log(
-                                                            '-----------------> FINDED CHAT COMMENT: ',
-                                                            findedComment
-                                                        );
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                            item: { liveChatTextMessageRenderer: {} }
-                                                        };
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                            findedComment;
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        const timestampUsec: string | undefined = wrapTryCatch(
-                                            () =>
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                    .liveChatTextMessageRenderer.timestampUsec
-                                        ) as any;
-
-                                        if (timestampUsec && !chatCmnts.has(parseInt(timestampUsec, 10))) {
-                                            const chatMsgs =
-                                                (wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer.message.runs
-                                                ) as any) || [];
-
-                                            let fullText = '';
-                                            let renderFullTextComment = '';
-
-                                            // Removed hardcoded HTML for purchaseAmountText
-                                            // Now handled by donatedChip structure and chip badge rendering
-
-                                            for (const msg of chatMsgs) {
-                                                try {
-                                                    fullText += msg?.text || '';
-
-                                                    if (
-                                                        parseInt(
-                                                            msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds
-                                                        ) >= 0
-                                                    ) {
-                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${msg?.navigationEndpoint?.watchEndpoint?.videoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}">${msg?.text || ''}</a>`;
-
-                                                        const currentVideoId = (getVideoId(window.location.href) ||
-                                                            '') as string;
-                                                        const linkVideoId = (wrapTryCatch(
-                                                            () => msg?.navigationEndpoint?.watchEndpoint?.videoId
-                                                        ) || '') as string;
-                                                        const isSameVideo =
-                                                            String(linkVideoId || '') === String(currentVideoId || '');
-
-                                                        if (
-                                                            isSameVideo &&
-                                                            wrapTryCatch(
-                                                                () =>
-                                                                    comment.replayChatItemAction.actions[0]
-                                                                        .addChatItemAction.item
-                                                                        .liveChatTextMessageRenderer
-                                                            )
-                                                        ) {
-                                                            comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.isTimeLine =
-                                                                'timeline';
-                                                        }
-                                                    } else if (msg?.navigationEndpoint) {
-                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${msg?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl || msg?.navigationEndpoint?.urlEndpoint?.url || msg?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url || msg?.text || '#'}" target="_blank">${msg?.text || ''}</a>`;
-                                                    } else if (wrapTryCatch(() => (msg as any).emoji)) {
-                                                        const emoji: any = wrapTryCatch(() => (msg as any).emoji) || {};
-                                                        const thumbnails =
-                                                            wrapTryCatch(() => emoji.image.thumbnails) || [];
-                                                        const url =
-                                                            wrapTryCatch(() => thumbnails[thumbnails.length - 1].url) ||
-                                                            '';
-                                                        const shortcut =
-                                                            (wrapTryCatch(() => emoji.shortcuts?.[0]) as string) || '';
-                                                        const label =
-                                                            (wrapTryCatch(
-                                                                () => emoji.image.accessibility.accessibilityData.label
-                                                            ) as string) || '';
-
-                                                        // Always add a textual placeholder into fullText for exports/search
-                                                        if (shortcut) {
-                                                            fullText += shortcut;
-                                                        } else if (label) {
-                                                            fullText += `:${label}:`;
-                                                        } else {
-                                                            fullText += ':emoji:';
-                                                        }
-
-                                                        // Prefer image in rich HTML, fallback to shortcut text if no image URL
-                                                        const alt = shortcut || label || 'emoji';
-                                                        const style = `margin-left: 2px; margin-right: 2px;`;
-                                                        if (url) {
-                                                            renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
-                                                        } else {
-                                                            renderFullTextComment += alt;
-                                                        }
-                                                    } else if (wrapTryCatch(() => (msg as any).attachment?.image)) {
-                                                        const image: any = wrapTryCatch(
-                                                            () => (msg as any).attachment.image
-                                                        );
-                                                        const url = image?.url || '';
-                                                        const width = image?.width || 24;
-                                                        const height = image?.height || 24;
-                                                        const margin = image?.margin || { left: 0, right: 0 };
-                                                        const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
-                                                        const alt = (msg as any)?.text || '';
-                                                        renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
-                                                    } else {
-                                                        renderFullTextComment += msg?.text || '';
-                                                    }
-                                                } catch (e) {
-                                                    console.error(e);
-                                                    renderFullTextComment += msg?.text || '';
-                                                }
-                                            }
-
-                                            if (fullText) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.message.fullText =
-                                                    fullText;
-
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.message.renderFullText =
-                                                    renderFullTextComment || fullText;
-                                            }
-
-                                            if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer.authorName
-                                                )
-                                            ) {
-                                                chatCmnts.set(
-                                                    parseInt(timestampUsec, 10),
-                                                    _prepareFieldsChatComments(comment)
-                                                );
-                                                showLoadComments(chatCmnts.size, elShowLoading);
-                                            }
-                                        }
-                                    } catch (err) {
-                                        console.error(err);
-                                        continue;
-                                    }
-                                }
-
-                                // Update playerOffsetMs for next iteration
-                                if (lastOffsetTimeInCmnts !== undefined) {
-                                    currentOffsetTimeMsec = lastOffsetTimeInCmnts;
-                                }
-                            } else {
-                                next = false;
-                            }
-                        } else {
-                            next = false;
-                        }
-                    }
-
-                    return chatCmnts;
-                } catch (e) {
-                    console.error('Legacy API error:', e);
-                    return chatCmnts;
-                }
+            if (continuationToken) {
+                nextContinuation = { continuation: continuationToken };
             } else {
-                // ========== New API Logic ==========
-                try {
-                    let nextContinuation = cDChat;
-
-                    while (nextContinuation) {
-                        console.log('Loop chat comments (New API)');
-                        const params = await getParamsForChat(window, nextContinuation, signal, false);
-
-                        if (params) {
-                            const res = await fetchR(
-                                `https://www.youtube.com/youtubei/v1/live_chat/get_live_chat_replay`,
-                                { ...params, signal, cache: 'no-store' }
-                            );
-
-                            const response = await res.json();
-                            const cmnts = response?.continuationContents?.liveChatContinuation?.actions;
-                            console.log('Chat comments (New): ', cmnts);
-
-                            // Extract next continuation token
-                            const continuations = response?.continuationContents?.liveChatContinuation?.continuations;
-                            const continuationToken = continuations?.[0]?.liveChatReplayContinuationData?.continuation;
-                            if (continuationToken) {
-                                nextContinuation = { continuation: continuationToken };
-                            } else {
-                                break;
-                            }
-
-                            if (cmnts && cmnts.length > 0) {
-                                for (const comment of cmnts) {
-                                    try {
-                                        if (
-                                            !wrapTryCatch(
-                                                () =>
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                        .liveChatTextMessageRenderer.timestampUsec
-                                            )
-                                        ) {
-                                            if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatPaidMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatPaidMessageRenderer;
-                                                console.log('Done! Added liveChatPaidMessageRenderer: ', comment);
-
-                                                // Extract donate chip information from liveChatPaidMessageRenderer
-                                                addDonatedChipFromPaidRenderer(
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                        .liveChatTextMessageRenderer
-                                                );
-                                            } else if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0]
-                                                            .addBannerToLiveChatCommand.bannerRenderer
-                                                            .liveChatBannerRenderer.contents.liveChatTextMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                    item: { liveChatTextMessageRenderer: {} }
-                                                };
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                    comment.replayChatItemAction.actions[0].addBannerToLiveChatCommand.bannerRenderer.liveChatBannerRenderer.contents.liveChatTextMessageRenderer;
-                                                console.log('Done! Added liveChatBannerRenderer: ', comment);
-                                            } else if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0]
-                                                            .addLiveChatTickerItemAction.item
-                                                            .liveChatTickerPaidMessageItemRenderer.showItemEndpoint
-                                                            .showLiveChatItemEndpoint.renderer
-                                                            .liveChatPaidMessageRenderer
-                                                )
-                                            ) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                    item: { liveChatTextMessageRenderer: {} }
-                                                };
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                    comment.replayChatItemAction.actions[0].addLiveChatTickerItemAction.item.liveChatTickerPaidMessageItemRenderer.showItemEndpoint.showLiveChatItemEndpoint.renderer.liveChatPaidMessageRenderer;
-                                                console.log('Done! Added LiveChatTickerItemAction: ', comment);
-
-                                                // Extract donate chip information from liveChatPaidMessageRenderer
-                                                addDonatedChipFromPaidRenderer(
-                                                    comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                        .liveChatTextMessageRenderer
-                                                );
-                                            } else {
-                                                const pathComment = wrapTryCatch(() =>
-                                                    Object.keys(deepFindObjKey(comment, 'timestampUsec')[0])[0]
-                                                        .split('.')
-                                                        .slice(0, -1)
-                                                        .join('.')
-                                                ) as string | undefined;
-
-                                                if (pathComment) {
-                                                    const findedComment = getObj(
-                                                        comment,
-                                                        pathComment,
-                                                        undefined
-                                                    ) as any;
-                                                    console.log(
-                                                        '-----------------> GET OBJECT CHAT COMMENT: ',
-                                                        findedComment
-                                                    );
-
-                                                    if (
-                                                        findedComment &&
-                                                        findedComment?.authorName &&
-                                                        findedComment?.message
-                                                    ) {
-                                                        console.log(
-                                                            '-----------------> FINDED CHAT COMMENT: ',
-                                                            findedComment
-                                                        );
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction = {
-                                                            item: { liveChatTextMessageRenderer: {} }
-                                                        };
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer =
-                                                            findedComment;
-                                                    }
-                                                }
-                                            }
-                                        }
-
-                                        const timestampUsec: string | undefined = wrapTryCatch(
-                                            () =>
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                    .liveChatTextMessageRenderer.timestampUsec
-                                        ) as any;
-
-                                        if (timestampUsec && !chatCmnts.has(parseInt(timestampUsec, 10))) {
-                                            const chatMsgs =
-                                                (wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer.message.runs
-                                                ) as any) || [];
-
-                                            let fullText = '';
-                                            let renderFullTextComment = '';
-
-                                            // Removed hardcoded HTML for purchaseAmountText
-                                            // Now handled by donatedChip structure and chip badge rendering
-
-                                            for (const msg of chatMsgs) {
-                                                try {
-                                                    fullText += msg?.text || '';
-
-                                                    if (
-                                                        parseInt(
-                                                            msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds
-                                                        ) >= 0
-                                                    ) {
-                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${msg?.navigationEndpoint?.watchEndpoint?.videoId}&t=${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${msg?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}">${msg?.text || ''}</a>`;
-
-                                                        const currentVideoId = (getVideoId(window.location.href) ||
-                                                            '') as string;
-                                                        const linkVideoId = (wrapTryCatch(
-                                                            () => msg?.navigationEndpoint?.watchEndpoint?.videoId
-                                                        ) || '') as string;
-                                                        const isSameVideo =
-                                                            String(linkVideoId || '') === String(currentVideoId || '');
-
-                                                        if (
-                                                            isSameVideo &&
-                                                            wrapTryCatch(
-                                                                () =>
-                                                                    comment.replayChatItemAction.actions[0]
-                                                                        .addChatItemAction.item
-                                                                        .liveChatTextMessageRenderer
-                                                            )
-                                                        ) {
-                                                            comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.isTimeLine =
-                                                                'timeline';
-                                                        }
-                                                    } else if (msg?.navigationEndpoint) {
-                                                        renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${msg?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl || msg?.navigationEndpoint?.urlEndpoint?.url || msg?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url || msg?.text || '#'}" target="_blank">${msg?.text || ''}</a>`;
-                                                    } else if (wrapTryCatch(() => (msg as any).emoji)) {
-                                                        const emoji: any = wrapTryCatch(() => (msg as any).emoji) || {};
-                                                        const thumbnails =
-                                                            wrapTryCatch(() => emoji.image.thumbnails) || [];
-                                                        const url =
-                                                            wrapTryCatch(() => thumbnails[thumbnails.length - 1].url) ||
-                                                            '';
-                                                        const shortcut =
-                                                            (wrapTryCatch(() => emoji.shortcuts?.[0]) as string) || '';
-                                                        const label =
-                                                            (wrapTryCatch(
-                                                                () => emoji.image.accessibility.accessibilityData.label
-                                                            ) as string) || '';
-
-                                                        if (shortcut) {
-                                                            fullText += shortcut;
-                                                        } else if (label) {
-                                                            fullText += `:${label}:`;
-                                                        } else {
-                                                            fullText += ':emoji:';
-                                                        }
-
-                                                        const alt = shortcut || label || 'emoji';
-                                                        const style = `margin-left: 2px; margin-right: 2px;`;
-                                                        if (url) {
-                                                            renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
-                                                        } else {
-                                                            renderFullTextComment += alt;
-                                                        }
-                                                    } else if (wrapTryCatch(() => (msg as any).attachment?.image)) {
-                                                        const image: any = wrapTryCatch(
-                                                            () => (msg as any).attachment.image
-                                                        );
-                                                        const url = image?.url || '';
-                                                        const width = image?.width || 24;
-                                                        const height = image?.height || 24;
-                                                        const margin = image?.margin || { left: 0, right: 0 };
-                                                        const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
-                                                        const alt = (msg as any)?.text || '';
-                                                        renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
-                                                    } else {
-                                                        renderFullTextComment += msg?.text || '';
-                                                    }
-                                                } catch (e) {
-                                                    console.error(e);
-                                                    renderFullTextComment += msg?.text || '';
-                                                }
-                                            }
-
-                                            if (fullText) {
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.message.fullText =
-                                                    fullText;
-
-                                                comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer.message.renderFullText =
-                                                    renderFullTextComment || fullText;
-                                            }
-
-                                            if (
-                                                wrapTryCatch(
-                                                    () =>
-                                                        comment.replayChatItemAction.actions[0].addChatItemAction.item
-                                                            .liveChatTextMessageRenderer.authorName
-                                                )
-                                            ) {
-                                                chatCmnts.set(
-                                                    parseInt(timestampUsec, 10),
-                                                    _prepareFieldsChatComments(comment)
-                                                );
-                                                showLoadComments(chatCmnts.size, elShowLoading);
-                                            }
-                                        }
-                                    } catch (err) {
-                                        console.error(err);
-                                        continue;
-                                    }
-                                }
-                            }
-
-                            // Check if there are more messages
-                            if (!nextContinuation) {
-                                console.log('No more continuation, finished loading chat');
-                                break;
-                            }
-                        } else {
-                            break;
-                        }
-                    }
-
-                    return chatCmnts;
-                } catch (e) {
-                    console.error('New API error:', e);
-                    return chatCmnts;
-                }
+                console.log('No more continuation, finished loading chat');
+                break;
             }
         }
+
+        return chatCmnts;
     } catch (e) {
         console.error(e);
         return;
     }
-
-    return;
 }
 
 async function getTranscriptBaseUrl(w: any, signal: AbortSignal): Promise<string> {

--- a/app/src/source/utils/innertube/chat/liveChat.ts
+++ b/app/src/source/utils/innertube/chat/liveChat.ts
@@ -1,0 +1,67 @@
+import { wrapTryCatch } from '../../common';
+import {
+    ChatProcessingContext,
+    ensureTextMessageRenderer,
+    formatChatRuns,
+    markTimelineLinks,
+    prepareChatCommentFields
+} from './utils';
+
+/**
+ * 處理直播聊天室回傳的 actions，將訊息整理進共用 Map。
+ * 手動測試：於直播影片載入擴充功能後觸發留言抓取，確認新訊息與時間軸連結仍可正確跳轉。
+ */
+export function processLiveChatActions(actions: any[], context: ChatProcessingContext): void {
+    if (!Array.isArray(actions) || actions.length === 0) return;
+
+    for (const action of actions) {
+        try {
+            const comment = {
+                replayChatItemAction: {
+                    actions: [action]
+                }
+            };
+
+            ensureTextMessageRenderer(comment);
+
+            const timestampUsec = wrapTryCatch(
+                () =>
+                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer
+                        .timestampUsec
+            ) as string | undefined;
+
+            const timestamp = Number.parseInt(String(timestampUsec ?? ''), 10);
+            if (!timestamp || Number.isNaN(timestamp) || context.chatMap.has(timestamp)) {
+                continue;
+            }
+
+            const renderer = wrapTryCatch(
+                () => comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer
+            );
+            if (!renderer) continue;
+
+            renderer.message = renderer.message || {};
+            const runs = (wrapTryCatch(() => renderer.message.runs) as any[]) || [];
+            const formatted = formatChatRuns(runs, { currentVideoId: context.currentVideoId });
+
+            if (formatted.fullText) {
+                renderer.message.fullText = formatted.fullText;
+                renderer.message.renderFullText = formatted.richText;
+            }
+
+            markTimelineLinks(comment, formatted.hasTimelineLink);
+
+            const hasAuthor = wrapTryCatch(() => renderer.authorName);
+            if (!hasAuthor) continue;
+
+            const prepared = prepareChatCommentFields(comment);
+            context.chatMap.set(timestamp, prepared);
+
+            if (context.onCommentAdded) {
+                context.onCommentAdded(context.chatMap.size);
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+}

--- a/app/src/source/utils/innertube/chat/liveChat.ts
+++ b/app/src/source/utils/innertube/chat/liveChat.ts
@@ -8,8 +8,10 @@ import {
 } from './utils';
 
 /**
- * 處理直播聊天室回傳的 actions，將訊息整理進共用 Map。
- * 手動測試：於直播影片載入擴充功能後觸發留言抓取，確認新訊息與時間軸連結仍可正確跳轉。
+ * Process incoming live chat actions and normalize them into the shared map.
+ * Manual testing: open a live stream, trigger chat fetching, and verify that
+ * new messages still appear and timeline links keep jumping to the expected
+ * timestamps.
  */
 export function processLiveChatActions(actions: any[], context: ChatProcessingContext): void {
     if (!Array.isArray(actions) || actions.length === 0) return;

--- a/app/src/source/utils/innertube/chat/replayChat.ts
+++ b/app/src/source/utils/innertube/chat/replayChat.ts
@@ -1,0 +1,61 @@
+import { wrapTryCatch } from '../../common';
+import {
+    ChatProcessingContext,
+    ensureTextMessageRenderer,
+    formatChatRuns,
+    markTimelineLinks,
+    prepareChatCommentFields
+} from './utils';
+
+/**
+ * 處理回放批次資料，確保訊息欄位一致並寫入暫存 Map。
+ * 手動測試：播放聊天室回放影片並執行抓取，驗證留言數量與時間軸標記與舊版結果相同。
+ */
+export function processReplayBatch(actions: any[], context: ChatProcessingContext): void {
+    if (!Array.isArray(actions) || actions.length === 0) return;
+
+    for (const comment of actions) {
+        try {
+            ensureTextMessageRenderer(comment);
+
+            const timestampUsec = wrapTryCatch(
+                () =>
+                    comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer
+                        .timestampUsec
+            ) as string | undefined;
+
+            const timestamp = Number.parseInt(String(timestampUsec ?? ''), 10);
+            if (!timestamp || Number.isNaN(timestamp) || context.chatMap.has(timestamp)) {
+                continue;
+            }
+
+            const renderer = wrapTryCatch(
+                () => comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer
+            );
+            if (!renderer) continue;
+
+            renderer.message = renderer.message || {};
+            const runs = (wrapTryCatch(() => renderer.message.runs) as any[]) || [];
+            const formatted = formatChatRuns(runs, { currentVideoId: context.currentVideoId });
+
+            if (formatted.fullText) {
+                renderer.message.fullText = formatted.fullText;
+                renderer.message.renderFullText = formatted.richText;
+            }
+
+            markTimelineLinks(comment, formatted.hasTimelineLink);
+
+            const hasAuthor = wrapTryCatch(() => renderer.authorName);
+            if (!hasAuthor) continue;
+
+            const prepared = prepareChatCommentFields(comment);
+            context.chatMap.set(timestamp, prepared);
+
+            if (context.onCommentAdded) {
+                context.onCommentAdded(context.chatMap.size);
+            }
+        } catch (error) {
+            console.error(error);
+        }
+    }
+}

--- a/app/src/source/utils/innertube/chat/replayChat.ts
+++ b/app/src/source/utils/innertube/chat/replayChat.ts
@@ -8,8 +8,10 @@ import {
 } from './utils';
 
 /**
- * 處理回放批次資料，確保訊息欄位一致並寫入暫存 Map。
- * 手動測試：播放聊天室回放影片並執行抓取，驗證留言數量與時間軸標記與舊版結果相同。
+ * Process a batch of chat replay actions, align message fields, and store the
+ * normalized comments in the shared map.
+ * Manual testing: play a chat replay video, run the fetch routine, and confirm
+ * the comment count and timeline markers match the previous implementation.
  */
 export function processReplayBatch(actions: any[], context: ChatProcessingContext): void {
     if (!Array.isArray(actions) || actions.length === 0) return;

--- a/app/src/source/utils/innertube/chat/utils.ts
+++ b/app/src/source/utils/innertube/chat/utils.ts
@@ -1,0 +1,235 @@
+import { deepFindObjKey, getObj, wrapTryCatch } from '../../common';
+
+export interface ChatProcessingContext {
+    chatMap: Map<number, object>;
+    currentVideoId?: string;
+    onCommentAdded?: (count: number) => void;
+}
+
+export interface FormatChatRunsOptions {
+    currentVideoId?: string;
+}
+
+export interface FormatChatRunsResult {
+    fullText: string;
+    richText: string;
+    hasTimelineLink: boolean;
+}
+
+export function addDonatedChipFromPaidRenderer(renderer: any): void {
+    const purchaseAmount =
+        wrapTryCatch(() => renderer.purchaseAmountText?.simpleText) ??
+        wrapTryCatch(() => (renderer.purchaseAmountText?.runs || []).map((run: any) => run?.text || '').join(''));
+
+    if (!purchaseAmount) return;
+
+    renderer.donatedChip = {
+        pdgCommentChipRenderer: {
+            chipText: {
+                simpleText: purchaseAmount
+            },
+            chipColorPalette: {
+                backgroundColor: renderer.headerBackgroundColor ?? renderer.bodyBackgroundColor,
+                foregroundTitleColor: renderer.headerTextColor ?? renderer.bodyTextColor
+            }
+        }
+    };
+}
+
+export function prepareChatCommentFields(comment: any): any {
+    try {
+        const renderer = wrapTryCatch(
+            () => comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer
+        );
+        if (!renderer) return comment;
+
+        const badgeRenderer = wrapTryCatch(() => renderer.authorBadges?.[0]?.liveChatAuthorBadgeRenderer);
+        const iconType = wrapTryCatch(() => badgeRenderer?.icon?.iconType) as string | undefined;
+        const tooltip = wrapTryCatch(() => badgeRenderer?.tooltip) as string | undefined;
+
+        if (typeof iconType === 'string' && (iconType.indexOf('VERIFIED') >= 0 || iconType.indexOf('CHECK') >= 0)) {
+            renderer.verifiedAuthor = true;
+        } else if (typeof tooltip === 'string' && tooltip.indexOf('Verified') >= 0) {
+            renderer.verifiedAuthor = true;
+        }
+
+        return comment;
+    } catch (error) {
+        console.error(error);
+        return comment;
+    }
+}
+
+export function markTimelineLinks(comment: any, hasTimelineLink: boolean): void {
+    if (!hasTimelineLink) return;
+
+    try {
+        const renderer = wrapTryCatch(
+            () => comment.replayChatItemAction.actions[0].addChatItemAction.item.liveChatTextMessageRenderer
+        );
+        if (!renderer) return;
+
+        renderer.isTimeLine = 'timeline';
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+export function ensureTextMessageRenderer(comment: any): void {
+    try {
+        const action = wrapTryCatch(() => comment?.replayChatItemAction?.actions?.[0]) as any;
+        if (!action) return;
+
+        const existingTimestamp = wrapTryCatch(
+            () => action?.addChatItemAction?.item?.liveChatTextMessageRenderer?.timestampUsec
+        );
+        if (existingTimestamp) return;
+
+        const paidRenderer = wrapTryCatch(() => action?.addChatItemAction?.item?.liveChatPaidMessageRenderer);
+        if (paidRenderer) {
+            action.addChatItemAction = action.addChatItemAction || { item: {} };
+            action.addChatItemAction.item = action.addChatItemAction.item || {};
+            action.addChatItemAction.item.liveChatTextMessageRenderer = paidRenderer;
+            addDonatedChipFromPaidRenderer(action.addChatItemAction.item.liveChatTextMessageRenderer);
+            return;
+        }
+
+        const bannerRenderer = wrapTryCatch(
+            () =>
+                action?.addBannerToLiveChatCommand?.bannerRenderer?.liveChatBannerRenderer?.contents
+                    ?.liveChatTextMessageRenderer
+        );
+        if (bannerRenderer) {
+            action.addChatItemAction = { item: { liveChatTextMessageRenderer: bannerRenderer } };
+            return;
+        }
+
+        const tickerRenderer = wrapTryCatch(
+            () =>
+                action?.addLiveChatTickerItemAction?.item?.liveChatTickerPaidMessageItemRenderer?.showItemEndpoint
+                    ?.showLiveChatItemEndpoint?.renderer?.liveChatPaidMessageRenderer
+        );
+        if (tickerRenderer) {
+            action.addChatItemAction = { item: { liveChatTextMessageRenderer: tickerRenderer } };
+            addDonatedChipFromPaidRenderer(action.addChatItemAction.item.liveChatTextMessageRenderer);
+            return;
+        }
+
+        const pathComment = wrapTryCatch(() => {
+            const matches = deepFindObjKey(comment, 'timestampUsec');
+            if (!Array.isArray(matches) || matches.length === 0) return undefined;
+            return Object.keys(matches[0])[0].split('.').slice(0, -1).join('.');
+        }) as string | undefined;
+
+        if (pathComment) {
+            const foundComment = getObj(comment, pathComment, undefined) as any;
+            if (foundComment?.authorName && foundComment?.message) {
+                action.addChatItemAction = { item: { liveChatTextMessageRenderer: foundComment } };
+            }
+        }
+    } catch (error) {
+        console.error(error);
+    }
+}
+
+export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {}): FormatChatRunsResult {
+    const result: FormatChatRunsResult = {
+        fullText: '',
+        richText: '',
+        hasTimelineLink: false
+    };
+
+    const items = Array.isArray(runs) ? runs : [];
+
+    for (const run of items) {
+        try {
+            const text = (wrapTryCatch(() => run?.text) as string) || '';
+            result.fullText += text;
+
+            const startTimeValue = wrapTryCatch(() => run?.navigationEndpoint?.watchEndpoint?.startTimeSeconds) as
+                | string
+                | number
+                | undefined;
+            const startTimeSeconds = Number.parseInt(String(startTimeValue ?? ''), 10);
+
+            if (!Number.isNaN(startTimeSeconds) && startTimeSeconds >= 0) {
+                const linkVideoId = (wrapTryCatch(() => run?.navigationEndpoint?.watchEndpoint?.videoId) ||
+                    '') as string;
+                const href = `https://www.youtube.com/watch?v=${linkVideoId}&t=${startTimeSeconds}s`;
+                result.richText += `<a class="ycs-cpointer ycs-goto-comment-time" href="${href}" data-offsetvideo="${startTimeSeconds}" data-video-id="${linkVideoId}">${text || ''}</a>`;
+
+                if (options.currentVideoId && String(linkVideoId || '') === String(options.currentVideoId || '')) {
+                    result.hasTimelineLink = true;
+                }
+
+                continue;
+            }
+
+            if (run?.navigationEndpoint) {
+                const href =
+                    run?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl ||
+                    run?.navigationEndpoint?.urlEndpoint?.url ||
+                    run?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url ||
+                    text ||
+                    '#';
+
+                result.richText += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${text || ''}</a>`;
+                continue;
+            }
+
+            const emoji = wrapTryCatch(() => (run as any).emoji);
+            if (emoji) {
+                const thumbnails = (wrapTryCatch(() => emoji.image.thumbnails) as any[]) || [];
+                const url = (thumbnails[thumbnails.length - 1] || {}).url || '';
+                const shortcut = (wrapTryCatch(() => emoji.shortcuts?.[0]) as string) || '';
+                const label = (wrapTryCatch(() => emoji.image.accessibility.accessibilityData.label) as string) || '';
+
+                if (!text) {
+                    if (shortcut) {
+                        result.fullText += shortcut;
+                    } else if (label) {
+                        result.fullText += `:${label}:`;
+                    } else {
+                        result.fullText += ':emoji:';
+                    }
+                }
+
+                const alt = shortcut || label || 'emoji';
+                const style = 'margin-left: 2px; margin-right: 2px;';
+
+                if (url) {
+                    result.richText += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
+                } else {
+                    result.richText += alt;
+                }
+
+                continue;
+            }
+
+            const attachmentImage = wrapTryCatch(() => (run as any).attachment?.image);
+            if (attachmentImage) {
+                const url = attachmentImage?.url || '';
+                const width = attachmentImage?.width || 24;
+                const height = attachmentImage?.height || 24;
+                const margin = attachmentImage?.margin || { left: 0, right: 0 };
+                const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
+                const alt = (run as any)?.text || '';
+
+                result.richText += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
+                continue;
+            }
+
+            result.richText += text || '';
+        } catch (error) {
+            console.error(error);
+            const fallbackText = (wrapTryCatch(() => run?.text) as string) || '';
+            result.richText += fallbackText;
+        }
+    }
+
+    if (!result.richText) {
+        result.richText = result.fullText;
+    }
+
+    return result;
+}


### PR DESCRIPTION
## Summary
- extract shared chat formatting helpers into reusable innertube/chat utilities
- add dedicated live and replay chat processors that reuse the shared helpers
- simplify getChatComments to delegate chat handling to the new processors

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f8aca55d00832996d9f1b3fc9b3c64