### PR TITLE
refactor(comments): centralize comment run formatting

### DIFF
--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -42,6 +42,99 @@ export interface ScheduleReplyFetchParams {
     frameworkUpdatesResolver?: (response: any) => Record<string, any>;
 }
 
+export interface FormattedCommentContent {
+    fullText: string;
+    renderFullText: string;
+    isTimeline: boolean;
+}
+
+export function formatCommentRuns(runs: any[] | undefined, currentVideoId: string): FormattedCommentContent {
+    let fullTextComment = '';
+    let renderFullTextComment = '';
+    let isTimeline = false;
+
+    const safeRuns = Array.isArray(runs) ? runs : [];
+
+    for (const partTextComment of safeRuns) {
+        let text = '';
+        let navigationEndpoint: any;
+        try {
+            text =
+                (partTextComment as any)?.text ??
+                (partTextComment as any)?.simpleText ??
+                (wrapTryCatch(() => (partTextComment as any)?.textRun?.content) as string) ??
+                (wrapTryCatch(() => (partTextComment as any)?.textRun?.text) as string) ??
+                (wrapTryCatch(() => (partTextComment as any)?.content) as string) ??
+                '';
+            navigationEndpoint =
+                (partTextComment as any)?.navigationEndpoint ??
+                wrapTryCatch(() => (partTextComment as any)?.textRun?.navigationEndpoint);
+
+            fullTextComment += text || '';
+
+            const rawTimeValue = wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds);
+            const parsedTime =
+                typeof rawTimeValue === 'string' ? parseInt(rawTimeValue, 10) : (rawTimeValue as number | undefined);
+            if (Number.isFinite(parsedTime) && (parsedTime as number) >= 0) {
+                const linkVideoId = (wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.videoId) || '') as string;
+                const isSameVideo = String(linkVideoId || '') === String(currentVideoId || '');
+                const timeValue = rawTimeValue ?? parsedTime ?? '';
+                renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${timeValue}s" data-offsetvideo="${timeValue}" data-video-id="${linkVideoId}">${text || ''}</a>`;
+                if (isSameVideo) {
+                    isTimeline = true;
+                }
+            } else if (navigationEndpoint) {
+                const href = (wrapTryCatch(() => navigationEndpoint?.browseEndpoint?.canonicalBaseUrl) ||
+                    wrapTryCatch(() => navigationEndpoint?.urlEndpoint?.url) ||
+                    wrapTryCatch(() => navigationEndpoint?.commandMetadata?.webCommandMetadata?.url) ||
+                    text ||
+                    '#') as string;
+                renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${text || ''}</a>`;
+            } else if (wrapTryCatch(() => (partTextComment as any).emoji)) {
+                const url =
+                    wrapTryCatch(() => {
+                        const thumbnails = (partTextComment as any).emoji.image.thumbnails;
+                        return thumbnails[thumbnails.length - 1].url;
+                    }) || '';
+                const alt = (wrapTryCatch(() => (partTextComment as any).emoji.shortcuts?.[0]) as string) || '';
+                const style = `margin-left: 2px; margin-right: 2px;`;
+                renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
+            } else if (wrapTryCatch(() => (partTextComment as any).attachment?.image)) {
+                const image: any = wrapTryCatch(() => (partTextComment as any).attachment.image);
+                const url = image?.url || '';
+                const width = image?.width || 24;
+                const height = image?.height || 24;
+                const margin = image?.margin || { left: 0, right: 0 };
+                const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
+                const alt = text || '';
+                renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
+            } else {
+                renderFullTextComment += text || '';
+            }
+        } catch (e) {
+            console.error(e);
+            const fallbackText: string = ((): string => {
+                try {
+                    const t =
+                        (partTextComment as any)?.text ??
+                        (partTextComment as any)?.simpleText ??
+                        (wrapTryCatch(() => (partTextComment as any)?.textRun?.content) as string) ??
+                        (wrapTryCatch(() => (partTextComment as any)?.textRun?.text) as string) ??
+                        (wrapTryCatch(() => (partTextComment as any)?.content) as string) ??
+                        '';
+                    return typeof t === 'string' ? t : '';
+                } catch {
+                    return '';
+                }
+            })();
+            renderFullTextComment += fallbackText;
+            fullTextComment += fallbackText;
+        }
+    }
+
+    return { fullText: fullTextComment, renderFullText: renderFullTextComment, isTimeline };
+}
+
 export interface FetchInitialCommentBatchParams {
     windowRef: Window & typeof globalThis;
     signal?: AbortSignal;
@@ -333,6 +426,22 @@ export function generateCommentObjectFromFW(params: {
             }
         };
 
+        let currentVideoId = '';
+        if (typeof window !== 'undefined') {
+            try {
+                currentVideoId = String(getVideoId(window.location.href) || '');
+            } catch {
+                currentVideoId = '';
+            }
+        }
+        const formattedContent = formatCommentRuns(runs, currentVideoId);
+        comment.commentRenderer.contentText.fullText = formattedContent.fullText || baseText;
+        comment.commentRenderer.contentText.renderFullText =
+            formattedContent.renderFullText || formattedContent.fullText || baseText;
+        if (formattedContent.isTimeline) {
+            comment.commentRenderer.isTimeLine = 'timeline';
+        }
+
         const publishedTime = wrapTryCatch(() => update.properties?.publishedTime) || '';
         if (publishedTime) {
             comment.commentRenderer.publishedTimeText = {
@@ -342,25 +451,6 @@ export function generateCommentObjectFromFW(params: {
                     }
                 ]
             };
-        }
-
-        if (typeof window !== 'undefined') {
-            try {
-                const hasTimeline =
-                    Array.isArray(runs) &&
-                    runs.some((r: any) => {
-                        const vId = wrapTryCatch(() => r.navigationEndpoint.watchEndpoint.videoId) as any;
-                        const v = wrapTryCatch(() => r.navigationEndpoint.watchEndpoint.startTimeSeconds) as any;
-                        const n = typeof v === 'string' ? parseInt(v, 10) : v;
-                        const currentVideoId = (getVideoId(window.location.href) || '') as string;
-                        return Number.isFinite(n) && n >= 0 && String(vId || '') === String(currentVideoId || '');
-                    });
-                if (hasTimeline) {
-                    comment.commentRenderer.isTimeLine = 'timeline';
-                }
-            } catch {
-                // ignore timeline detection errors
-            }
         }
 
         if (surfaceUpdate) {
@@ -687,87 +777,21 @@ export function prepareFieldsComment(cmnt: any): object {
 function enrichCommentRenderer(comment: any, currentVideoId: string, originComment?: any, type: 'C' | 'R' = 'C'): any {
     if (!comment?.commentRenderer) return undefined;
 
-    const runs = comment.commentRenderer?.contentText?.runs || [];
-    let fullTextComment = '';
-    let renderFullTextComment = '';
-
-    for (const partTextComment of runs) {
-        let text = '';
-        let navigationEndpoint: any;
-        try {
-            text =
-                (partTextComment as any)?.text ??
-                (partTextComment as any)?.simpleText ??
-                (wrapTryCatch(() => (partTextComment as any)?.textRun?.content) as string) ??
-                (wrapTryCatch(() => (partTextComment as any)?.textRun?.text) as string) ??
-                (wrapTryCatch(() => (partTextComment as any)?.content) as string) ??
-                '';
-            navigationEndpoint =
-                (partTextComment as any)?.navigationEndpoint ??
-                wrapTryCatch(() => (partTextComment as any)?.textRun?.navigationEndpoint);
-
-            fullTextComment += text || '';
-
-            if (parseInt(wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds) as any) >= 0) {
-                const linkVideoId = (wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.videoId) || '') as string;
-                const isSameVideo = String(linkVideoId || '') === String(currentVideoId || '');
-                const timeValue = wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.startTimeSeconds) || '';
-                renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${timeValue}s" data-offsetvideo="${timeValue}" data-video-id="${linkVideoId}">${text || ''}</a>`;
-                if (isSameVideo && comment.commentRenderer) {
-                    comment.commentRenderer.isTimeLine = 'timeline';
-                }
-            } else if (navigationEndpoint) {
-                const href = (wrapTryCatch(() => navigationEndpoint?.browseEndpoint?.canonicalBaseUrl) ||
-                    wrapTryCatch(() => navigationEndpoint?.urlEndpoint?.url) ||
-                    wrapTryCatch(() => navigationEndpoint?.commandMetadata?.webCommandMetadata?.url) ||
-                    text ||
-                    '#') as string;
-                renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${text || ''}</a>`;
-            } else if (wrapTryCatch(() => (partTextComment as any).emoji)) {
-                const url =
-                    wrapTryCatch(() => {
-                        const thumbnails = (partTextComment as any).emoji.image.thumbnails;
-                        return thumbnails[thumbnails.length - 1].url;
-                    }) || '';
-                const alt = (wrapTryCatch(() => (partTextComment as any).emoji.shortcuts?.[0]) as string) || '';
-                const style = `margin-left: 2px; margin-right: 2px;`;
-                renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
-            } else if (wrapTryCatch(() => (partTextComment as any).attachment?.image)) {
-                const image: any = wrapTryCatch(() => (partTextComment as any).attachment.image);
-                const url = image?.url || '';
-                const width = image?.width || 24;
-                const height = image?.height || 24;
-                const margin = image?.margin || { left: 0, right: 0 };
-                const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
-                const alt = text || '';
-                renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
-            } else {
-                renderFullTextComment += text || '';
-            }
-        } catch (e) {
-            console.error(e);
-            const fallbackText: string = ((): string => {
-                try {
-                    const t =
-                        (partTextComment as any)?.text ??
-                        (partTextComment as any)?.simpleText ??
-                        (wrapTryCatch(() => (partTextComment as any)?.textRun?.content) as string) ??
-                        (wrapTryCatch(() => (partTextComment as any)?.textRun?.text) as string) ??
-                        (wrapTryCatch(() => (partTextComment as any)?.content) as string) ??
-                        '';
-                    return typeof t === 'string' ? t : '';
-                } catch {
-                    return '';
-                }
-            })();
-            renderFullTextComment += fallbackText;
-            fullTextComment += fallbackText;
+    try {
+        const contentText = comment.commentRenderer.contentText || {};
+        const runs = contentText?.runs || [];
+        const formatted = formatCommentRuns(runs, currentVideoId);
+        const existingFullText = (contentText as any).fullText || '';
+        const computedFullText = formatted.fullText || existingFullText || '';
+        contentText.fullText = computedFullText;
+        contentText.renderFullText =
+            formatted.renderFullText || (contentText as any).renderFullText || computedFullText;
+        comment.commentRenderer.contentText = contentText;
+        if (formatted.isTimeline) {
+            comment.commentRenderer.isTimeLine = 'timeline';
         }
-    }
-
-    if (comment.commentRenderer?.contentText) {
-        comment.commentRenderer.contentText.fullText = fullTextComment;
-        comment.commentRenderer.contentText.renderFullText = renderFullTextComment;
+    } catch (e) {
+        console.error(e);
     }
 
     comment.typeComment = type;

--- a/app/tests/innertube-comments-pipeline.test.ts
+++ b/app/tests/innertube-comments-pipeline.test.ts
@@ -167,6 +167,97 @@ test('processParentComment collects replies and reply continuations', () => {
     });
 });
 
+test('processParentComment formats timeline links, external links, emojis, and attachments consistently', () => {
+    const runs = [
+        { text: 'See ' },
+        {
+            text: '1:23',
+            navigationEndpoint: {
+                watchEndpoint: {
+                    startTimeSeconds: 83,
+                    videoId: 'video-1'
+                }
+            }
+        },
+        { text: ' example ' },
+        {
+            text: 'docs',
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: 'https://example.com'
+                }
+            }
+        },
+        {
+            text: ' :smile:',
+            emoji: {
+                image: {
+                    thumbnails: [
+                        { url: 'https://example.com/smile-small.png' },
+                        { url: 'https://example.com/smile.png' }
+                    ]
+                },
+                shortcuts: [':smile:']
+            }
+        },
+        {
+            text: ' [img]',
+            attachment: {
+                image: {
+                    url: 'https://example.com/image.png',
+                    width: 48,
+                    height: 48,
+                    margin: { left: 1, right: 2 }
+                }
+            }
+        }
+    ];
+    const parentRuns = JSON.parse(JSON.stringify(runs));
+    const replyRuns = JSON.parse(JSON.stringify(runs));
+    const thread = createParentThread({
+        commentId: 'parent-format',
+        contentText: { runs: parentRuns }
+    });
+    thread.commentThreadRenderer.replies = {
+        commentRepliesRenderer: {
+            contents: [
+                {
+                    commentRenderer: {
+                        commentId: 'reply-format',
+                        contentText: { runs: replyRuns },
+                        publishedTimeText: { runs: [{ text: 'just now' }] }
+                    }
+                }
+            ]
+        }
+    };
+
+    const result = processParentComment({ item: thread, frameworkUpdates: {}, currentVideoId: 'video-1' });
+
+    const parent = result.comments.find((c: any) => c.typeComment === 'C') as any;
+    const reply = result.comments.find((c: any) => c.typeComment === 'R') as any;
+
+    assert.ok(parent);
+    assert.ok(reply);
+    assert.strictEqual(parent.commentRenderer.contentText.fullText, 'See 1:23 example docs :smile: [img]');
+    assert.strictEqual(parent.commentRenderer.contentText.fullText, reply.commentRenderer.contentText.fullText);
+    assert.strictEqual(
+        parent.commentRenderer.contentText.renderFullText,
+        reply.commentRenderer.contentText.renderFullText
+    );
+
+    const rendered = parent.commentRenderer.contentText.renderFullText;
+    assert.ok(rendered.includes('ycs-goto-comment-time'));
+    assert.ok(rendered.includes('href="https://www.youtube.com/watch?v=video-1&t=83s"'));
+    assert.ok(rendered.includes('data-video-id="video-1"'));
+    assert.ok(rendered.includes('ycs-comment-link'));
+    assert.ok(rendered.includes('href="https://example.com"'));
+    const attachmentMatches = rendered.match(/class="ycs-attachment"/g) || [];
+    assert.strictEqual(attachmentMatches.length, 2);
+    assert.strictEqual(parent.commentRenderer.isTimeLine, 'timeline');
+    assert.strictEqual(reply.commentRenderer.isTimeLine, 'timeline');
+});
+
 test('processParentComment applies framework updates for creator flag', () => {
     const thread = createParentThread();
     const frameworkUpdates = {


### PR DESCRIPTION
## Summary
- add a shared `formatCommentRuns` helper to normalize comment run formatting and expose `FormattedCommentContent`
- update comment enrichment to reuse the helper and ensure timeline detection and render output stay consistent
- extend pipeline tests to cover timeline links, emojis, and attachments for both parent comments and replies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f98e571adc83299660cf394d4e3ca4