### PR TITLE
fix(init): enhance initialization reliability and add UI recovery mechanism

### DIFF
--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1317,11 +1317,21 @@ export function initApp(): void {
                 document.querySelector('#meta.style-scope.ytd-watch-flexy') &&
                 prevUrl !== getCleanUrlVideo(window.location.href)
             ) {
-                prevUrl = getCleanUrlVideo(window.location.href);
-                // console.log('prevUrl After: ', prevUrl);
+                const currentUrl = getCleanUrlVideo(window.location.href);
 
                 getController(state).abort();
                 app();
+
+                // Only update prevUrl after confirming .ycs-app was successfully created
+                // If DOM insertion failed, next interval tick will retry
+                if (document.querySelector('.ycs-app')) {
+                    prevUrl = currentUrl;
+                    if (DEBUG) {
+                        console.log('YCS: Video switch successful, prevUrl updated to:', prevUrl);
+                    }
+                } else if (DEBUG) {
+                    console.log('YCS: .ycs-app not found after app(), will retry on next interval');
+                }
             }
         }, 1000);
 

--- a/app/src/source/web-resources/bootstrap.ts
+++ b/app/src/source/web-resources/bootstrap.ts
@@ -5,9 +5,141 @@ const DEBUG = false;
 const META_SELECTOR = '#meta.style-scope.ytd-watch-flexy';
 
 let hasStarted = false;
+let mutationObserver: MutationObserver | null = null;
+let isRetryingApp = false;
+let lastRetryTime = 0;
+let pendingVerificationTimer: number | null = null;
+const RETRY_THROTTLE_MS = 1000;
 
 const metaElementExists = (): Element | null => {
     return document.querySelector(META_SELECTOR);
+};
+
+/**
+ * Throttled version of retryApp with state protection
+ * Prevents multiple simultaneous retries and rate-limits execution
+ */
+const throttledRetryApp = (): void => {
+    const now = Date.now();
+
+    // Throttle check: maximum once per second
+    if (now - lastRetryTime < RETRY_THROTTLE_MS) {
+        if (DEBUG) {
+            console.log('YCS: throttledRetryApp skipped - within throttle window');
+        }
+        return;
+    }
+
+    // State check: prevent concurrent execution
+    if (isRetryingApp) {
+        if (DEBUG) {
+            console.log('YCS: throttledRetryApp skipped - already retrying');
+        }
+        return;
+    }
+
+    // Check if .ycs-app actually disappeared
+    if (document.querySelector('.ycs-app')) {
+        if (DEBUG) {
+            console.log('YCS: throttledRetryApp skipped - UI still exists');
+        }
+        return;
+    }
+
+    isRetryingApp = true;
+    lastRetryTime = now;
+
+    const didRetry = retryApp();
+
+    if (DEBUG && didRetry) {
+        console.log('YCS: UI recovered via throttled retry');
+    }
+
+    // Reset state with delay to avoid immediate re-trigger
+    setTimeout(() => {
+        isRetryingApp = false;
+    }, 500);
+};
+
+/**
+ * Setup MutationObserver to detect when .ycs-app is removed from DOM
+ * This handles cases where YouTube re-renders #meta without URL change
+ */
+const setupDOMObserver = (): void => {
+    // Clean up existing observer
+    if (mutationObserver) {
+        mutationObserver.disconnect();
+        mutationObserver = null;
+    }
+
+    // Find observation target (priority order)
+    const observeTarget =
+        document.querySelector('ytd-watch-flexy') || // Top-level container
+        document.querySelector('#columns') || // Main content area
+        document.querySelector('#primary'); // Fallback container
+
+    if (!observeTarget) {
+        if (DEBUG) {
+            console.warn('YCS: No suitable DOM observer target found');
+        }
+        return;
+    }
+
+    mutationObserver = new MutationObserver((mutations) => {
+        // Check if .ycs-app was removed
+        for (const mutation of mutations) {
+            if (mutation.type === 'childList' && mutation.removedNodes.length > 0) {
+                for (const node of mutation.removedNodes) {
+                    if (
+                        node instanceof Element &&
+                        (node.classList.contains('ycs-app') || node.querySelector('.ycs-app'))
+                    ) {
+                        if (DEBUG) {
+                            console.log('YCS: Detected .ycs-app removal, scheduling verification check');
+                        }
+
+                        // Skip if verification timer is already pending
+                        if (pendingVerificationTimer !== null) {
+                            if (DEBUG) {
+                                console.log('YCS: Verification check already scheduled, skipping duplicate');
+                            }
+                            return;
+                        }
+
+                        // Delay check to avoid false positives during normal app() re-rendering
+                        // If app() is doing removeNodeList() + renderLoadComments(), the UI will
+                        // be restored before this timeout fires
+                        pendingVerificationTimer = window.setTimeout(() => {
+                            pendingVerificationTimer = null;
+
+                            if (!document.querySelector('.ycs-app')) {
+                                if (DEBUG) {
+                                    console.log('YCS: Confirmed .ycs-app still missing, triggering recovery');
+                                }
+                                throttledRetryApp();
+                            } else {
+                                if (DEBUG) {
+                                    console.log('YCS: .ycs-app was restored by normal flow, recovery not needed');
+                                }
+                            }
+                        }, 300); // Wait 300ms to confirm UI is truly missing
+
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    // Start observing
+    mutationObserver.observe(observeTarget, {
+        childList: true,
+        subtree: true
+    });
+
+    if (DEBUG) {
+        console.log('YCS: DOM observer started on', observeTarget.tagName);
+    }
 };
 
 export function startWebResources(): void {
@@ -28,6 +160,9 @@ export function startWebResources(): void {
             console.log(`YCS: Initializing app via ${source}`);
             isInitAppCalled = true;
             initApp();
+            // Setup observer after successful initialization
+            // This ensures observer is attached even when initialized via event listeners
+            setupDOMObserver();
         }
     };
 
@@ -58,7 +193,12 @@ export function startWebResources(): void {
     window.addEventListener('yt-navigate-finish', handleNavigateFinish);
     window.addEventListener('popstate', handlePopState);
 
-    const intervalCheckLoadDOM = setInterval(() => {
+    // Start DOM observer to detect .ycs-app removal
+    setupDOMObserver();
+
+    // Polling fallback mechanism (runs continuously at lower frequency)
+    // No need to store interval ID - runs for entire extension lifecycle
+    setInterval(() => {
         if (!isVideoPage() || !metaElementExists()) {
             return;
         }
@@ -68,17 +208,13 @@ export function startWebResources(): void {
                 console.log('YCS: Initializing app via polling fallback');
                 isInitAppCalled = true;
                 initApp();
+                // Re-setup observer after first successful initialization
+                setupDOMObserver();
                 return;
             }
 
-            const didRetry = retryApp();
-
-            if (DEBUG && !didRetry) {
-                console.log('YCS: retryApp skipped - no app() reference available yet');
-            }
-        } else {
-            console.log('YCS: UI successfully created, stopping polling');
-            clearInterval(intervalCheckLoadDOM);
+            // Use throttled retry to prevent excessive retries
+            throttledRetryApp();
         }
-    }, 1000);
+    }, 2000); // Reduced frequency to 2s since MutationObserver handles most cases
 }

--- a/app/src/source/web-resources/bootstrap.ts
+++ b/app/src/source/web-resources/bootstrap.ts
@@ -9,7 +9,13 @@ let mutationObserver: MutationObserver | null = null;
 let isRetryingApp = false;
 let lastRetryTime = 0;
 let pendingVerificationTimer: number | null = null;
+
+// Timing constants
 const RETRY_THROTTLE_MS = 1000;
+const VERIFICATION_DELAY_MS = 300; // Wait for normal re-renders to complete
+const RETRY_STATE_RESET_DELAY_MS = 500; // Prevent immediate re-trigger
+const POPSTATE_INIT_DELAY_MS = 100; // Wait for YouTube SPA DOM update after popstate
+const POLLING_INTERVAL_MS = 2000; // Fallback polling interval (reduced since MutationObserver handles most cases)
 
 const metaElementExists = (): Element | null => {
     return document.querySelector(META_SELECTOR);
@@ -58,7 +64,7 @@ const throttledRetryApp = (): void => {
     // Reset state with delay to avoid immediate re-trigger
     setTimeout(() => {
         isRetryingApp = false;
-    }, 500);
+    }, RETRY_STATE_RESET_DELAY_MS);
 };
 
 /**
@@ -70,6 +76,12 @@ const setupDOMObserver = (): void => {
     if (mutationObserver) {
         mutationObserver.disconnect();
         mutationObserver = null;
+    }
+
+    // Clean up pending verification timer to prevent orphaned timers
+    if (pendingVerificationTimer !== null) {
+        clearTimeout(pendingVerificationTimer);
+        pendingVerificationTimer = null;
     }
 
     // Find observation target (priority order)
@@ -122,7 +134,7 @@ const setupDOMObserver = (): void => {
                                     console.log('YCS: .ycs-app was restored by normal flow, recovery not needed');
                                 }
                             }
-                        }, 300); // Wait 300ms to confirm UI is truly missing
+                        }, VERIFICATION_DELAY_MS); // Wait for normal re-renders to complete
 
                         return;
                     }
@@ -187,7 +199,7 @@ export function startWebResources(): void {
 
         setTimeout(() => {
             ensureAppInitialized('popstate');
-        }, 100);
+        }, POPSTATE_INIT_DELAY_MS);
     };
 
     window.addEventListener('yt-navigate-finish', handleNavigateFinish);
@@ -216,5 +228,5 @@ export function startWebResources(): void {
             // Use throttled retry to prevent excessive retries
             throttledRetryApp();
         }
-    }, 2000); // Reduced frequency to 2s since MutationObserver handles most cases
+    }, POLLING_INTERVAL_MS);
 }


### PR DESCRIPTION
## Summary

This PR addresses two critical initialization issues in the YCS extension:

1. **Race condition fix**: Prevents the extension from getting stuck when UI creation fails during video navigation
2. **UI recovery mechanism**: Adds a `MutationObserver` to detect and recover when YouTube unexpectedly removes the extension UI

These changes significantly improve the extension's reliability on YouTube's dynamic SPA environment.

## Key Changes

### Race Condition Fix in Video Navigation Flow

**Problem**: When navigating between videos, `prevUrl` was updated immediately before confirming UI creation success. If `app()` failed to insert `.ycs-app`, the next interval tick would not retry because `prevUrl` already matched the current URL.

**Solution**: Only update `prevUrl` after confirming `.ycs-app` exists in the DOM. If UI creation fails, the next interval tick will detect the mismatch and retry initialization.

**Files modified**:
- `appController.ts`: Modified the interval check logic to verify `.ycs-app` presence before updating `prevUrl`

### MutationObserver-Based UI Recovery

**Problem**: YouTube may re-render the `#meta` container without URL changes, removing the extension UI in the process. The existing polling mechanism only triggers on URL changes, leaving the UI lost.

**Solution**: Implemented a `MutationObserver` to watch for `.ycs-app` removal and trigger recovery via `throttledRetryApp()`.

**Features**:
- Observes DOM mutations on `ytd-watch-flexy`, `#columns`, or `#primary` containers
- 300ms verification delay to avoid false positives during normal re-rendering
- Throttled retry mechanism to prevent excessive recovery attempts (max once per second)
- State protection to prevent concurrent retry operations

**Files modified**:
- `bootstrap.ts`: Added `setupDOMObserver()`, `throttledRetryApp()`, and integrated observer setup in initialization flow

### Polling Mechanism Optimization

- Reduced polling frequency from 1s to 2s since `MutationObserver` handles most cases
- Removed interval cleanup logic (observer handles real-time detection)
- Polling now serves as a fallback mechanism
