### PR TITLE
refactor(innertube): modularize comment normalization

### DIFF
--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -1,4 +1,3 @@
-// @ts-expect-error [No have types]
 import objectScan from 'object-scan';
 import Queue from 'p-queue';
 
@@ -1691,53 +1690,56 @@ async function getAllCommentsModeV2(
                         let fullTextComment = '';
                         let renderFullTextComment = '';
 
-                        const contentText = normalized.commentRenderer.contentText.runs || [];
+                        const contentText = normalized.commentRenderer.contentText?.runs ?? [];
                         for (const partTextComment of contentText) {
-                            fullTextComment += partTextComment?.text || '';
+                            const text = partTextComment?.text ?? '';
+                            fullTextComment += text;
                             try {
-                                if (
-                                    parseInt(partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds) >= 0
-                                ) {
-                                    const currentVideoId = (getVideoId(window.location.href) || '') as string;
-                                    const linkVideoId = (wrapTryCatch(
-                                        () => partTextComment?.navigationEndpoint?.watchEndpoint?.videoId
-                                    ) || '') as string;
-                                    const isSameVideo = String(linkVideoId || '') === String(currentVideoId || '');
+                                const navigationEndpoint = partTextComment?.navigationEndpoint;
+                                const watchEndpoint = navigationEndpoint?.watchEndpoint;
+                                const startTimeSeconds = watchEndpoint?.startTimeSeconds;
+                                const startTimeValue =
+                                    typeof startTimeSeconds === 'string' ? parseInt(startTimeSeconds, 10) : Number.NaN;
 
-                                    renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}s" data-offsetvideo="${partTextComment?.navigationEndpoint?.watchEndpoint?.startTimeSeconds}" data-video-id="${linkVideoId}">${partTextComment?.text || ''}</a>`;
-                                    try {
-                                        if (isSameVideo) normalized.commentRenderer.isTimeLine = 'timeline';
-                                    } catch {
-                                        // If timeline property setting fails, continue processing
+                                if (!Number.isNaN(startTimeValue) && startTimeValue >= 0) {
+                                    const currentVideoId = String(getVideoId(window.location.href) || '');
+                                    const linkVideoId = watchEndpoint?.videoId ?? '';
+                                    const isSameVideo = linkVideoId === currentVideoId;
+                                    const timeParam = startTimeSeconds ?? String(startTimeValue);
+
+                                    renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${timeParam}s" data-offsetvideo="${timeParam}" data-video-id="${linkVideoId}">${text}</a>`;
+                                    if (isSameVideo) {
+                                        normalized.commentRenderer.isTimeLine = 'timeline';
                                     }
-                                } else if (partTextComment?.navigationEndpoint) {
-                                    renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${partTextComment?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl || partTextComment?.navigationEndpoint?.urlEndpoint?.url || partTextComment?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url || partTextComment?.text || '#'}" target="_blank">${partTextComment?.text || ''}</a>`;
-                                } else if (wrapTryCatch(() => (partTextComment as any).emoji)) {
-                                    const url =
-                                        wrapTryCatch(() => {
-                                            const thumbnails = (partTextComment as any).emoji.image.thumbnails;
-                                            return thumbnails[thumbnails.length - 1].url;
-                                        }) || '';
-                                    const alt =
-                                        (wrapTryCatch(() => (partTextComment as any).emoji.shortcuts?.[0]) as string) ||
-                                        '';
-                                    const style = `margin-left: 2px; margin-right: 2px;`;
+                                } else if (navigationEndpoint) {
+                                    const href =
+                                        navigationEndpoint.browseEndpoint?.canonicalBaseUrl ??
+                                        navigationEndpoint.urlEndpoint?.url ??
+                                        navigationEndpoint.commandMetadata?.webCommandMetadata?.url ??
+                                        (text || '#');
+
+                                    renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${text}</a>`;
+                                } else if (partTextComment?.emoji) {
+                                    const thumbnails = partTextComment.emoji.image?.thumbnails ?? [];
+                                    const url = thumbnails[thumbnails.length - 1]?.url ?? '';
+                                    const alt = partTextComment.emoji.shortcuts?.[0] ?? '';
+                                    const style = 'margin-left: 2px; margin-right: 2px;';
                                     renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
-                                } else if (wrapTryCatch(() => (partTextComment as any).attachment?.image)) {
-                                    const image: any = wrapTryCatch(() => (partTextComment as any).attachment.image);
-                                    const url = image?.url || '';
-                                    const width = image?.width || 24;
-                                    const height = image?.height || 24;
-                                    const margin = image?.margin || { left: 0, right: 0 };
-                                    const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
-                                    const alt = (partTextComment as any)?.text || '';
+                                } else if (partTextComment?.attachment?.image) {
+                                    const image = partTextComment.attachment.image;
+                                    const url = image.url ?? '';
+                                    const width = image.width ?? 24;
+                                    const height = image.height ?? 24;
+                                    const margin = image.margin ?? { left: 0, right: 0 };
+                                    const style = `margin-left: ${margin.left ?? 0}px; margin-right: ${margin.right ?? 0}px;`;
+                                    const alt = text;
                                     renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
                                 } else {
-                                    renderFullTextComment += partTextComment?.text || '';
+                                    renderFullTextComment += text;
                                 }
                             } catch (e) {
                                 console.error(e);
-                                renderFullTextComment += partTextComment?.text || '';
+                                renderFullTextComment += text;
                                 continue;
                             }
                         }

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -11,6 +11,7 @@ import { buildInnertubeBody, buildInnertubeHeaders } from './innertube/request';
 import { processLiveChatActions } from './innertube/chat/liveChat';
 import { processReplayBatch } from './innertube/chat/replayChat';
 import type { ChatProcessingContext } from './innertube/chat/utils';
+import { normalizeCommentViewModel } from './innertube/comments/normalize';
 
 async function findInitYParams(initData: [object]): Promise<string | undefined> {
     try {
@@ -132,138 +133,6 @@ async function getParams(w: Window & typeof globalThis, signal?: AbortSignal): P
             mode: 'cors'
         }
     };
-}
-
-function normalizeCommentFromViewModel(item: any): any | undefined {
-    try {
-        const commentVM =
-            wrapTryCatch(() => item.commentThreadRenderer.commentViewModel) ||
-            wrapTryCatch(() => item.commentViewModel);
-        if (!commentVM) return undefined;
-
-        const candidates = [] as any[];
-        const preferredPaths = [
-            '**.commentContentViewModel.content',
-            '**.attributedText.content',
-            '**.content.content',
-            '**.content',
-            '**.commentContentViewModel.content.runs',
-            '**.attributedText.runs',
-            '**.content.runs',
-            '**.content.content.runs',
-            '**.textContent.runs',
-            '**.body.runs',
-            '**.commentText.runs',
-            '**.contentText.runs',
-            '**.runs'
-        ];
-        for (const p of preferredPaths) {
-            const arrs = objectScan([p], { joined: true, rtn: 'value' })(commentVM) as any[];
-            for (const arr of arrs) {
-                if (Array.isArray(arr)) candidates.push(arr);
-            }
-            if (candidates.length > 0) break;
-        }
-
-        if (candidates.length === 0) {
-            const anyArrays = objectScan(['**.*'], { rtn: 'value' })(commentVM) as any[];
-            for (const v of anyArrays) {
-                if (
-                    Array.isArray(v) &&
-                    v.length > 0 &&
-                    v.some(
-                        (r: any) =>
-                            typeof r === 'object' &&
-                            (wrapTryCatch(() => r.text) ||
-                                wrapTryCatch(() => r.emoji) ||
-                                wrapTryCatch(() => r.attachment) ||
-                                wrapTryCatch(() => r.navigationEndpoint))
-                    )
-                ) {
-                    candidates.push(v);
-                    break;
-                }
-            }
-        }
-
-        const runsLike = (candidates.find((a) => a && Array.isArray(a) && a.some((r: any) => typeof r === 'object')) ||
-            []) as any[];
-
-        const mapElementToRun = (elem: any): any | undefined => {
-            try {
-                if (!elem || typeof elem !== 'object') return undefined;
-                const text = wrapTryCatch(() => elem.text) || wrapTryCatch(() => elem.simpleText);
-                if (typeof text === 'string') {
-                    return { text, navigationEndpoint: wrapTryCatch(() => elem.navigationEndpoint) };
-                }
-                const textRunContent =
-                    wrapTryCatch(() => elem.textRun.content) || wrapTryCatch(() => elem.textRun.text);
-                if (typeof textRunContent === 'string') {
-                    return {
-                        text: textRunContent,
-                        navigationEndpoint: wrapTryCatch(() => elem.textRun.navigationEndpoint)
-                    };
-                }
-                const nestedText =
-                    wrapTryCatch(() => elem.content) ||
-                    wrapTryCatch(() => elem.string) ||
-                    wrapTryCatch(() => elem.value);
-                if (typeof nestedText === 'string') {
-                    return { text: nestedText };
-                }
-                const emoji = wrapTryCatch(() => elem.emoji) || wrapTryCatch(() => elem.emojiRun.emoji);
-                if (emoji) {
-                    return { emoji };
-                }
-                const attachment =
-                    wrapTryCatch(() => elem.attachment) ||
-                    wrapTryCatch(() => elem.image) ||
-                    wrapTryCatch(() => elem.inlineObject);
-                if (attachment) {
-                    return { attachment };
-                }
-                return undefined;
-            } catch {
-                return undefined;
-            }
-        };
-
-        const collectRunsFromElements = (elements: any[]): any[] => {
-            const acc: any[] = [];
-            for (const elem of elements) {
-                const mapped = mapElementToRun(elem);
-                if (mapped) acc.push(mapped);
-                const nestedSegs =
-                    wrapTryCatch(() => elem.attributedText?.content) ||
-                    wrapTryCatch(() => elem.content?.content) ||
-                    wrapTryCatch(() => elem.content);
-                if (Array.isArray(nestedSegs) && nestedSegs.length > 0) {
-                    acc.push(...collectRunsFromElements(nestedSegs));
-                }
-            }
-            return acc;
-        };
-
-        let runs = collectRunsFromElements(runsLike).filter((x: any) => !!x);
-
-        if (!runs || runs.length === 0) {
-            const parts: any[] = [];
-            const textValues = objectScan(['**.simpleText', '**.text', '**.content'], { joined: true, rtn: 'value' })(
-                commentVM
-            ) as any[];
-            for (const t of textValues) {
-                if (typeof t === 'string' && t.trim().length > 0) {
-                    parts.push({ text: t });
-                }
-            }
-            if (parts.length > 0) runs = parts;
-        }
-
-        return { commentRenderer: { contentText: { runs: runs || [] } } };
-    } catch (e) {
-        console.error(e);
-        return undefined;
-    }
 }
 
 function getFrameworkUpdatesById(response: any): Record<string, any> {
@@ -1725,7 +1594,7 @@ async function getAllCommentsModeV2(
                     (wrapTryCatch(() => c.commentThreadRenderer.commentViewModel) ||
                         wrapTryCatch(() => c.commentViewModel))
                 ) {
-                    const normalizedEarly = normalizeCommentFromViewModel(c);
+                    const normalizedEarly = normalizeCommentViewModel(c);
                     if (normalizedEarly) {
                         c.commentThreadRenderer.comment = normalizedEarly;
                         try {
@@ -1817,7 +1686,7 @@ async function getAllCommentsModeV2(
                     wrapTryCatch(() => c.commentThreadRenderer?.commentViewModel) ||
                     wrapTryCatch(() => c.commentViewModel)
                 ) {
-                    const normalized = normalizeCommentFromViewModel(c);
+                    const normalized = normalizeCommentViewModel(c);
                     if (normalized && normalized.commentRenderer?.contentText?.runs) {
                         let fullTextComment = '';
                         let renderFullTextComment = '';
@@ -1926,7 +1795,7 @@ async function getAllCommentsModeV2(
                                 const replies: any = repliesContainer || [];
                                 for (let comment of replies) {
                                     if (!comment?.commentRenderer) {
-                                        const norm = normalizeCommentFromViewModel(comment);
+                                        const norm = normalizeCommentViewModel(comment);
                                         if (norm && norm.commentRenderer) comment = norm;
                                     }
                                     if (!comment?.commentRenderer) continue;
@@ -2077,7 +1946,7 @@ async function getAllCommentsModeV2(
                                     const replies: any = moreReplies;
                                     for (let comment of replies) {
                                         if (!comment?.commentRenderer) {
-                                            const norm = normalizeCommentFromViewModel(comment);
+                                            const norm = normalizeCommentViewModel(comment);
                                             if (norm && norm.commentRenderer) comment = norm;
                                         }
                                         if (!comment?.commentRenderer) continue;

--- a/app/src/source/utils/innertube/comments/normalize.ts
+++ b/app/src/source/utils/innertube/comments/normalize.ts
@@ -106,7 +106,7 @@ function getCommentViewModel(source: unknown): CommentViewModel | undefined {
 }
 
 /**
- * 搜尋並回傳所有可能的 runs 候選陣列。
+ * Locate every array that might represent comment runs.
  */
 export function scanForRuns(viewModel: CommentViewModel): RunCandidate[] {
     const preferredMatches = (preferredRunScanner(viewModel) as unknown[]).filter(isRunElementArray) as RunCandidate[];
@@ -123,7 +123,7 @@ export function scanForRuns(viewModel: CommentViewModel): RunCandidate[] {
 }
 
 /**
- * 由 ViewModel 擷取最符合預期的 runs 候選陣列。
+ * Select the run array that best matches the expected view model shape.
  */
 export function extractRunCandidates(viewModel: CommentViewModel): CommentElement[] {
     const candidates = scanForRuns(viewModel);
@@ -133,7 +133,7 @@ export function extractRunCandidates(viewModel: CommentViewModel): CommentElemen
 }
 
 /**
- * 將單一元素映射為 commentRenderer 的 run 片段。
+ * Map a single element into a legacy commentRenderer run fragment.
  */
 export function mapElementToRun(element: CommentElement): CommentRun | undefined {
     const directText = safeString(() => (element as any).text ?? (element as any).simpleText);
@@ -173,7 +173,7 @@ export function mapElementToRun(element: CommentElement): CommentRun | undefined
 }
 
 /**
- * 遞迴蒐集元素及其巢狀內容轉換而成的 runs。
+ * Recursively collect runs from the provided elements and their nested segments.
  */
 export function collectRuns(elements: CommentElement[]): CommentRun[] {
     return elements.reduce<CommentRun[]>((accumulator, element) => {
@@ -192,7 +192,7 @@ export function collectRuns(elements: CommentElement[]): CommentRun[] {
 }
 
 /**
- * 將任意物件（含 commentThreadRenderer）正規化為 commentRenderer 結構。
+ * Normalize any object (including commentThreadRenderer wrappers) into a commentRenderer structure.
  */
 export function normalizeCommentViewModel(source: unknown): NormalizedCommentRenderer | undefined {
     const viewModel = getCommentViewModel(source);

--- a/app/src/source/utils/innertube/comments/normalize.ts
+++ b/app/src/source/utils/innertube/comments/normalize.ts
@@ -1,0 +1,217 @@
+import objectScan from 'object-scan';
+
+import type { CommentRun, NormalizedCommentRenderer } from '../../interfaces/i_assist';
+import { wrapTryCatch } from '../../common';
+
+type CommentViewModel = Record<string, unknown>;
+type CommentElement = Record<string, unknown>;
+type RunCandidate = CommentElement[];
+
+const PREFERRED_RUN_PATHS = [
+    '**.commentContentViewModel.content',
+    '**.attributedText.content',
+    '**.content.content',
+    '**.content',
+    '**.commentContentViewModel.content.runs',
+    '**.attributedText.runs',
+    '**.content.runs',
+    '**.content.content.runs',
+    '**.textContent.runs',
+    '**.body.runs',
+    '**.commentText.runs',
+    '**.contentText.runs',
+    '**.runs'
+] as const;
+
+const preferredRunScanner = objectScan(PREFERRED_RUN_PATHS as readonly string[], { joined: true, rtn: 'value' });
+const anyValueScanner = objectScan(['**.*'], { rtn: 'value' });
+const textValueScanner = objectScan(['**.simpleText', '**.text', '**.content'], { joined: true, rtn: 'value' });
+
+function isRecord(value: unknown): value is CommentElement {
+    return typeof value === 'object' && value !== null;
+}
+
+function isRunElementArray(value: unknown): value is RunCandidate {
+    return Array.isArray(value) && value.some(isRecord);
+}
+
+function isPotentialRunElement(value: unknown): boolean {
+    if (!isRecord(value)) {
+        return false;
+    }
+
+    const element = value as Record<string, any>;
+
+    return (
+        typeof element.text === 'string' ||
+        typeof element.simpleText === 'string' ||
+        typeof element.textRun?.content === 'string' ||
+        typeof element.textRun?.text === 'string' ||
+        typeof element.content === 'string' ||
+        typeof element.string === 'string' ||
+        typeof element.value === 'string' ||
+        element.emoji != null ||
+        element.emojiRun?.emoji != null ||
+        element.attachment != null ||
+        element.image != null ||
+        element.inlineObject != null ||
+        element.navigationEndpoint != null
+    );
+}
+
+function safeString(getter: () => unknown): string | undefined {
+    const value = wrapTryCatch(getter);
+    return typeof value === 'string' ? value : undefined;
+}
+
+function safeValue<T>(getter: () => T): T | undefined {
+    return wrapTryCatch(getter);
+}
+
+function extractNestedSegments(element: CommentElement): CommentElement[] {
+    const candidates = [
+        safeValue(() => (element.attributedText as any)?.content),
+        safeValue(() => (element.content as any)?.content),
+        safeValue(() => element.content)
+    ];
+
+    for (const candidate of candidates) {
+        if (Array.isArray(candidate) && candidate.length > 0) {
+            return candidate.filter(isRecord) as CommentElement[];
+        }
+    }
+
+    return [];
+}
+
+function extractTextFallbacks(viewModel: CommentViewModel): CommentRun[] {
+    const textValues = textValueScanner(viewModel) as unknown[];
+    const runs: CommentRun[] = [];
+
+    for (const value of textValues) {
+        if (typeof value === 'string' && value.trim().length > 0) {
+            runs.push({ text: value });
+        }
+    }
+
+    return runs;
+}
+
+function getCommentViewModel(source: unknown): CommentViewModel | undefined {
+    const fromThread = safeValue(() => (source as any).commentThreadRenderer?.commentViewModel);
+    const direct = safeValue(() => (source as any).commentViewModel);
+    const viewModel = (fromThread ?? direct) as CommentViewModel | undefined;
+
+    return viewModel && isRecord(viewModel) ? viewModel : undefined;
+}
+
+/**
+ * 搜尋並回傳所有可能的 runs 候選陣列。
+ */
+export function scanForRuns(viewModel: CommentViewModel): RunCandidate[] {
+    const preferredMatches = (preferredRunScanner(viewModel) as unknown[]).filter(isRunElementArray) as RunCandidate[];
+    if (preferredMatches.length > 0) {
+        return preferredMatches;
+    }
+
+    const fallbackMatches = anyValueScanner(viewModel) as unknown[];
+    const fallbackArray = fallbackMatches.find(
+        (value) => isRunElementArray(value) && value.some(isPotentialRunElement)
+    );
+
+    return fallbackArray && isRunElementArray(fallbackArray) ? [fallbackArray] : [];
+}
+
+/**
+ * 由 ViewModel 擷取最符合預期的 runs 候選陣列。
+ */
+export function extractRunCandidates(viewModel: CommentViewModel): CommentElement[] {
+    const candidates = scanForRuns(viewModel);
+    const preferred = candidates.find((candidate) => candidate.some(isPotentialRunElement));
+
+    return preferred ? preferred.filter(isRecord) : [];
+}
+
+/**
+ * 將單一元素映射為 commentRenderer 的 run 片段。
+ */
+export function mapElementToRun(element: CommentElement): CommentRun | undefined {
+    const directText = safeString(() => (element as any).text ?? (element as any).simpleText);
+    if (directText) {
+        return {
+            text: directText,
+            navigationEndpoint: safeValue(() => (element as any).navigationEndpoint)
+        };
+    }
+
+    const textRunContent = safeString(() => (element as any).textRun?.content ?? (element as any).textRun?.text);
+    if (textRunContent) {
+        return {
+            text: textRunContent,
+            navigationEndpoint: safeValue(() => (element as any).textRun?.navigationEndpoint)
+        };
+    }
+
+    const nestedText = safeString(() => (element as any).content ?? (element as any).string ?? (element as any).value);
+    if (nestedText) {
+        return { text: nestedText };
+    }
+
+    const emoji = safeValue(() => (element as any).emoji ?? (element as any).emojiRun?.emoji);
+    if (emoji) {
+        return { emoji } as CommentRun;
+    }
+
+    const attachment = safeValue(
+        () => (element as any).attachment ?? (element as any).image ?? (element as any).inlineObject
+    );
+    if (attachment) {
+        return { attachment } as CommentRun;
+    }
+
+    return undefined;
+}
+
+/**
+ * 遞迴蒐集元素及其巢狀內容轉換而成的 runs。
+ */
+export function collectRuns(elements: CommentElement[]): CommentRun[] {
+    return elements.reduce<CommentRun[]>((accumulator, element) => {
+        const mapped = mapElementToRun(element);
+        if (mapped) {
+            accumulator.push(mapped);
+        }
+
+        const nested = extractNestedSegments(element);
+        if (nested.length > 0) {
+            accumulator.push(...collectRuns(nested));
+        }
+
+        return accumulator;
+    }, []);
+}
+
+/**
+ * 將任意物件（含 commentThreadRenderer）正規化為 commentRenderer 結構。
+ */
+export function normalizeCommentViewModel(source: unknown): NormalizedCommentRenderer | undefined {
+    const viewModel = getCommentViewModel(source);
+    if (!viewModel) {
+        return undefined;
+    }
+
+    const runElements = extractRunCandidates(viewModel);
+    let runs = collectRuns(runElements);
+
+    if (runs.length === 0) {
+        runs = extractTextFallbacks(viewModel);
+    }
+
+    return {
+        commentRenderer: {
+            contentText: {
+                runs
+            }
+        }
+    };
+}

--- a/app/src/source/utils/interfaces/i_assist.ts
+++ b/app/src/source/utils/interfaces/i_assist.ts
@@ -14,7 +14,7 @@ export interface GetParams {
 }
 
 /**
- * 單一 run 片段的標準化資料結構。
+ * Normalized representation for a single comment run fragment.
  */
 export interface NavigationWatchEndpoint {
     videoId?: string;
@@ -98,7 +98,7 @@ export interface CommentRendererData {
 }
 
 /**
- * 由 commentViewModel 轉換而來的 commentRenderer 介面。
+ * commentRenderer shape derived from a commentViewModel instance.
  */
 export interface NormalizedCommentRenderer {
     commentRenderer: CommentRendererData;

--- a/app/src/source/utils/interfaces/i_assist.ts
+++ b/app/src/source/utils/interfaces/i_assist.ts
@@ -16,22 +16,94 @@ export interface GetParams {
 /**
  * 單一 run 片段的標準化資料結構。
  */
+export interface NavigationWatchEndpoint {
+    videoId?: string;
+    startTimeSeconds?: string;
+}
+
+export interface NavigationBrowseEndpoint {
+    canonicalBaseUrl?: string;
+}
+
+export interface NavigationUrlEndpoint {
+    url?: string;
+}
+
+export interface NavigationCommandMetadata {
+    webCommandMetadata?: {
+        url?: string;
+    };
+}
+
+export interface NavigationEndpoint {
+    watchEndpoint?: NavigationWatchEndpoint;
+    browseEndpoint?: NavigationBrowseEndpoint;
+    urlEndpoint?: NavigationUrlEndpoint;
+    commandMetadata?: NavigationCommandMetadata;
+    [key: string]: unknown;
+}
+
+export interface EmojiImageThumbnail {
+    url?: string;
+    width?: number;
+    height?: number;
+}
+
+export interface EmojiImage {
+    thumbnails?: EmojiImageThumbnail[];
+}
+
+export interface EmojiData {
+    image?: EmojiImage;
+    shortcuts?: string[];
+    [key: string]: unknown;
+}
+
+export interface AttachmentImageMargin {
+    left?: number;
+    right?: number;
+}
+
+export interface AttachmentImage {
+    url?: string;
+    width?: number;
+    height?: number;
+    margin?: AttachmentImageMargin;
+}
+
+export interface AttachmentData {
+    image?: AttachmentImage;
+    [key: string]: unknown;
+}
+
 export interface CommentRun {
     text?: string;
-    emoji?: Record<string, unknown>;
-    attachment?: Record<string, unknown>;
-    navigationEndpoint?: Record<string, unknown>;
+    emoji?: EmojiData;
+    attachment?: AttachmentData;
+    navigationEndpoint?: NavigationEndpoint;
+    [key: string]: unknown;
+}
+
+export interface CommentRendererContentText {
+    runs: CommentRun[];
+    fullText?: string;
+    renderFullText?: string;
+    [key: string]: unknown;
+}
+
+export interface CommentRendererData {
+    contentText: CommentRendererContentText;
+    isTimeLine?: string;
+    [key: string]: unknown;
 }
 
 /**
  * 由 commentViewModel 轉換而來的 commentRenderer 介面。
  */
 export interface NormalizedCommentRenderer {
-    commentRenderer: {
-        contentText: {
-            runs: CommentRun[];
-        };
-    };
+    commentRenderer: CommentRendererData;
+    typeComment?: string;
+    [key: string]: unknown;
 }
 
 export interface ISheetDetails {

--- a/app/src/source/utils/interfaces/i_assist.ts
+++ b/app/src/source/utils/interfaces/i_assist.ts
@@ -13,6 +13,27 @@ export interface GetParams {
     };
 }
 
+/**
+ * 單一 run 片段的標準化資料結構。
+ */
+export interface CommentRun {
+    text?: string;
+    emoji?: Record<string, unknown>;
+    attachment?: Record<string, unknown>;
+    navigationEndpoint?: Record<string, unknown>;
+}
+
+/**
+ * 由 commentViewModel 轉換而來的 commentRenderer 介面。
+ */
+export interface NormalizedCommentRenderer {
+    commentRenderer: {
+        contentText: {
+            runs: CommentRun[];
+        };
+    };
+}
+
 export interface ISheetDetails {
     'Cache timestamp': number;
     URL: string;

--- a/app/src/types/object-scan.d.ts
+++ b/app/src/types/object-scan.d.ts
@@ -1,0 +1,21 @@
+declare module 'object-scan' {
+    interface ObjectScanOptions {
+        joined?: boolean;
+        rtn?: string;
+        filterFn?: (key: string[], value: unknown, data: unknown) => boolean | void;
+        useArraySelector?: boolean;
+        abort?: boolean;
+        reverse?: boolean;
+        breakFn?: (matched: { key: string[]; value: unknown; parents: unknown[]; isMatch: boolean }) => void;
+        [key: string]: unknown;
+    }
+
+    type ObjectScanResult<T> = (input: unknown) => T;
+
+    function objectScan<T = unknown>(
+        patterns: readonly string[] | string[],
+        options?: ObjectScanOptions
+    ): ObjectScanResult<T>;
+
+    export = objectScan;
+}


### PR DESCRIPTION
## Summary
- extract comment normalization helpers into a dedicated module under utils/innertube/comments with typed pure functions
- add CommentRun and NormalizedCommentRenderer interfaces to describe normalized comment structures
- update innertube comment handling to call the new normalizeCommentViewModel entry point

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f8bb6b79c08329a793b8cb28e3483b