### PR TITLE
fix(comments): preserve essential metadata in comment processing pipeline

### DIFF
--- a/app/src/source/options/assets/ts/export_comments.ts
+++ b/app/src/source/options/assets/ts/export_comments.ts
@@ -40,6 +40,23 @@ window.onload = async (): Promise<void> => {
             }
         };
 
+        const getTotalLikesText = (cmnt: any): string => {
+            const voteCountText = wrapTryCatch(() => cmnt?.commentRenderer?.voteCount?.simpleText) as
+                | string
+                | undefined;
+            if (typeof voteCountText === 'string' && voteCountText.length > 0) {
+                return voteCountText;
+            }
+            const likeCount = wrapTryCatch(() => cmnt?.commentRenderer?.likeCount) as string | number | undefined;
+            if (typeof likeCount === 'number') {
+                return String(likeCount);
+            }
+            if (typeof likeCount === 'string' && likeCount.length > 0) {
+                return likeCount;
+            }
+            return '0';
+        };
+
         const getProcessShowAllHtml = (): HTMLElement | void => {
             removeNodeList('#ycs_process_show_all_wrap');
 
@@ -195,7 +212,7 @@ Total: ${c.count}\n${c.html}`;
                             ) as string,
                             commentMessage: (cmnt?.commentRenderer?.contentText?.fullText ||
                                 cmnt?.commentRenderer?.renderFullText) as string,
-                            totalLikes: (cmnt?.commentRenderer?.voteCount?.simpleText || '0') as string,
+                            totalLikes: getTotalLikesText(cmnt),
                             member: cmnt?.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer
                                 ?.tooltip as string,
                             commentReplies: {
@@ -238,7 +255,7 @@ Total: ${c.count}\n${c.html}`;
                             ) as string,
                             commentMessage: (cmnt?.commentRenderer?.contentText?.fullText ||
                                 cmnt?.commentRenderer?.renderFullText) as string,
-                            totalLikes: (cmnt?.commentRenderer?.voteCount?.simpleText || '0') as string,
+                            totalLikes: getTotalLikesText(cmnt),
                             member: cmnt?.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer
                                 ?.tooltip as string
                         });

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -663,6 +663,91 @@ export function extractNextContinuation(response: any): { token?: string; clickT
 
 export function prepareFieldsComment(cmnt: any): object {
     try {
+        const preservedAuthorText = wrapTryCatch(() => {
+            const authorText = cmnt.commentRenderer?.authorText;
+            if (!authorText) return undefined;
+            const copy: any = {};
+            if (typeof authorText.simpleText !== 'undefined') {
+                copy.simpleText = authorText.simpleText;
+            }
+            if (Array.isArray(authorText.runs)) {
+                copy.runs = authorText.runs.map((run: any) => {
+                    const runCopy: any = {};
+                    const navigationEndpoint = wrapTryCatch(() => run?.navigationEndpoint);
+                    if (navigationEndpoint) {
+                        runCopy.navigationEndpoint = navigationEndpoint;
+                    }
+                    const text = wrapTryCatch(() => run?.text);
+                    if (typeof text !== 'undefined') {
+                        runCopy.text = text;
+                    }
+                    const simpleRunText = wrapTryCatch(() => run?.simpleText);
+                    if (typeof simpleRunText !== 'undefined') {
+                        runCopy.simpleText = simpleRunText;
+                    }
+                    return runCopy;
+                });
+            }
+            return copy;
+        });
+
+        const preservedAuthorEndpoint = wrapTryCatch(() => {
+            const endpoint = cmnt.commentRenderer?.authorEndpoint;
+            if (!endpoint) return undefined;
+            const url = wrapTryCatch(() => endpoint.commandMetadata?.webCommandMetadata?.url);
+            const browseId = wrapTryCatch(() => endpoint.browseEndpoint?.browseId);
+            const canonicalBaseUrl = wrapTryCatch(() => endpoint.browseEndpoint?.canonicalBaseUrl);
+            return { url, browseId, canonicalBaseUrl };
+        });
+
+        const preservedPublishedTimeTextRuns = wrapTryCatch(() => {
+            const runs = cmnt.commentRenderer?.publishedTimeText?.runs;
+            if (!Array.isArray(runs)) return undefined;
+            return runs.map((run: any) => {
+                const text = wrapTryCatch(() => run?.text);
+                return typeof text !== 'undefined' ? { text } : {};
+            });
+        });
+
+        const preservedContentRuns = wrapTryCatch(() => {
+            const runs = cmnt.commentRenderer?.contentText?.runs;
+            if (!Array.isArray(runs)) return undefined;
+            return runs.map((run: any) => {
+                const runCopy: any = {};
+                const text = wrapTryCatch(() => run?.text);
+                if (typeof text !== 'undefined') {
+                    runCopy.text = text;
+                }
+                const navigationEndpoint = wrapTryCatch(() => run?.navigationEndpoint);
+                if (navigationEndpoint) {
+                    runCopy.navigationEndpoint = navigationEndpoint;
+                }
+                return runCopy;
+            });
+        });
+
+        const preservedVoteCount = wrapTryCatch(() => {
+            const voteCount = cmnt.commentRenderer?.voteCount;
+            if (!voteCount) return undefined;
+            const copy: any = {};
+            const simpleText = wrapTryCatch(() => voteCount.simpleText);
+            if (typeof simpleText !== 'undefined') {
+                copy.simpleText = simpleText;
+            }
+            const runs = wrapTryCatch(() => voteCount.runs);
+            if (Array.isArray(runs)) {
+                copy.runs = runs.map((run: any) => {
+                    const runCopy: any = {};
+                    const text = wrapTryCatch(() => run?.text);
+                    if (typeof text !== 'undefined') {
+                        runCopy.text = text;
+                    }
+                    return runCopy;
+                });
+            }
+            return copy;
+        });
+
         if (wrapTryCatch(() => cmnt.commentRenderer?.actionButtons?.commentActionButtonsRenderer?.creatorHeart)) {
             try {
                 cmnt.commentRenderer.creatorHeart = {
@@ -719,9 +804,7 @@ export function prepareFieldsComment(cmnt: any): object {
 
         wrapTryCatch(() => delete cmnt.commentRenderer.analyticsTrackingParams);
 
-        wrapTryCatch(() => delete cmnt.commentRenderer.authorText.simpleText);
         wrapTryCatch(() => delete cmnt.commentRenderer.authorText.accessibility);
-        wrapTryCatch(() => delete cmnt.commentRenderer.authorText.runs[0].navigationEndpoint);
 
         wrapTryCatch(() => delete cmnt.commentRenderer.authorCommentBadge);
 
@@ -736,10 +819,6 @@ export function prepareFieldsComment(cmnt: any): object {
         });
 
         wrapTryCatch(() => delete cmnt.commentRenderer.authorEndpoint.clickTrackingParams);
-        wrapTryCatch(() => delete cmnt.commentRenderer.authorEndpoint.commandMetadata);
-
-        wrapTryCatch(() => delete cmnt.commentRenderer.authorEndpoint.browseEndpoint.browseId);
-
         wrapTryCatch(() => delete cmnt.commentRenderer.commentSimpleboxEndpoint);
         wrapTryCatch(() => delete cmnt.commentRenderer.commentActionButtonsRenderer);
 
@@ -761,9 +840,14 @@ export function prepareFieldsComment(cmnt: any): object {
             () => delete cmnt.commentRenderer.publishedTimeText.runs[0].navigationEndpoint.clickTrackingParams
         );
 
-        if (wrapTryCatch(() => cmnt.commentRenderer.contentText.runs.length > 0)) {
-            for (const [i, textPart] of cmnt.commentRenderer.contentText.runs.entries()) {
-                if (textPart.navigationEndpoint) {
+        wrapTryCatch(() => {
+            const runs = cmnt.commentRenderer?.contentText?.runs;
+            if (!Array.isArray(runs)) return;
+            for (const [i, textPart] of runs.entries()) {
+                if (!textPart) continue;
+                const originalText = wrapTryCatch(() => textPart?.text);
+                const navEndpoint = wrapTryCatch(() => textPart?.navigationEndpoint);
+                if (navEndpoint) {
                     wrapTryCatch(
                         () =>
                             delete cmnt.commentRenderer.contentText.runs[i].navigationEndpoint.commandMetadata
@@ -784,11 +868,125 @@ export function prepareFieldsComment(cmnt: any): object {
                         () => delete cmnt.commentRenderer.contentText.runs[i].navigationEndpoint.clickTrackingParams
                     );
 
-                    wrapTryCatch(() => delete cmnt.commentRenderer.contentText.runs[i].text);
+                    if (typeof originalText !== 'undefined') {
+                        cmnt.commentRenderer.contentText.runs[i].text = originalText;
+                    }
                 } else {
-                    wrapTryCatch(() => delete cmnt.commentRenderer.contentText.runs[i]);
+                    cmnt.commentRenderer.contentText.runs[i] = {};
+                    if (typeof originalText !== 'undefined') {
+                        cmnt.commentRenderer.contentText.runs[i].text = originalText;
+                    }
                 }
             }
+        });
+
+        if (preservedAuthorText) {
+            cmnt.commentRenderer.authorText = cmnt.commentRenderer.authorText || {};
+            if (typeof preservedAuthorText.simpleText !== 'undefined') {
+                cmnt.commentRenderer.authorText.simpleText = preservedAuthorText.simpleText;
+            }
+            if (Array.isArray(preservedAuthorText.runs)) {
+                cmnt.commentRenderer.authorText.runs = preservedAuthorText.runs.map((run: any, index: number) => {
+                    const sanitized =
+                        (cmnt.commentRenderer.authorText?.runs || [])[index] &&
+                        typeof (cmnt.commentRenderer.authorText?.runs || [])[index] === 'object'
+                            ? { ...(cmnt.commentRenderer.authorText?.runs || [])[index] }
+                            : {};
+                    if (run?.navigationEndpoint) {
+                        sanitized.navigationEndpoint = run.navigationEndpoint;
+                    }
+                    if (typeof run?.text !== 'undefined') {
+                        sanitized.text = run.text;
+                    }
+                    if (typeof run?.simpleText !== 'undefined') {
+                        sanitized.simpleText = run.simpleText;
+                    }
+                    return sanitized;
+                });
+            }
+        }
+
+        if (preservedAuthorEndpoint) {
+            cmnt.commentRenderer.authorEndpoint = cmnt.commentRenderer.authorEndpoint || {};
+            if (typeof preservedAuthorEndpoint.url !== 'undefined') {
+                cmnt.commentRenderer.authorEndpoint.commandMetadata = {
+                    webCommandMetadata: { url: preservedAuthorEndpoint.url }
+                };
+            }
+            if (
+                typeof preservedAuthorEndpoint.browseId !== 'undefined' ||
+                typeof preservedAuthorEndpoint.canonicalBaseUrl !== 'undefined'
+            ) {
+                cmnt.commentRenderer.authorEndpoint.browseEndpoint = {
+                    ...(typeof preservedAuthorEndpoint.browseId !== 'undefined'
+                        ? { browseId: preservedAuthorEndpoint.browseId }
+                        : {}),
+                    ...(typeof preservedAuthorEndpoint.canonicalBaseUrl !== 'undefined'
+                        ? { canonicalBaseUrl: preservedAuthorEndpoint.canonicalBaseUrl }
+                        : {})
+                };
+            }
+        }
+
+        if (Array.isArray(preservedPublishedTimeTextRuns)) {
+            cmnt.commentRenderer.publishedTimeText = cmnt.commentRenderer.publishedTimeText || {};
+            const sanitizedRuns =
+                Array.isArray(cmnt.commentRenderer.publishedTimeText.runs) &&
+                cmnt.commentRenderer.publishedTimeText.runs.length === preservedPublishedTimeTextRuns.length
+                    ? cmnt.commentRenderer.publishedTimeText.runs
+                    : new Array(preservedPublishedTimeTextRuns.length).fill({});
+            cmnt.commentRenderer.publishedTimeText.runs = preservedPublishedTimeTextRuns.map(
+                (run: any, index: number) => {
+                    const sanitized =
+                        sanitizedRuns[index] && typeof sanitizedRuns[index] === 'object'
+                            ? { ...sanitizedRuns[index] }
+                            : {};
+                    if (typeof run?.text !== 'undefined') {
+                        sanitized.text = run.text;
+                    }
+                    return sanitized;
+                }
+            );
+        }
+
+        if (Array.isArray(preservedContentRuns)) {
+            cmnt.commentRenderer.contentText = cmnt.commentRenderer.contentText || {};
+            const sanitizedRuns =
+                Array.isArray(cmnt.commentRenderer.contentText.runs) &&
+                cmnt.commentRenderer.contentText.runs.length === preservedContentRuns.length
+                    ? cmnt.commentRenderer.contentText.runs
+                    : new Array(preservedContentRuns.length).fill({});
+            cmnt.commentRenderer.contentText.runs = preservedContentRuns.map((run: any, index: number) => {
+                const sanitized =
+                    sanitizedRuns[index] && typeof sanitizedRuns[index] === 'object' ? { ...sanitizedRuns[index] } : {};
+                if (typeof run?.text !== 'undefined') {
+                    sanitized.text = run.text;
+                }
+                if (run?.navigationEndpoint) {
+                    sanitized.navigationEndpoint = run.navigationEndpoint;
+                }
+                return sanitized;
+            });
+        }
+
+        if (
+            preservedVoteCount &&
+            (typeof preservedVoteCount.simpleText !== 'undefined' || Array.isArray(preservedVoteCount.runs))
+        ) {
+            const sanitized: any = {};
+            if (typeof preservedVoteCount.simpleText !== 'undefined') {
+                sanitized.simpleText = preservedVoteCount.simpleText;
+            }
+            if (Array.isArray(preservedVoteCount.runs)) {
+                sanitized.runs = preservedVoteCount.runs.map((run: any) => {
+                    const runCopy: any = {};
+                    if (typeof run?.text !== 'undefined') {
+                        runCopy.text = run.text;
+                    }
+                    return runCopy;
+                });
+            }
+            cmnt.commentRenderer.voteCount = sanitized;
         }
 
         return cmnt;

--- a/app/tests/innertube-comments-pipeline.test.ts
+++ b/app/tests/innertube-comments-pipeline.test.ts
@@ -7,6 +7,7 @@ import {
     fetchContinuationBatch,
     fetchInitialCommentBatch,
     generateCommentObjectFromFW,
+    prepareFieldsComment,
     type ReplyContinuation
 } from '../src/source/utils/innertube/comments/pipeline';
 import { setFetchImplementation } from '../src/source/utils/libs';
@@ -271,6 +272,118 @@ test('processParentComment applies framework updates for creator flag', () => {
 
     const parent: any = result.comments[0];
     assert.strictEqual(parent.commentRenderer.authorIsChannelOwner, true);
+});
+
+test('prepareFieldsComment retains metadata required for exports and caching', () => {
+    const originalComment = {
+        commentRenderer: {
+            authorText: {
+                simpleText: 'Author Name',
+                runs: [
+                    {
+                        text: 'Author Name',
+                        navigationEndpoint: {
+                            browseEndpoint: { browseId: 'UC12345', canonicalBaseUrl: '/@author' },
+                            commandMetadata: {
+                                webCommandMetadata: {
+                                    url: '/channel/UC12345',
+                                    apiUrl: '/youtubei/v1/browse',
+                                    rootVe: 123,
+                                    webPageType: 'WEB_PAGE_TYPE_BROWSE'
+                                }
+                            }
+                        }
+                    }
+                ]
+            },
+            authorEndpoint: {
+                commandMetadata: {
+                    webCommandMetadata: {
+                        url: '/channel/UC12345',
+                        apiUrl: '/youtubei/v1/browse',
+                        rootVe: 456,
+                        webPageType: 'WEB_PAGE_TYPE_BROWSE'
+                    }
+                },
+                browseEndpoint: {
+                    browseId: 'UC12345',
+                    canonicalBaseUrl: '/@author',
+                    params: 'extra'
+                },
+                clickTrackingParams: 'tracking'
+            },
+            publishedTimeText: {
+                runs: [
+                    {
+                        text: '2 hours ago',
+                        navigationEndpoint: {
+                            commandMetadata: {
+                                webCommandMetadata: {
+                                    webPageType: 'WEB_PAGE_TYPE_BROWSE'
+                                }
+                            },
+                            watchEndpoint: { params: 'detail' },
+                            clickTrackingParams: 'time-tracking'
+                        }
+                    }
+                ]
+            },
+            contentText: {
+                runs: [
+                    {
+                        text: 'with link',
+                        navigationEndpoint: {
+                            browseEndpoint: { browseId: 'UC12345', canonicalBaseUrl: '/@author' },
+                            commandMetadata: {
+                                webCommandMetadata: {
+                                    apiUrl: '/youtubei/v1/browse',
+                                    rootVe: 789,
+                                    webPageType: 'WEB_PAGE_TYPE_BROWSE'
+                                }
+                            },
+                            clickTrackingParams: 'run-1'
+                        }
+                    },
+                    { text: 'just text' }
+                ]
+            },
+            voteCount: {
+                simpleText: '42',
+                runs: [
+                    {
+                        text: '42'
+                    }
+                ],
+                extraData: 'remove me'
+            },
+            likeCount: 41
+        }
+    };
+
+    const prepared = prepareFieldsComment(JSON.parse(JSON.stringify(originalComment)));
+    const renderer: any = prepared.commentRenderer;
+
+    assert.strictEqual(renderer.authorText.simpleText, 'Author Name');
+    assert.ok(renderer.authorText.runs[0].navigationEndpoint);
+    assert.strictEqual(renderer.authorText.runs[0].navigationEndpoint.browseEndpoint.browseId, 'UC12345');
+    assert.strictEqual(renderer.authorEndpoint.commandMetadata.webCommandMetadata.url, '/channel/UC12345');
+    assert.strictEqual(renderer.authorEndpoint.browseEndpoint.browseId, 'UC12345');
+    assert.strictEqual(renderer.authorEndpoint.browseEndpoint.canonicalBaseUrl, '/@author');
+    assert.strictEqual(renderer.publishedTimeText.runs[0].text, '2 hours ago');
+    assert.strictEqual(renderer.contentText.runs[0].text, 'with link');
+    assert.strictEqual(renderer.contentText.runs[1].text, 'just text');
+    assert.strictEqual(renderer.voteCount.simpleText, '42');
+    assert.strictEqual(renderer.voteCount.runs[0].text, '42');
+    assert.strictEqual(renderer.likeCount, 41);
+
+    const serialized = JSON.parse(JSON.stringify(prepared));
+    assert.strictEqual(
+        serialized.commentRenderer.authorEndpoint.commandMetadata.webCommandMetadata.url,
+        '/channel/UC12345'
+    );
+    assert.strictEqual(serialized.commentRenderer.authorEndpoint.browseEndpoint.browseId, 'UC12345');
+    assert.strictEqual(serialized.commentRenderer.contentText.runs[0].text, 'with link');
+    assert.strictEqual(serialized.commentRenderer.voteCount.simpleText, '42');
 });
 
 test('scheduleReplyFetches returns without scheduling when no continuations', async () => {


### PR DESCRIPTION
## Summary
- retain sanitized voteCount data when preparing Innertube comments so cached exports keep like totals
- add export helper to fall back to likeCount when voteCount text is absent
- extend regression test to cover voteCount preservation after serialization

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68fbb81dee2c8329953ac4fe4b1fec62