### PR TITLE
feat(export): add dropdown menu for multiple export formats

### DIFF
--- a/app/manifest.firefox.json
+++ b/app/manifest.firefox.json
@@ -41,7 +41,7 @@
   "web_accessible_resources": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "resources": ["web-resources/*.js", "web-resources/*.js.map"]
+      "resources": ["web-resources/*.js", "web-resources/*.js.map", "xlsx.*.js"]
     }
   ],
   "browser_specific_settings": {

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -41,7 +41,7 @@
   "web_accessible_resources": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "resources": ["web-resources/*.js", "web-resources/*.js.map"]
+      "resources": ["web-resources/*.js", "web-resources/*.js.map", "xlsx.*.js"]
     }
   ]
 }

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -749,6 +749,50 @@ html[dark] #ycs-search-result::-webkit-scrollbar-thumb:hover {
   margin-right: 2px;
 }
 
+/* Dropdown for save button */
+.ycs_dropdown_wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.ycs_dropdown_menu {
+  display: none;
+  position: absolute;
+  top: 20px;
+  left: 0;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  min-width: 80px;
+  z-index: 9999;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+}
+
+html[dark='true'] .ycs_dropdown_menu,
+html[dark] .ycs_dropdown_menu {
+  background: #2b2b2b;
+  border: 1px solid #3e3e3e;
+  color: #fff;
+}
+
+.ycs_dropdown_menu.show {
+  display: block;
+}
+
+.ycs_dropdown_item {
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.ycs_dropdown_item:hover {
+  background: #f0f0f0;
+}
+
+html[dark='true'] .ycs_dropdown_item:hover,
+html[dark] .ycs_dropdown_item:hover {
+  background: #3a3a3a;
+}
+
 html[dark='true'] .ycs-infobar__search button,
 html[dark] .ycs-infobar__search button {
   border: 0;

--- a/app/src/source/options/assets/ts/export_comments.ts
+++ b/app/src/source/options/assets/ts/export_comments.ts
@@ -8,7 +8,8 @@ import {
     getCommentsChatHtmlText,
     getCommentsHtmlText,
     getCommentsTrVideoHtmlText,
-    msToRoundSec
+    msToRoundSec,
+    parseFormattedNumberToInt
 } from '../../../utils/formatting';
 import {
     getSheetChatComments,
@@ -40,21 +41,23 @@ window.onload = async (): Promise<void> => {
             }
         };
 
-        const getTotalLikesText = (cmnt: any): string => {
+        const getTotalLikesCount = (cmnt: any): number => {
             const voteCountText = wrapTryCatch(() => cmnt?.commentRenderer?.voteCount?.simpleText) as
                 | string
                 | undefined;
-            if (typeof voteCountText === 'string' && voteCountText.length > 0) {
-                return voteCountText;
-            }
             const likeCount = wrapTryCatch(() => cmnt?.commentRenderer?.likeCount) as string | number | undefined;
-            if (typeof likeCount === 'number') {
-                return String(likeCount);
+
+            // Use nullish coalescing to get the first available value
+            const value = voteCountText ?? likeCount;
+
+            // Convert to number
+            if (typeof value === 'number' && Number.isFinite(value)) {
+                return value;
             }
-            if (typeof likeCount === 'string' && likeCount.length > 0) {
-                return likeCount;
+            if (typeof value === 'string' && value.length > 0) {
+                return parseFormattedNumberToInt(value);
             }
-            return '0';
+            return 0;
         };
 
         const getProcessShowAllHtml = (): HTMLElement | void => {
@@ -212,7 +215,7 @@ Total: ${c.count}\n${c.html}`;
                             ) as string,
                             commentMessage: (cmnt?.commentRenderer?.contentText?.fullText ||
                                 cmnt?.commentRenderer?.renderFullText) as string,
-                            totalLikes: getTotalLikesText(cmnt),
+                            totalLikes: getTotalLikesCount(cmnt),
                             member: cmnt?.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer
                                 ?.tooltip as string,
                             commentReplies: {
@@ -255,7 +258,7 @@ Total: ${c.count}\n${c.html}`;
                             ) as string,
                             commentMessage: (cmnt?.commentRenderer?.contentText?.fullText ||
                                 cmnt?.commentRenderer?.renderFullText) as string,
-                            totalLikes: getTotalLikesText(cmnt),
+                            totalLikes: getTotalLikesCount(cmnt),
                             member: cmnt?.commentRenderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer
                                 ?.tooltip as string
                         });

--- a/app/src/source/utils/interfaces/i_export_comments.ts
+++ b/app/src/source/utils/interfaces/i_export_comments.ts
@@ -15,7 +15,7 @@ export interface IReply {
     };
     commentMessage: string;
     publishedTimeText: string;
-    totalLikes: string;
+    totalLikes: number;
     member: string;
 }
 
@@ -28,7 +28,7 @@ export interface IComment {
     };
     commentMessage: string;
     publishedTimeText: string;
-    totalLikes: string;
+    totalLikes: number;
     member: string;
     commentReplies?: {
         replies: IReply[];

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -14,6 +14,7 @@ import {
     DonatedChipViewModel
 } from './viewModels';
 import { iconExpand, iconExpandShowMore, iconReload, iconSortDown } from './icons';
+import { EXPORT_FORMAT } from '../web-resources/services/exportService';
 
 // Debug mode configuration
 // Set to true for detailed diagnostic logs during development
@@ -762,9 +763,9 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
                                         save ▾
                                     </button>
                                     <div id="ycs_save_all_comments_menu" class="ycs_dropdown_menu" aria-hidden="true">
-                                        <div class="ycs_dropdown_item" data-format="txt">.TXT</div>
-                                        <div class="ycs_dropdown_item" data-format="json">.JSON</div>
-                                        <div class="ycs_dropdown_item" data-format="xlsx">.XLSX</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.TXT}">.TXT</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.JSON}">.JSON</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.XLSX}">.XLSX</div>
                                     </div>
                                 </div>
                             </div>
@@ -796,9 +797,9 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
                                         save ▾
                                     </button>
                                     <div id="ycs_save_all_comments_chat_menu" class="ycs_dropdown_menu" aria-hidden="true">
-                                        <div class="ycs_dropdown_item" data-format="txt">.TXT</div>
-                                        <div class="ycs_dropdown_item" data-format="json">.JSON</div>
-                                        <div class="ycs_dropdown_item" data-format="xlsx">.XLSX</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.TXT}">.TXT</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.JSON}">.JSON</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.XLSX}">.XLSX</div>
                                     </div>
                                 </div>
                             </div>
@@ -829,9 +830,9 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
                                         save ▾
                                     </button>
                                     <div id="ycs_save_all_comments_trvideo_menu" class="ycs_dropdown_menu" aria-hidden="true">
-                                        <div class="ycs_dropdown_item" data-format="txt">.TXT</div>
-                                        <div class="ycs_dropdown_item" data-format="json">.JSON</div>
-                                        <div class="ycs_dropdown_item" data-format="xlsx">.XLSX</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.TXT}">.TXT</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.JSON}">.JSON</div>
+                                        <div class="ycs_dropdown_item" data-format="${EXPORT_FORMAT.XLSX}">.XLSX</div>
                                     </div>
                                 </div>
                             </div>

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -756,11 +756,16 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
                                         open
                                     </button>
                                 </div>
-                                <div class="ycs_save_wrap">
-                                    <button id="ycs_save_all_comments" class="ycs-btn-search ycs-title" name="Save comments to file"
+                                <div class="ycs_save_wrap ycs_dropdown_wrap">
+                                    <button id="ycs_save_all_comments" class="ycs-btn-search ycs-title ycs_dropdown_trigger" name="Save comments to file"
                                         title="Save comments to file">
-                                        save
+                                        save ▾
                                     </button>
+                                    <div id="ycs_save_all_comments_menu" class="ycs_dropdown_menu" aria-hidden="true">
+                                        <div class="ycs_dropdown_item" data-format="txt">.TXT</div>
+                                        <div class="ycs_dropdown_item" data-format="json">.JSON</div>
+                                        <div class="ycs_dropdown_item" data-format="xlsx">.XLSX</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -785,11 +790,16 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
                                         open
                                     </button>
                                 </div>
-                                <div class="ycs_save_wrap">
-                                    <button id="ycs_save_all_comments_chat" class="ycs-btn-search ycs-title"
+                                <div class="ycs_save_wrap ycs_dropdown_wrap">
+                                    <button id="ycs_save_all_comments_chat" class="ycs-btn-search ycs-title ycs_dropdown_trigger"
                                         name="Save chat comments to file" title="Save chat comments to file">
-                                        save
+                                        save ▾
                                     </button>
+                                    <div id="ycs_save_all_comments_chat_menu" class="ycs_dropdown_menu" aria-hidden="true">
+                                        <div class="ycs_dropdown_item" data-format="txt">.TXT</div>
+                                        <div class="ycs_dropdown_item" data-format="json">.JSON</div>
+                                        <div class="ycs_dropdown_item" data-format="xlsx">.XLSX</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -813,11 +823,16 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
                                         open
                                     </button>
                                 </div>
-                                <div class="ycs_save_wrap">
-                                    <button id="ycs_save_all_comments_trvideo" class="ycs-btn-search ycs-title"
+                                <div class="ycs_save_wrap ycs_dropdown_wrap">
+                                    <button id="ycs_save_all_comments_trvideo" class="ycs-btn-search ycs-title ycs_dropdown_trigger"
                                         name="Save transcript video to file" title="Save transcript video to file">
-                                        save
+                                        save ▾
                                     </button>
+                                    <div id="ycs_save_all_comments_trvideo_menu" class="ycs_dropdown_menu" aria-hidden="true">
+                                        <div class="ycs_dropdown_item" data-format="txt">.TXT</div>
+                                        <div class="ycs_dropdown_item" data-format="json">.JSON</div>
+                                        <div class="ycs_dropdown_item" data-format="xlsx">.XLSX</div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -24,7 +24,13 @@ import {
     openChatWindow,
     openCommentsWindow,
     openTranscriptWindow,
-    ExportMeta
+    ExportMeta,
+    downloadCommentsFileJSON,
+    downloadCommentsFileXLSX,
+    downloadChatFileJSON,
+    downloadChatFileXLSX,
+    downloadTranscriptFileJSON,
+    downloadTranscriptFileXLSX
 } from './services/exportService';
 import {
     clearComments,
@@ -760,6 +766,18 @@ export function initApp(): void {
             });
         }
 
+        // Ensure only one dropdown is open at a time
+        const closeAllDropdowns = (except?: HTMLElement | null) => {
+            try {
+                const menus = document.querySelectorAll('.ycs_dropdown_menu.show');
+                menus.forEach((m) => {
+                    if (m !== except) m.classList.remove('show');
+                });
+            } catch (err) {
+                // ignore
+            }
+        };
+
         const btnOpenCommentsNewWindow = document.getElementById('ycs_open_all_comments_window');
         btnOpenCommentsNewWindow?.addEventListener('click', () => {
             const comments = getComments(state);
@@ -773,16 +791,40 @@ export function initApp(): void {
             }
         });
 
+        // Comments save dropdown
         const btnSaveCommentsToFile = document.getElementById('ycs_save_all_comments');
-        btnSaveCommentsToFile?.addEventListener('click', () => {
-            const comments = getComments(state);
-            if (comments.length === 0) return;
-
+        const btnSaveCommentsToFileMenu = document.getElementById('ycs_save_all_comments_menu');
+        btnSaveCommentsToFile?.addEventListener('click', (e) => {
             try {
-                downloadCommentsFile(comments, buildExportMeta());
-            } catch (e) {
-                console.error(e);
-                return;
+                e.stopPropagation();
+                if (!btnSaveCommentsToFileMenu) return;
+                // close others first
+                closeAllDropdowns(btnSaveCommentsToFileMenu);
+                btnSaveCommentsToFileMenu.classList.toggle('show');
+            } catch (err) {
+                console.error(err);
+            }
+        });
+
+        btnSaveCommentsToFileMenu?.addEventListener('click', (ev) => {
+            try {
+                const target = ev.target as HTMLElement | null;
+                if (!target) return;
+                const fmt = target.dataset.format;
+                const comments = getComments(state);
+                if (!comments || comments.length === 0) return;
+
+                if (fmt === 'txt') {
+                    downloadCommentsFile(comments, buildExportMeta());
+                } else if (fmt === 'json') {
+                    downloadCommentsFileJSON(comments, buildExportMeta());
+                } else if (fmt === 'xlsx') {
+                    downloadCommentsFileXLSX(comments, buildExportMeta());
+                }
+
+                btnSaveCommentsToFileMenu.classList.remove('show');
+            } catch (err) {
+                console.error(err);
             }
         });
 
@@ -799,16 +841,41 @@ export function initApp(): void {
             }
         });
 
+        // Chat save dropdown
         const btnSaveCommentsChatToFile = document.getElementById('ycs_save_all_comments_chat');
-        btnSaveCommentsChatToFile?.addEventListener('click', () => {
-            const commentsChat = getCommentsChat(state);
-            if (commentsChat.size === 0) return;
-
+        const btnSaveCommentsChatToFileMenu = document.getElementById('ycs_save_all_comments_chat_menu');
+        btnSaveCommentsChatToFile?.addEventListener('click', (e) => {
             try {
-                downloadChatFile([...commentsChat.values()], buildExportMeta());
-            } catch (e) {
-                console.error(e);
-                return;
+                e.stopPropagation();
+                if (!btnSaveCommentsChatToFileMenu) return;
+                // close others first
+                closeAllDropdowns(btnSaveCommentsChatToFileMenu);
+                btnSaveCommentsChatToFileMenu.classList.toggle('show');
+            } catch (err) {
+                console.error(err);
+            }
+        });
+
+        btnSaveCommentsChatToFileMenu?.addEventListener('click', (ev) => {
+            try {
+                const target = ev.target as HTMLElement | null;
+                if (!target) return;
+                const fmt = target.dataset.format;
+                const commentsChat = getCommentsChat(state);
+                if (!commentsChat || commentsChat.size === 0) return;
+                const arr = [...commentsChat.values()];
+
+                if (fmt === 'txt') {
+                    downloadChatFile(arr, buildExportMeta());
+                } else if (fmt === 'json') {
+                    downloadChatFileJSON(arr, buildExportMeta());
+                } else if (fmt === 'xlsx') {
+                    downloadChatFileXLSX(arr, buildExportMeta());
+                }
+
+                btnSaveCommentsChatToFileMenu.classList.remove('show');
+            } catch (err) {
+                console.error(err);
             }
         });
 
@@ -828,17 +895,53 @@ export function initApp(): void {
             }
         });
 
+        // Transcript save dropdown
         const btnSaveCommentsTrVideoToFile = document.getElementById('ycs_save_all_comments_trvideo');
-        btnSaveCommentsTrVideoToFile?.addEventListener('click', () => {
+        const btnSaveCommentsTrVideoToFileMenu = document.getElementById('ycs_save_all_comments_trvideo_menu');
+        btnSaveCommentsTrVideoToFile?.addEventListener('click', (e) => {
             try {
+                e.stopPropagation();
+                if (!btnSaveCommentsTrVideoToFileMenu) return;
+                // close others first
+                closeAllDropdowns(btnSaveCommentsTrVideoToFileMenu);
+                btnSaveCommentsTrVideoToFileMenu.classList.toggle('show');
+            } catch (err) {
+                console.error(err);
+            }
+        });
+
+        btnSaveCommentsTrVideoToFileMenu?.addEventListener('click', (ev) => {
+            try {
+                const target = ev.target as HTMLElement | null;
+                if (!target) return;
+                const fmt = target.dataset.format;
                 const commentsTrVideo = getCommentsTrVideo(state);
                 const cueGroups = extractCueGroups(commentsTrVideo);
-                if (cueGroups && cueGroups.length > 0) {
+                if (!cueGroups || cueGroups.length === 0) return;
+
+                if (fmt === 'txt') {
                     downloadTranscriptFile(cueGroups, buildExportMeta());
+                } else if (fmt === 'json') {
+                    downloadTranscriptFileJSON(cueGroups, buildExportMeta());
+                } else if (fmt === 'xlsx') {
+                    downloadTranscriptFileXLSX(cueGroups, buildExportMeta());
                 }
-            } catch (e) {
-                console.error(e);
-                return;
+
+                btnSaveCommentsTrVideoToFileMenu.classList.remove('show');
+            } catch (err) {
+                console.error(err);
+            }
+        });
+
+        // Close dropdowns when clicking outside
+        document.addEventListener('click', (ev) => {
+            try {
+                const t = ev.target as HTMLElement | null;
+                if (t && t.closest && t.closest('.ycs_dropdown_wrap')) return;
+
+                closeAllDropdowns();
+            } catch (err) {
+                // ignore
             }
         });
 

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -30,8 +30,10 @@ import {
     downloadChatFileJSON,
     downloadChatFileXLSX,
     downloadTranscriptFileJSON,
-    downloadTranscriptFileXLSX
+    downloadTranscriptFileXLSX,
+    EXPORT_FORMAT
 } from './services/exportService';
+import type { ExportFormat } from './services/exportService';
 import {
     clearComments,
     clearCommentsChat,
@@ -76,7 +78,14 @@ const TRANSCRIPT_UNSUPPORTED_FILTERS = [
 
 type SortAttribute = 'sort' | 'sortChat' | 'sortTrp';
 
+const dropdownMenus = new Set<HTMLElement>();
+
 let filterRegistry: FilterButtonRegistry | null = null;
+let handleDocumentClick: ((ev: MouseEvent) => void) | null = null;
+
+const isExportFormat = (value: string | undefined): value is ExportFormat => {
+    return value === EXPORT_FORMAT.TXT || value === EXPORT_FORMAT.JSON || value === EXPORT_FORMAT.XLSX;
+};
 
 const getSortableButtonIds = (): string[] => {
     if (filterRegistry?.sortButtonIds?.length) {
@@ -188,6 +197,11 @@ export function initApp(): void {
         updateBadge('NUMBER_COMMENTS', '');
 
         removeNodeList('.ycs-app');
+        dropdownMenus.clear();
+        if (handleDocumentClick) {
+            document.removeEventListener('click', handleDocumentClick);
+            handleDocumentClick = null;
+        }
 
         // Try new insertion points first (between expandable-metadata and ticket-shelf)
         if (document.querySelector('#expandable-metadata.ytd-watch-flexy')) {
@@ -766,16 +780,59 @@ export function initApp(): void {
             });
         }
 
-        // Ensure only one dropdown is open at a time
-        const closeAllDropdowns = (except?: HTMLElement | null) => {
-            try {
-                const menus = document.querySelectorAll('.ycs_dropdown_menu.show');
-                menus.forEach((m) => {
-                    if (m !== except) m.classList.remove('show');
-                });
-            } catch (err) {
-                // ignore
+        const setMenuVisibility = (menu: HTMLElement | null, visible: boolean): void => {
+            if (!menu) return;
+            if (visible) {
+                menu.classList.add('show');
+            } else {
+                menu.classList.remove('show');
             }
+            menu.setAttribute('aria-hidden', visible ? 'false' : 'true');
+        };
+
+        const closeAllDropdowns = (except?: HTMLElement | null): void => {
+            dropdownMenus.forEach((menu) => {
+                if (menu !== except) {
+                    setMenuVisibility(menu, false);
+                }
+            });
+        };
+
+        const setupDropdown = (
+            trigger: HTMLElement | null,
+            menu: HTMLElement | null,
+            onSelect: (format: ExportFormat) => void
+        ): void => {
+            if (!trigger || !menu) return;
+
+            dropdownMenus.add(menu);
+            setMenuVisibility(menu, false);
+
+            trigger.addEventListener('click', (event) => {
+                try {
+                    event.stopPropagation();
+                    closeAllDropdowns(menu);
+                    const shouldShow = !menu.classList.contains('show');
+                    setMenuVisibility(menu, shouldShow);
+                } catch (err) {
+                    console.error(err);
+                }
+            });
+
+            menu.addEventListener('click', (event) => {
+                try {
+                    const target = event.target as HTMLElement | null;
+                    if (!target) return;
+                    const format = target.dataset.format;
+                    if (!isExportFormat(format)) return;
+
+                    onSelect(format);
+                } catch (err) {
+                    console.error(err);
+                } finally {
+                    setMenuVisibility(menu, false);
+                }
+            });
         };
 
         const btnOpenCommentsNewWindow = document.getElementById('ycs_open_all_comments_window');
@@ -794,37 +851,16 @@ export function initApp(): void {
         // Comments save dropdown
         const btnSaveCommentsToFile = document.getElementById('ycs_save_all_comments');
         const btnSaveCommentsToFileMenu = document.getElementById('ycs_save_all_comments_menu');
-        btnSaveCommentsToFile?.addEventListener('click', (e) => {
-            try {
-                e.stopPropagation();
-                if (!btnSaveCommentsToFileMenu) return;
-                // close others first
-                closeAllDropdowns(btnSaveCommentsToFileMenu);
-                btnSaveCommentsToFileMenu.classList.toggle('show');
-            } catch (err) {
-                console.error(err);
-            }
-        });
+        setupDropdown(btnSaveCommentsToFile, btnSaveCommentsToFileMenu, (format) => {
+            const comments = getComments(state);
+            if (!comments || comments.length === 0) return;
 
-        btnSaveCommentsToFileMenu?.addEventListener('click', (ev) => {
-            try {
-                const target = ev.target as HTMLElement | null;
-                if (!target) return;
-                const fmt = target.dataset.format;
-                const comments = getComments(state);
-                if (!comments || comments.length === 0) return;
-
-                if (fmt === 'txt') {
-                    downloadCommentsFile(comments, buildExportMeta());
-                } else if (fmt === 'json') {
-                    downloadCommentsFileJSON(comments, buildExportMeta());
-                } else if (fmt === 'xlsx') {
-                    downloadCommentsFileXLSX(comments, buildExportMeta());
-                }
-
-                btnSaveCommentsToFileMenu.classList.remove('show');
-            } catch (err) {
-                console.error(err);
+            if (format === EXPORT_FORMAT.TXT) {
+                downloadCommentsFile(comments, buildExportMeta());
+            } else if (format === EXPORT_FORMAT.JSON) {
+                downloadCommentsFileJSON(comments, buildExportMeta());
+            } else if (format === EXPORT_FORMAT.XLSX) {
+                downloadCommentsFileXLSX(comments, buildExportMeta());
             }
         });
 
@@ -844,38 +880,17 @@ export function initApp(): void {
         // Chat save dropdown
         const btnSaveCommentsChatToFile = document.getElementById('ycs_save_all_comments_chat');
         const btnSaveCommentsChatToFileMenu = document.getElementById('ycs_save_all_comments_chat_menu');
-        btnSaveCommentsChatToFile?.addEventListener('click', (e) => {
-            try {
-                e.stopPropagation();
-                if (!btnSaveCommentsChatToFileMenu) return;
-                // close others first
-                closeAllDropdowns(btnSaveCommentsChatToFileMenu);
-                btnSaveCommentsChatToFileMenu.classList.toggle('show');
-            } catch (err) {
-                console.error(err);
-            }
-        });
+        setupDropdown(btnSaveCommentsChatToFile, btnSaveCommentsChatToFileMenu, (format) => {
+            const commentsChat = getCommentsChat(state);
+            if (!commentsChat || commentsChat.size === 0) return;
+            const arr = [...commentsChat.values()];
 
-        btnSaveCommentsChatToFileMenu?.addEventListener('click', (ev) => {
-            try {
-                const target = ev.target as HTMLElement | null;
-                if (!target) return;
-                const fmt = target.dataset.format;
-                const commentsChat = getCommentsChat(state);
-                if (!commentsChat || commentsChat.size === 0) return;
-                const arr = [...commentsChat.values()];
-
-                if (fmt === 'txt') {
-                    downloadChatFile(arr, buildExportMeta());
-                } else if (fmt === 'json') {
-                    downloadChatFileJSON(arr, buildExportMeta());
-                } else if (fmt === 'xlsx') {
-                    downloadChatFileXLSX(arr, buildExportMeta());
-                }
-
-                btnSaveCommentsChatToFileMenu.classList.remove('show');
-            } catch (err) {
-                console.error(err);
+            if (format === EXPORT_FORMAT.TXT) {
+                downloadChatFile(arr, buildExportMeta());
+            } else if (format === EXPORT_FORMAT.JSON) {
+                downloadChatFileJSON(arr, buildExportMeta());
+            } else if (format === EXPORT_FORMAT.XLSX) {
+                downloadChatFileXLSX(arr, buildExportMeta());
             }
         });
 
@@ -898,52 +913,32 @@ export function initApp(): void {
         // Transcript save dropdown
         const btnSaveCommentsTrVideoToFile = document.getElementById('ycs_save_all_comments_trvideo');
         const btnSaveCommentsTrVideoToFileMenu = document.getElementById('ycs_save_all_comments_trvideo_menu');
-        btnSaveCommentsTrVideoToFile?.addEventListener('click', (e) => {
-            try {
-                e.stopPropagation();
-                if (!btnSaveCommentsTrVideoToFileMenu) return;
-                // close others first
-                closeAllDropdowns(btnSaveCommentsTrVideoToFileMenu);
-                btnSaveCommentsTrVideoToFileMenu.classList.toggle('show');
-            } catch (err) {
-                console.error(err);
-            }
-        });
+        setupDropdown(btnSaveCommentsTrVideoToFile, btnSaveCommentsTrVideoToFileMenu, (format) => {
+            const commentsTrVideo = getCommentsTrVideo(state);
+            const cueGroups = extractCueGroups(commentsTrVideo);
+            if (!cueGroups || cueGroups.length === 0) return;
 
-        btnSaveCommentsTrVideoToFileMenu?.addEventListener('click', (ev) => {
-            try {
-                const target = ev.target as HTMLElement | null;
-                if (!target) return;
-                const fmt = target.dataset.format;
-                const commentsTrVideo = getCommentsTrVideo(state);
-                const cueGroups = extractCueGroups(commentsTrVideo);
-                if (!cueGroups || cueGroups.length === 0) return;
-
-                if (fmt === 'txt') {
-                    downloadTranscriptFile(cueGroups, buildExportMeta());
-                } else if (fmt === 'json') {
-                    downloadTranscriptFileJSON(cueGroups, buildExportMeta());
-                } else if (fmt === 'xlsx') {
-                    downloadTranscriptFileXLSX(cueGroups, buildExportMeta());
-                }
-
-                btnSaveCommentsTrVideoToFileMenu.classList.remove('show');
-            } catch (err) {
-                console.error(err);
+            if (format === EXPORT_FORMAT.TXT) {
+                downloadTranscriptFile(cueGroups, buildExportMeta());
+            } else if (format === EXPORT_FORMAT.JSON) {
+                downloadTranscriptFileJSON(cueGroups, buildExportMeta());
+            } else if (format === EXPORT_FORMAT.XLSX) {
+                downloadTranscriptFileXLSX(cueGroups, buildExportMeta());
             }
         });
 
         // Close dropdowns when clicking outside
-        document.addEventListener('click', (ev) => {
+        handleDocumentClick = (event) => {
             try {
-                const t = ev.target as HTMLElement | null;
-                if (t && t.closest && t.closest('.ycs_dropdown_wrap')) return;
+                const target = event.target as HTMLElement | null;
+                if (target?.closest('.ycs_dropdown_wrap')) return;
 
                 closeAllDropdowns();
             } catch (err) {
                 // ignore
             }
-        });
+        };
+        document.addEventListener('click', handleDocumentClick);
 
         const runCommentsPipeline = (selector: string, query: string, param?: IParamSearch) => {
             const context = buildSearchContext();

--- a/app/src/source/web-resources/services/exportFormats.ts
+++ b/app/src/source/web-resources/services/exportFormats.ts
@@ -169,7 +169,7 @@ function buildCommentsExportPayload(input: {
                 },
                 publishedTimeText: wrapTryCatch(() => cr.publishedTimeText.runs[0].text) || '',
                 commentMessage: cr?.contentText?.fullText || cr?.renderFullText || '',
-                totalLikes: parseLikeCount(cr?.voteCount?.simpleText),
+                totalLikes: parseLikeCount(cr?.voteCount?.simpleText ?? cr?.likeCount),
                 member: wrapTryCatch(() => cr.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip) || '',
                 commentReplies: { replies: [] }
             };
@@ -203,7 +203,7 @@ function buildCommentsExportPayload(input: {
             },
             publishedTimeText: wrapTryCatch(() => renderer.publishedTimeText.runs[0].text) || '',
             commentMessage: renderer?.contentText?.fullText || renderer?.renderFullText || '',
-            totalLikes: parseLikeCount(renderer?.voteCount?.simpleText),
+            totalLikes: parseLikeCount(renderer?.voteCount?.simpleText ?? renderer?.likeCount),
             member: wrapTryCatch(() => renderer.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip) || '',
             commentReplies: { replies: [] }
         };

--- a/app/src/source/web-resources/services/exportFormats.ts
+++ b/app/src/source/web-resources/services/exportFormats.ts
@@ -1,0 +1,432 @@
+import type { ChatItem, TranscriptCueGroup, CommentItem } from '../../utils/interfaces/i_types';
+import {
+    getSheetDetails,
+    getSheetComments,
+    getSheetReplies,
+    getSheetChatDetails,
+    getSheetChatComments,
+    getSheetTrVideoDetails,
+    getSheetTrVideo
+} from '../../utils/sheets';
+
+// Lazy-load xlsx only when user chooses .xlsx export
+let xlsxModulePromise: Promise<any> | null = null;
+function loadXLSX(): Promise<any> {
+    if (!xlsxModulePromise) xlsxModulePromise = import('xlsx');
+    return xlsxModulePromise;
+}
+
+// Wrapper functions to convert data into downloadable payloads
+export function exportCommentsAsJSON(input: {
+    titleVideo?: string;
+    url?: string;
+    videoId?: string;
+    comments?: CommentItem[];
+    cachedDate?: number;
+}): { content: string; fileName: string; mime: string } | void {
+    try {
+        const title = input?.titleVideo || '';
+        const url = input?.url || '';
+        const videoId = input?.videoId || getVideoIdFromUrl(url) || '';
+        const comments = (input?.comments || []) as CommentItem[];
+
+        // Build export JSON identical to export page getCommentsJSON
+        const cmnts: any = {
+            urlVideo: url,
+            titleVideo: title,
+            videoId: videoId,
+            cachedDate: input?.cachedDate || Date.now(),
+            totalComments: 0,
+            totalReplies: 0,
+            total: comments.length,
+            comments: []
+        };
+
+        const commentMap = new Map<string, any>();
+        const repliesSet: any[] = [];
+
+        for (const item of comments) {
+            const type = (item as any)?.typeComment;
+            const cr = (item as any)?.commentRenderer || {};
+            if (type === 'C') {
+                const commentId = cr?.commentId;
+                const authorChannelUrl =
+                    cr?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl ||
+                    cr?.authorEndpoint?.commandMetadata?.webCommandMetadata?.url;
+
+                const publishedUrl = safe(
+                    () => cr.publishedTimeText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url
+                );
+
+                commentMap.set(commentId, {
+                    commentUrl: 'youtube.com' + (publishedUrl || `/watch?v=${videoId}&lc=${commentId}`),
+                    author: {
+                        nameAuthor: cr?.authorText?.simpleText,
+                        authorIsChannelOwner: cr?.authorIsChannelOwner,
+                        channel: 'youtube.com' + (authorChannelUrl || '')
+                    },
+                    publishedTimeText: safe(() => cr.publishedTimeText.runs[0].text),
+                    commentMessage: cr?.contentText?.fullText || cr?.renderFullText,
+                    totalLikes: cr?.voteCount?.simpleText || '0',
+                    member: safe(() => cr.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip),
+                    commentReplies: { replies: [] }
+                });
+            } else if (type === 'R') {
+                repliesSet.push(item);
+            }
+        }
+
+        for (const reply of repliesSet) {
+            const r = (reply as any).commentRenderer || {};
+            const origId = (reply as any)?.originComment?.commentRenderer?.commentId;
+            const orig = commentMap.get(origId);
+            if (orig) {
+                const publishedUrl = safe(
+                    () => r.publishedTimeText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url
+                );
+                orig.commentReplies.replies.push({
+                    commentUrl: 'youtube.com' + (publishedUrl || `/watch?v=${videoId}&lc=${r?.commentId}`),
+                    author: {
+                        nameAuthor: r?.authorText?.simpleText,
+                        authorIsChannelOwner: r?.authorIsChannelOwner,
+                        channel:
+                            'youtube.com' +
+                            ((r as any)?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl ||
+                                (r as any)?.authorEndpoint?.commandMetadata?.webCommandMetadata?.url)
+                    },
+                    publishedTimeText: safe(() => r.publishedTimeText.runs[0].text),
+                    commentMessage: r?.contentText?.fullText || r?.renderFullText,
+                    totalLikes: r?.voteCount?.simpleText || '0',
+                    member: safe(() => r.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip)
+                });
+            }
+        }
+
+        cmnts.totalReplies = repliesSet.length;
+        for (const [, v] of commentMap) {
+            cmnts.comments.push(v);
+        }
+        cmnts.totalComments = cmnts.comments.length;
+
+        const json = JSON.stringify(cmnts);
+        return {
+            content: json,
+            fileName: `Comments, ${title} (${comments.length}).json`,
+            mime: 'text/plain'
+        };
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+}
+
+export function exportCommentsAsXLSX(input: {
+    titleVideo?: string;
+    url?: string;
+    videoId?: string;
+    comments?: CommentItem[];
+    cachedDate?: number;
+}): { writeFunc: () => void } | void {
+    try {
+        const title = input?.titleVideo || '';
+        const url = input?.url || '';
+        const videoId = input?.videoId || getVideoIdFromUrl(url) || '';
+        const comments = (input?.comments || []) as CommentItem[];
+
+        // Build same JSON and then same sheets as export page
+        const jsonPayload = exportCommentsAsJSON({ ...input, titleVideo: title, url, videoId, comments });
+        if (!jsonPayload) return;
+        const cmnt = JSON.parse(jsonPayload.content);
+
+        return {
+            writeFunc: () => {
+                loadXLSX()
+                    .then((XLSX) => {
+                        const wb = XLSX.utils.book_new();
+                        const created = `Report was created by ${new Date().toUTCString()}`;
+                        let ws;
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet([getSheetDetails(cmnt) as any]);
+                            XLSX.utils.sheet_add_aoa(ws, [[created]], { origin: 'A5' });
+                            XLSX.utils.book_append_sheet(wb, ws, 'Details');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet(getSheetComments(cmnt.comments) as any);
+                            XLSX.utils.book_append_sheet(wb, ws, 'Comments');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet(getSheetReplies(cmnt.comments) as any);
+                            XLSX.utils.book_append_sheet(wb, ws, 'Replies');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        XLSX.writeFile(wb, `Comments, ${title} (${comments.length}).xlsx`);
+                    })
+                    .catch((e) => console.error(e));
+            }
+        };
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+}
+
+// Placeholder helpers reused from export_comments.ts - small copies to build sheets
+// helpers (kept for future reuse)
+/* istanbul ignore next */
+function _getSheetDetails(cmnt: any): Record<string, unknown> {
+    return {
+        title: cmnt.title || '',
+        totalComments: cmnt.totalComments || 0,
+        totalReplies: cmnt.totalReplies || 0
+    };
+}
+
+/* istanbul ignore next */
+function _getSheetComments(comments: any[]): any[] {
+    return (comments || []).map((c) => ({
+        author: c.author || '',
+        message: c.commentMessage || '',
+        likes: c.totalLikes || 0,
+        member: c.member || ''
+    }));
+}
+
+/* istanbul ignore next */
+function _getSheetReplies(comments: any[]): any[] {
+    const replies: any[] = [];
+    for (const c of comments || []) {
+        if (Array.isArray(c.replies) && c.replies.length > 0) {
+            for (const r of c.replies) {
+                replies.push({ parentId: c.commentId || '', author: r.author || '', message: r.commentMessage || '' });
+            }
+        }
+    }
+    return replies;
+}
+
+// Chat and Transcript exporters: simple JSON wrappers (XLSX can be added similarly)
+export function exportChatAsJSON(
+    chatMessages: ChatItem[] | any,
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
+): { content: string; fileName: string; mime: string } | void {
+    try {
+        const title = meta?.titleVideo || '';
+        const url = meta?.url || '';
+        const videoId = meta?.videoId || getVideoIdFromUrl(url) || '';
+        const arr = chatMessages || [];
+
+        interface ChatNorm {
+            author: { nameAuthor: string; channel: string; member: string };
+            commentMessage: string;
+            timestampUsec: number;
+            timestampText: string;
+        }
+
+        const cmntsChat: any = {
+            urlVideo: url,
+            titleVideo: title,
+            videoId,
+            cachedDate: meta?.cachedDate || Date.now(),
+            total: 0,
+            commentsChat: [] as ChatNorm[]
+        };
+
+        for (const it of arr) {
+            const renderer = safe(() => it.replayChatItemAction.actions[0].addChatItemAction.item)
+                ?.liveChatTextMessageRenderer as any;
+            if (!renderer) continue;
+            const name = renderer?.authorName?.simpleText || '';
+            const channel = '';
+            const member = (renderer?.authorBadges || [])?.some(
+                (b: any) => b?.liveChatAuthorBadgeRenderer?.customThumbnail
+            )
+                ? 'member'
+                : '';
+            const message =
+                renderer?.message?.simpleText || renderer?.message?.fullText || renderer?.message?.renderFullText || '';
+            const timestampUsec = Number(renderer?.timestampUsec || 0);
+            const timestampText = renderer?.timestampText?.simpleText || '';
+
+            cmntsChat.commentsChat.push({
+                author: { nameAuthor: name, channel, member },
+                commentMessage: message,
+                timestampUsec,
+                timestampText
+            });
+        }
+
+        cmntsChat.total = cmntsChat.commentsChat.length;
+        const json = JSON.stringify(cmntsChat);
+        return { content: json, fileName: `Comments chat, ${title} (${cmntsChat.total}).json`, mime: 'text/plain' };
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+}
+
+export function exportChatAsXLSX(
+    chatMessages: ChatItem[] | any,
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
+): { writeFunc: () => void } | void {
+    try {
+        const payload = exportChatAsJSON(chatMessages, meta);
+        if (!payload) return;
+        const cmnt = JSON.parse(payload.content);
+
+        return {
+            writeFunc: () => {
+                loadXLSX()
+                    .then((XLSX) => {
+                        const wb = XLSX.utils.book_new();
+                        const created = `Report was created by ${new Date().toUTCString()}`;
+                        let ws;
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet([getSheetChatDetails(cmnt) as any]);
+                            XLSX.utils.sheet_add_aoa(ws, [[created]], { origin: 'A5' });
+                            XLSX.utils.book_append_sheet(wb, ws, 'Details');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet(getSheetChatComments(cmnt) as any);
+                            XLSX.utils.book_append_sheet(wb, ws, 'Chat comments');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        XLSX.writeFile(wb, `Comments chat, ${meta?.titleVideo || ''} (${cmnt.total}).xlsx`);
+                    })
+                    .catch((e) => console.error(e));
+            }
+        };
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+}
+
+export function exportTranscriptAsJSON(
+    cueGroups: TranscriptCueGroup[] | any,
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
+): { content: string; fileName: string; mime: string } | void {
+    try {
+        const title = meta?.titleVideo || '';
+        const url = meta?.url || '';
+        const videoId = meta?.videoId || getVideoIdFromUrl(url) || '';
+        const groups = cueGroups || [];
+
+        const trVideo: any = {
+            urlVideo: url,
+            titleVideo: title,
+            videoId,
+            cachedDate: meta?.cachedDate || Date.now(),
+            titleTrVideo: meta?.titleTrVideo || '',
+            total: 0,
+            trVideo: [] as any[]
+        };
+
+        for (const g of groups) {
+            const r = (g as any)?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer || {};
+            const message = r?.cue?.simpleText || r?.cue?.runs?.[0]?.text || '';
+            const startOffsetMs = Number(r?.startOffsetMs || 0);
+            const durationMs = Number(r?.durationMs || 0);
+            const startSeconds = safe(() => r.navigationEndpoint.watchEndpoint.startTimeSeconds) || 0;
+            const formattedStartOffset = safe(() => r.formattedStartOffset.simpleText) || '';
+            const urlShare = `https://youtu.be/${videoId}?t=${startSeconds || 0}`;
+            trVideo.trVideo.push({
+                urlShare,
+                formattedStartOffset,
+                startOffsetMs,
+                durationMs,
+                message
+            });
+        }
+
+        trVideo.total = trVideo.trVideo.length;
+        const json = JSON.stringify(trVideo);
+        return { content: json, fileName: `Transcript video, ${title} (${trVideo.total}).json`, mime: 'text/plain' };
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+}
+
+export function exportTranscriptAsXLSX(
+    cueGroups: TranscriptCueGroup[] | any,
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
+): { writeFunc: () => void } | void {
+    try {
+        const payload = exportTranscriptAsJSON(cueGroups, meta);
+        if (!payload) return;
+        const trVideo = JSON.parse(payload.content);
+
+        return {
+            writeFunc: () => {
+                loadXLSX()
+                    .then((XLSX) => {
+                        const wb = XLSX.utils.book_new();
+                        const created = `Report was created by ${new Date().toUTCString()}`;
+                        let ws;
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet([getSheetTrVideoDetails(trVideo) as any]);
+                            XLSX.utils.sheet_add_aoa(ws, [[created]], { origin: 'A5' });
+                            XLSX.utils.book_append_sheet(wb, ws, 'Details');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        try {
+                            ws = XLSX.utils.json_to_sheet(getSheetTrVideo(trVideo) as any);
+                            XLSX.utils.book_append_sheet(wb, ws, 'Transcript video');
+                        } catch (err) {
+                            console.error(err);
+                        }
+
+                        XLSX.writeFile(wb, `Transcript video, ${meta?.titleVideo || ''} (${trVideo.total}).xlsx`);
+                    })
+                    .catch((e) => console.error(e));
+            }
+        };
+    } catch (e) {
+        console.error(e);
+        return;
+    }
+}
+
+export default {};
+
+function getVideoIdFromUrl(url: string | undefined): string | undefined {
+    try {
+        if (!url) return undefined;
+        const u = new URL(url);
+        const vid = u.searchParams.get('v');
+        if (vid) return vid;
+        // youtu.be short link
+        if (u.hostname.includes('youtu.be')) {
+            return u.pathname.replace('/', '') || undefined;
+        }
+        return undefined;
+    } catch (e) {
+        return undefined;
+    }
+}
+
+function safe<T>(fn: () => T): T | undefined {
+    try {
+        return fn();
+    } catch (e) {
+        return undefined;
+    }
+}

--- a/app/src/source/web-resources/services/exportFormats.ts
+++ b/app/src/source/web-resources/services/exportFormats.ts
@@ -179,43 +179,9 @@ export function exportCommentsAsXLSX(input: {
     }
 }
 
-// Placeholder helpers reused from export_comments.ts - small copies to build sheets
-// helpers (kept for future reuse)
-/* istanbul ignore next */
-function _getSheetDetails(cmnt: any): Record<string, unknown> {
-    return {
-        title: cmnt.title || '',
-        totalComments: cmnt.totalComments || 0,
-        totalReplies: cmnt.totalReplies || 0
-    };
-}
-
-/* istanbul ignore next */
-function _getSheetComments(comments: any[]): any[] {
-    return (comments || []).map((c) => ({
-        author: c.author || '',
-        message: c.commentMessage || '',
-        likes: c.totalLikes || 0,
-        member: c.member || ''
-    }));
-}
-
-/* istanbul ignore next */
-function _getSheetReplies(comments: any[]): any[] {
-    const replies: any[] = [];
-    for (const c of comments || []) {
-        if (Array.isArray(c.replies) && c.replies.length > 0) {
-            for (const r of c.replies) {
-                replies.push({ parentId: c.commentId || '', author: r.author || '', message: r.commentMessage || '' });
-            }
-        }
-    }
-    return replies;
-}
-
 // Chat and Transcript exporters: simple JSON wrappers (XLSX can be added similarly)
 export function exportChatAsJSON(
-    chatMessages: ChatItem[] | any,
+    chatMessages: ChatItem[],
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
 ): { content: string; fileName: string; mime: string } | void {
     try {
@@ -241,8 +207,8 @@ export function exportChatAsJSON(
         };
 
         for (const it of arr) {
-            const renderer = safe(() => it.replayChatItemAction.actions[0].addChatItemAction.item)
-                ?.liveChatTextMessageRenderer as any;
+            const item = safe(() => (it as any).replayChatItemAction.actions[0].addChatItemAction.item);
+            const renderer = item?.liveChatTextMessageRenderer as any;
             if (!renderer) continue;
             const name = renderer?.authorName?.simpleText || '';
             const channel = '';
@@ -274,7 +240,7 @@ export function exportChatAsJSON(
 }
 
 export function exportChatAsXLSX(
-    chatMessages: ChatItem[] | any,
+    chatMessages: ChatItem[],
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
 ): { writeFunc: () => void } | void {
     try {
@@ -317,7 +283,7 @@ export function exportChatAsXLSX(
 }
 
 export function exportTranscriptAsJSON(
-    cueGroups: TranscriptCueGroup[] | any,
+    cueGroups: TranscriptCueGroup[],
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
 ): { content: string; fileName: string; mime: string } | void {
     try {
@@ -363,7 +329,7 @@ export function exportTranscriptAsJSON(
 }
 
 export function exportTranscriptAsXLSX(
-    cueGroups: TranscriptCueGroup[] | any,
+    cueGroups: TranscriptCueGroup[],
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
 ): { writeFunc: () => void } | void {
     try {

--- a/app/src/source/web-resources/services/exportFormats.ts
+++ b/app/src/source/web-resources/services/exportFormats.ts
@@ -1,4 +1,7 @@
 import type { ChatItem, TranscriptCueGroup, CommentItem } from '../../utils/interfaces/i_types';
+import type { ISheetCommentsParam, ISheetRepliesParam } from '../../utils/interfaces/i_assist';
+import { getVideoId, wrapTryCatch } from '../../utils/common';
+import { parseFormattedNumberToInt } from '../../utils/formatting';
 import {
     getSheetDetails,
     getSheetComments,
@@ -16,6 +19,296 @@ function loadXLSX(): Promise<any> {
     return xlsxModulePromise;
 }
 
+type CommentExportItem = ISheetCommentsParam;
+type CommentExportReply = ISheetRepliesParam;
+
+interface CommentsExportPayload {
+    urlVideo: string;
+    titleVideo: string;
+    videoId: string;
+    cachedDate: number;
+    totalComments: number;
+    totalReplies: number;
+    total: number;
+    comments: CommentExportItem[];
+}
+
+interface ChatExportItem {
+    author: {
+        nameAuthor: string;
+        channel: string;
+        member: string;
+    };
+    commentMessage: string;
+    timestampUsec: number;
+    timestampText: string;
+}
+
+interface ChatExportPayload {
+    urlVideo: string;
+    titleVideo: string;
+    videoId: string;
+    cachedDate: number;
+    total: number;
+    commentsChat: ChatExportItem[];
+}
+
+interface TranscriptExportItem {
+    urlShare: string;
+    formattedStartOffset: string;
+    startOffsetMs: number;
+    durationMs: number;
+    message: string;
+}
+
+interface TranscriptExportPayload {
+    urlVideo: string;
+    titleVideo: string;
+    videoId: string;
+    cachedDate: number;
+    titleTrVideo: string;
+    total: number;
+    trVideo: TranscriptExportItem[];
+}
+
+type SheetBuilder<TPayload> = (XLSX: any, workbook: any, payload: TPayload, createdLabel: string) => void;
+
+function createJsonResponse(fileName: string, payload: unknown): { content: string; fileName: string; mime: string } {
+    return {
+        content: JSON.stringify(payload),
+        fileName,
+        mime: 'application/json'
+    };
+}
+
+function createXlsxWriter<TPayload>(
+    payload: TPayload,
+    fileName: string,
+    builders: Array<SheetBuilder<TPayload>>
+): { writeFunc: () => void } {
+    return {
+        writeFunc: () => {
+            loadXLSX()
+                .then((XLSX) => {
+                    const workbook = XLSX.utils.book_new();
+                    const created = `Report was created by ${new Date().toUTCString()}`;
+
+                    for (const build of builders) {
+                        try {
+                            build(XLSX, workbook, payload, created);
+                        } catch (err) {
+                            console.error(err);
+                        }
+                    }
+
+                    XLSX.writeFile(workbook, fileName);
+                })
+                .catch((e) => console.error(e));
+        }
+    };
+}
+
+function parseLikeCount(value: unknown): number {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+    if (typeof value !== 'string') {
+        return 0;
+    }
+
+    // Reuse shared formatter so suffix/multilingual units stay consistent across exports.
+    return parseFormattedNumberToInt(value);
+}
+
+function buildCommentsExportPayload(input: {
+    titleVideo?: string;
+    url?: string;
+    videoId?: string;
+    comments?: CommentItem[];
+    cachedDate?: number;
+}): CommentsExportPayload {
+    const title = input?.titleVideo || '';
+    const url = input?.url || '';
+    const videoId = input?.videoId || (url ? getVideoId(url) : undefined) || '';
+    const comments = (input?.comments || []) as CommentItem[];
+
+    const payload: CommentsExportPayload = {
+        urlVideo: url,
+        titleVideo: title,
+        videoId,
+        cachedDate: input?.cachedDate || Date.now(),
+        totalComments: 0,
+        totalReplies: 0,
+        total: comments.length,
+        comments: []
+    };
+
+    const commentMap = new Map<string, CommentExportItem>();
+    const repliesSet: CommentItem[] = [];
+
+    for (const item of comments) {
+        const type = (item as any)?.typeComment;
+        const cr = (item as any)?.commentRenderer || {};
+        if (type === 'C') {
+            const commentId = cr?.commentId;
+            if (typeof commentId !== 'string' || commentId.length === 0) continue;
+            const authorChannelUrl =
+                cr?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl ||
+                cr?.authorEndpoint?.commandMetadata?.webCommandMetadata?.url;
+
+            const publishedUrl = wrapTryCatch(
+                () => cr.publishedTimeText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url
+            );
+
+            const comment: CommentExportItem = {
+                commentUrl: 'youtube.com' + (publishedUrl || `/watch?v=${videoId}&lc=${commentId}`),
+                author: {
+                    nameAuthor: cr?.authorText?.simpleText || '',
+                    authorIsChannelOwner: Boolean(cr?.authorIsChannelOwner),
+                    channel: 'youtube.com' + (authorChannelUrl || '')
+                },
+                publishedTimeText: wrapTryCatch(() => cr.publishedTimeText.runs[0].text) || '',
+                commentMessage: cr?.contentText?.fullText || cr?.renderFullText || '',
+                totalLikes: parseLikeCount(cr?.voteCount?.simpleText),
+                member: wrapTryCatch(() => cr.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip) || '',
+                commentReplies: { replies: [] }
+            };
+
+            commentMap.set(commentId, comment);
+        } else if (type === 'R') {
+            repliesSet.push(item);
+        }
+    }
+
+    for (const reply of repliesSet) {
+        const renderer = (reply as any).commentRenderer || {};
+        const originId = (reply as any)?.originComment?.commentRenderer?.commentId;
+        if (typeof originId !== 'string' || originId.length === 0) continue;
+        const origin = commentMap.get(originId);
+        if (!origin) continue;
+
+        const publishedUrl = wrapTryCatch(
+            () => renderer.publishedTimeText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url
+        );
+
+        const replyEntry: CommentExportReply = {
+            commentUrl: 'youtube.com' + (publishedUrl || `/watch?v=${videoId}&lc=${renderer?.commentId}`),
+            author: {
+                nameAuthor: renderer?.authorText?.simpleText || '',
+                authorIsChannelOwner: Boolean(renderer?.authorIsChannelOwner),
+                channel:
+                    'youtube.com' +
+                    ((renderer as any)?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl ||
+                        (renderer as any)?.authorEndpoint?.commandMetadata?.webCommandMetadata?.url)
+            },
+            publishedTimeText: wrapTryCatch(() => renderer.publishedTimeText.runs[0].text) || '',
+            commentMessage: renderer?.contentText?.fullText || renderer?.renderFullText || '',
+            totalLikes: parseLikeCount(renderer?.voteCount?.simpleText),
+            member: wrapTryCatch(() => renderer.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip) || '',
+            commentReplies: { replies: [] }
+        };
+
+        origin.commentReplies.replies.push(replyEntry);
+    }
+
+    for (const [, value] of commentMap) {
+        payload.comments.push(value);
+    }
+
+    payload.totalReplies = repliesSet.length;
+    payload.totalComments = payload.comments.length;
+
+    return payload;
+}
+
+function buildChatExportPayload(
+    chatMessages: ChatItem[],
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
+): ChatExportPayload {
+    const title = meta?.titleVideo || '';
+    const url = meta?.url || '';
+    const videoId = meta?.videoId || (url ? getVideoId(url) : undefined) || '';
+    const items = chatMessages || [];
+
+    const payload: ChatExportPayload = {
+        urlVideo: url,
+        titleVideo: title,
+        videoId,
+        cachedDate: meta?.cachedDate || Date.now(),
+        total: 0,
+        commentsChat: []
+    };
+
+    for (const item of items) {
+        const renderer = wrapTryCatch(() => (item as any).replayChatItemAction.actions[0].addChatItemAction.item)
+            ?.liveChatTextMessageRenderer as any;
+        if (!renderer) continue;
+
+        const member = (renderer?.authorBadges || [])?.some(
+            (badge: any) => badge?.liveChatAuthorBadgeRenderer?.customThumbnail
+        )
+            ? 'member'
+            : '';
+        const message =
+            renderer?.message?.simpleText || renderer?.message?.fullText || renderer?.message?.renderFullText || '';
+
+        payload.commentsChat.push({
+            author: {
+                nameAuthor: renderer?.authorName?.simpleText || '',
+                channel: '',
+                member
+            },
+            commentMessage: message,
+            timestampUsec: Number(renderer?.timestampUsec || 0),
+            timestampText: renderer?.timestampText?.simpleText || ''
+        });
+    }
+
+    payload.total = payload.commentsChat.length;
+    return payload;
+}
+
+function buildTranscriptExportPayload(
+    cueGroups: TranscriptCueGroup[] | any,
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
+): TranscriptExportPayload {
+    const title = meta?.titleVideo || '';
+    const url = meta?.url || '';
+    const videoId = meta?.videoId || (url ? getVideoId(url) : undefined) || '';
+    const groups = cueGroups || [];
+
+    const payload: TranscriptExportPayload = {
+        urlVideo: url,
+        titleVideo: title,
+        videoId,
+        cachedDate: meta?.cachedDate || Date.now(),
+        titleTrVideo: meta?.titleTrVideo || '',
+        total: 0,
+        trVideo: []
+    };
+
+    for (const group of groups) {
+        const renderer = (group as any)?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer || {};
+        const message = renderer?.cue?.simpleText || renderer?.cue?.runs?.[0]?.text || '';
+        const startOffsetMs = Number(renderer?.startOffsetMs || 0);
+        const durationMs = Number(renderer?.durationMs || 0);
+        const startSeconds = wrapTryCatch(() => renderer.navigationEndpoint.watchEndpoint.startTimeSeconds) || 0;
+        const formattedStartOffset = wrapTryCatch(() => renderer.formattedStartOffset.simpleText) || '';
+        const urlShare = `https://youtu.be/${videoId}?t=${startSeconds || 0}`;
+
+        payload.trVideo.push({
+            urlShare,
+            formattedStartOffset,
+            startOffsetMs,
+            durationMs,
+            message
+        });
+    }
+
+    payload.total = payload.trVideo.length;
+    return payload;
+}
+
 // Wrapper functions to convert data into downloadable payloads
 export function exportCommentsAsJSON(input: {
     titleVideo?: string;
@@ -25,95 +318,8 @@ export function exportCommentsAsJSON(input: {
     cachedDate?: number;
 }): { content: string; fileName: string; mime: string } | void {
     try {
-        const title = input?.titleVideo || '';
-        const url = input?.url || '';
-        const videoId = input?.videoId || getVideoIdFromUrl(url) || '';
-        const comments = (input?.comments || []) as CommentItem[];
-
-        // Build export JSON identical to export page getCommentsJSON
-        const cmnts: any = {
-            urlVideo: url,
-            titleVideo: title,
-            videoId: videoId,
-            cachedDate: input?.cachedDate || Date.now(),
-            totalComments: 0,
-            totalReplies: 0,
-            total: comments.length,
-            comments: []
-        };
-
-        const commentMap = new Map<string, any>();
-        const repliesSet: any[] = [];
-
-        for (const item of comments) {
-            const type = (item as any)?.typeComment;
-            const cr = (item as any)?.commentRenderer || {};
-            if (type === 'C') {
-                const commentId = cr?.commentId;
-                const authorChannelUrl =
-                    cr?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl ||
-                    cr?.authorEndpoint?.commandMetadata?.webCommandMetadata?.url;
-
-                const publishedUrl = safe(
-                    () => cr.publishedTimeText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url
-                );
-
-                commentMap.set(commentId, {
-                    commentUrl: 'youtube.com' + (publishedUrl || `/watch?v=${videoId}&lc=${commentId}`),
-                    author: {
-                        nameAuthor: cr?.authorText?.simpleText,
-                        authorIsChannelOwner: cr?.authorIsChannelOwner,
-                        channel: 'youtube.com' + (authorChannelUrl || '')
-                    },
-                    publishedTimeText: safe(() => cr.publishedTimeText.runs[0].text),
-                    commentMessage: cr?.contentText?.fullText || cr?.renderFullText,
-                    totalLikes: cr?.voteCount?.simpleText || '0',
-                    member: safe(() => cr.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip),
-                    commentReplies: { replies: [] }
-                });
-            } else if (type === 'R') {
-                repliesSet.push(item);
-            }
-        }
-
-        for (const reply of repliesSet) {
-            const r = (reply as any).commentRenderer || {};
-            const origId = (reply as any)?.originComment?.commentRenderer?.commentId;
-            const orig = commentMap.get(origId);
-            if (orig) {
-                const publishedUrl = safe(
-                    () => r.publishedTimeText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url
-                );
-                orig.commentReplies.replies.push({
-                    commentUrl: 'youtube.com' + (publishedUrl || `/watch?v=${videoId}&lc=${r?.commentId}`),
-                    author: {
-                        nameAuthor: r?.authorText?.simpleText,
-                        authorIsChannelOwner: r?.authorIsChannelOwner,
-                        channel:
-                            'youtube.com' +
-                            ((r as any)?.authorEndpoint?.browseEndpoint?.canonicalBaseUrl ||
-                                (r as any)?.authorEndpoint?.commandMetadata?.webCommandMetadata?.url)
-                    },
-                    publishedTimeText: safe(() => r.publishedTimeText.runs[0].text),
-                    commentMessage: r?.contentText?.fullText || r?.renderFullText,
-                    totalLikes: r?.voteCount?.simpleText || '0',
-                    member: safe(() => r.sponsorCommentBadge.sponsorCommentBadgeRenderer.tooltip)
-                });
-            }
-        }
-
-        cmnts.totalReplies = repliesSet.length;
-        for (const [, v] of commentMap) {
-            cmnts.comments.push(v);
-        }
-        cmnts.totalComments = cmnts.comments.length;
-
-        const json = JSON.stringify(cmnts);
-        return {
-            content: json,
-            fileName: `Comments, ${title} (${comments.length}).json`,
-            mime: 'text/plain'
-        };
+        const payload = buildCommentsExportPayload(input);
+        return createJsonResponse(`Comments, ${payload.titleVideo} (${payload.total}).json`, payload);
     } catch (e) {
         console.error(e);
         return;
@@ -128,51 +334,24 @@ export function exportCommentsAsXLSX(input: {
     cachedDate?: number;
 }): { writeFunc: () => void } | void {
     try {
-        const title = input?.titleVideo || '';
-        const url = input?.url || '';
-        const videoId = input?.videoId || getVideoIdFromUrl(url) || '';
-        const comments = (input?.comments || []) as CommentItem[];
-
-        // Build same JSON and then same sheets as export page
-        const jsonPayload = exportCommentsAsJSON({ ...input, titleVideo: title, url, videoId, comments });
-        if (!jsonPayload) return;
-        const cmnt = JSON.parse(jsonPayload.content);
-
-        return {
-            writeFunc: () => {
-                loadXLSX()
-                    .then((XLSX) => {
-                        const wb = XLSX.utils.book_new();
-                        const created = `Report was created by ${new Date().toUTCString()}`;
-                        let ws;
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet([getSheetDetails(cmnt) as any]);
-                            XLSX.utils.sheet_add_aoa(ws, [[created]], { origin: 'A5' });
-                            XLSX.utils.book_append_sheet(wb, ws, 'Details');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet(getSheetComments(cmnt.comments) as any);
-                            XLSX.utils.book_append_sheet(wb, ws, 'Comments');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet(getSheetReplies(cmnt.comments) as any);
-                            XLSX.utils.book_append_sheet(wb, ws, 'Replies');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        XLSX.writeFile(wb, `Comments, ${title} (${comments.length}).xlsx`);
-                    })
-                    .catch((e) => console.error(e));
+        const payload = buildCommentsExportPayload(input);
+        return createXlsxWriter(payload, `Comments, ${payload.titleVideo} (${payload.total}).xlsx`, [
+            (XLSX, workbook, data, created) => {
+                const details = getSheetDetails(data);
+                if (!details) return;
+                const sheet = XLSX.utils.json_to_sheet([details as any]);
+                XLSX.utils.sheet_add_aoa(sheet, [[created]], { origin: 'A5' });
+                XLSX.utils.book_append_sheet(workbook, sheet, 'Details');
+            },
+            (XLSX, workbook, data) => {
+                const commentsSheet = XLSX.utils.json_to_sheet(getSheetComments(data.comments) as any);
+                XLSX.utils.book_append_sheet(workbook, commentsSheet, 'Comments');
+            },
+            (XLSX, workbook, data) => {
+                const repliesSheet = XLSX.utils.json_to_sheet(getSheetReplies(data.comments) as any);
+                XLSX.utils.book_append_sheet(workbook, repliesSheet, 'Replies');
             }
-        };
+        ]);
     } catch (e) {
         console.error(e);
         return;
@@ -185,54 +364,8 @@ export function exportChatAsJSON(
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
 ): { content: string; fileName: string; mime: string } | void {
     try {
-        const title = meta?.titleVideo || '';
-        const url = meta?.url || '';
-        const videoId = meta?.videoId || getVideoIdFromUrl(url) || '';
-        const arr = chatMessages || [];
-
-        interface ChatNorm {
-            author: { nameAuthor: string; channel: string; member: string };
-            commentMessage: string;
-            timestampUsec: number;
-            timestampText: string;
-        }
-
-        const cmntsChat: any = {
-            urlVideo: url,
-            titleVideo: title,
-            videoId,
-            cachedDate: meta?.cachedDate || Date.now(),
-            total: 0,
-            commentsChat: [] as ChatNorm[]
-        };
-
-        for (const it of arr) {
-            const item = safe(() => (it as any).replayChatItemAction.actions[0].addChatItemAction.item);
-            const renderer = item?.liveChatTextMessageRenderer as any;
-            if (!renderer) continue;
-            const name = renderer?.authorName?.simpleText || '';
-            const channel = '';
-            const member = (renderer?.authorBadges || [])?.some(
-                (b: any) => b?.liveChatAuthorBadgeRenderer?.customThumbnail
-            )
-                ? 'member'
-                : '';
-            const message =
-                renderer?.message?.simpleText || renderer?.message?.fullText || renderer?.message?.renderFullText || '';
-            const timestampUsec = Number(renderer?.timestampUsec || 0);
-            const timestampText = renderer?.timestampText?.simpleText || '';
-
-            cmntsChat.commentsChat.push({
-                author: { nameAuthor: name, channel, member },
-                commentMessage: message,
-                timestampUsec,
-                timestampText
-            });
-        }
-
-        cmntsChat.total = cmntsChat.commentsChat.length;
-        const json = JSON.stringify(cmntsChat);
-        return { content: json, fileName: `Comments chat, ${title} (${cmntsChat.total}).json`, mime: 'text/plain' };
+        const payload = buildChatExportPayload(chatMessages, meta);
+        return createJsonResponse(`Comments chat, ${payload.titleVideo} (${payload.total}).json`, payload);
     } catch (e) {
         console.error(e);
         return;
@@ -244,38 +377,20 @@ export function exportChatAsXLSX(
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
 ): { writeFunc: () => void } | void {
     try {
-        const payload = exportChatAsJSON(chatMessages, meta);
-        if (!payload) return;
-        const cmnt = JSON.parse(payload.content);
-
-        return {
-            writeFunc: () => {
-                loadXLSX()
-                    .then((XLSX) => {
-                        const wb = XLSX.utils.book_new();
-                        const created = `Report was created by ${new Date().toUTCString()}`;
-                        let ws;
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet([getSheetChatDetails(cmnt) as any]);
-                            XLSX.utils.sheet_add_aoa(ws, [[created]], { origin: 'A5' });
-                            XLSX.utils.book_append_sheet(wb, ws, 'Details');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet(getSheetChatComments(cmnt) as any);
-                            XLSX.utils.book_append_sheet(wb, ws, 'Chat comments');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        XLSX.writeFile(wb, `Comments chat, ${meta?.titleVideo || ''} (${cmnt.total}).xlsx`);
-                    })
-                    .catch((e) => console.error(e));
+        const payload = buildChatExportPayload(chatMessages, meta);
+        return createXlsxWriter(payload, `Comments chat, ${payload.titleVideo} (${payload.total}).xlsx`, [
+            (XLSX, workbook, data, created) => {
+                const details = getSheetChatDetails(data);
+                if (!details) return;
+                const sheet = XLSX.utils.json_to_sheet([details as any]);
+                XLSX.utils.sheet_add_aoa(sheet, [[created]], { origin: 'A5' });
+                XLSX.utils.book_append_sheet(workbook, sheet, 'Details');
+            },
+            (XLSX, workbook, data) => {
+                const commentsSheet = XLSX.utils.json_to_sheet(getSheetChatComments(data) as any);
+                XLSX.utils.book_append_sheet(workbook, commentsSheet, 'Chat comments');
             }
-        };
+        ]);
     } catch (e) {
         console.error(e);
         return;
@@ -287,41 +402,8 @@ export function exportTranscriptAsJSON(
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
 ): { content: string; fileName: string; mime: string } | void {
     try {
-        const title = meta?.titleVideo || '';
-        const url = meta?.url || '';
-        const videoId = meta?.videoId || getVideoIdFromUrl(url) || '';
-        const groups = cueGroups || [];
-
-        const trVideo: any = {
-            urlVideo: url,
-            titleVideo: title,
-            videoId,
-            cachedDate: meta?.cachedDate || Date.now(),
-            titleTrVideo: meta?.titleTrVideo || '',
-            total: 0,
-            trVideo: [] as any[]
-        };
-
-        for (const g of groups) {
-            const r = (g as any)?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer || {};
-            const message = r?.cue?.simpleText || r?.cue?.runs?.[0]?.text || '';
-            const startOffsetMs = Number(r?.startOffsetMs || 0);
-            const durationMs = Number(r?.durationMs || 0);
-            const startSeconds = safe(() => r.navigationEndpoint.watchEndpoint.startTimeSeconds) || 0;
-            const formattedStartOffset = safe(() => r.formattedStartOffset.simpleText) || '';
-            const urlShare = `https://youtu.be/${videoId}?t=${startSeconds || 0}`;
-            trVideo.trVideo.push({
-                urlShare,
-                formattedStartOffset,
-                startOffsetMs,
-                durationMs,
-                message
-            });
-        }
-
-        trVideo.total = trVideo.trVideo.length;
-        const json = JSON.stringify(trVideo);
-        return { content: json, fileName: `Transcript video, ${title} (${trVideo.total}).json`, mime: 'text/plain' };
+        const payload = buildTranscriptExportPayload(cueGroups, meta);
+        return createJsonResponse(`Transcript video, ${payload.titleVideo} (${payload.total}).json`, payload);
     } catch (e) {
         console.error(e);
         return;
@@ -333,38 +415,20 @@ export function exportTranscriptAsXLSX(
     meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; titleTrVideo?: string }
 ): { writeFunc: () => void } | void {
     try {
-        const payload = exportTranscriptAsJSON(cueGroups, meta);
-        if (!payload) return;
-        const trVideo = JSON.parse(payload.content);
-
-        return {
-            writeFunc: () => {
-                loadXLSX()
-                    .then((XLSX) => {
-                        const wb = XLSX.utils.book_new();
-                        const created = `Report was created by ${new Date().toUTCString()}`;
-                        let ws;
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet([getSheetTrVideoDetails(trVideo) as any]);
-                            XLSX.utils.sheet_add_aoa(ws, [[created]], { origin: 'A5' });
-                            XLSX.utils.book_append_sheet(wb, ws, 'Details');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        try {
-                            ws = XLSX.utils.json_to_sheet(getSheetTrVideo(trVideo) as any);
-                            XLSX.utils.book_append_sheet(wb, ws, 'Transcript video');
-                        } catch (err) {
-                            console.error(err);
-                        }
-
-                        XLSX.writeFile(wb, `Transcript video, ${meta?.titleVideo || ''} (${trVideo.total}).xlsx`);
-                    })
-                    .catch((e) => console.error(e));
+        const payload = buildTranscriptExportPayload(cueGroups, meta);
+        return createXlsxWriter(payload, `Transcript video, ${payload.titleVideo} (${payload.total}).xlsx`, [
+            (XLSX, workbook, data, created) => {
+                const details = getSheetTrVideoDetails(data);
+                if (!details) return;
+                const sheet = XLSX.utils.json_to_sheet([details as any]);
+                XLSX.utils.sheet_add_aoa(sheet, [[created]], { origin: 'A5' });
+                XLSX.utils.book_append_sheet(workbook, sheet, 'Details');
+            },
+            (XLSX, workbook, data) => {
+                const transcriptSheet = XLSX.utils.json_to_sheet(getSheetTrVideo(data) as any);
+                XLSX.utils.book_append_sheet(workbook, transcriptSheet, 'Transcript video');
             }
-        };
+        ]);
     } catch (e) {
         console.error(e);
         return;
@@ -372,27 +436,3 @@ export function exportTranscriptAsXLSX(
 }
 
 export default {};
-
-function getVideoIdFromUrl(url: string | undefined): string | undefined {
-    try {
-        if (!url) return undefined;
-        const u = new URL(url);
-        const vid = u.searchParams.get('v');
-        if (vid) return vid;
-        // youtu.be short link
-        if (u.hostname.includes('youtu.be')) {
-            return u.pathname.replace('/', '') || undefined;
-        }
-        return undefined;
-    } catch (e) {
-        return undefined;
-    }
-}
-
-function safe<T>(fn: () => T): T | undefined {
-    try {
-        return fn();
-    } catch (e) {
-        return undefined;
-    }
-}

--- a/app/src/source/web-resources/services/exportService.ts
+++ b/app/src/source/web-resources/services/exportService.ts
@@ -69,4 +69,86 @@ export function downloadTranscriptFile(cueGroups: TranscriptCueGroup[], meta?: E
     downloadFile(documentBody, `Transcript video, ${resolved.title} (${formatted.count}).txt`, 'text/plain');
 }
 
+// New format-specific download helpers (JSON / XLSX)
+import {
+    exportCommentsAsJSON,
+    exportCommentsAsXLSX,
+    exportChatAsJSON,
+    exportChatAsXLSX,
+    exportTranscriptAsJSON,
+    exportTranscriptAsXLSX
+} from './exportFormats';
+
+export function downloadCommentsFileJSON(comments: CommentItem[], meta?: ExportMeta): void {
+    try {
+        const body = { titleVideo: meta?.title || '', url: meta?.url || '', comments: comments } as any;
+        const payload = exportCommentsAsJSON(body);
+        if (!payload) return;
+
+        downloadFile(payload.content, payload.fileName, payload.mime);
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export function downloadCommentsFileXLSX(comments: CommentItem[], meta?: ExportMeta): void {
+    try {
+        const body = { titleVideo: meta?.title || '', url: meta?.url || '', comments: comments } as any;
+        const payload = exportCommentsAsXLSX(body);
+        if (!payload || !payload.writeFunc) return;
+
+        payload.writeFunc();
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export function downloadChatFileJSON(chatMessages: ChatItem[], meta?: ExportMeta): void {
+    try {
+        const body = { titleVideo: meta?.title || '', url: meta?.url || '' } as any;
+        const payload = exportChatAsJSON(chatMessages, body);
+        if (!payload) return;
+
+        downloadFile(payload.content, payload.fileName, payload.mime);
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export function downloadChatFileXLSX(chatMessages: ChatItem[], meta?: ExportMeta): void {
+    try {
+        const body = { titleVideo: meta?.title || '', url: meta?.url || '' } as any;
+        const payload = exportChatAsXLSX(chatMessages, body);
+        if (!payload || !payload.writeFunc) return;
+
+        payload.writeFunc();
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export function downloadTranscriptFileJSON(cueGroups: TranscriptCueGroup[], meta?: ExportMeta): void {
+    try {
+        const body = { titleVideo: meta?.title || '', url: meta?.url || '' } as any;
+        const payload = exportTranscriptAsJSON(cueGroups, body);
+        if (!payload) return;
+
+        downloadFile(payload.content, payload.fileName, payload.mime);
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export function downloadTranscriptFileXLSX(cueGroups: TranscriptCueGroup[], meta?: ExportMeta): void {
+    try {
+        const body = { titleVideo: meta?.title || '', url: meta?.url || '' } as any;
+        const payload = exportTranscriptAsXLSX(cueGroups, body);
+        if (!payload || !payload.writeFunc) return;
+
+        payload.writeFunc();
+    } catch (e) {
+        console.error(e);
+    }
+}
+
 export type { ExportMeta };

--- a/app/src/source/web-resources/services/exportService.ts
+++ b/app/src/source/web-resources/services/exportService.ts
@@ -8,6 +8,14 @@ import {
 import type { ChatItem, CommentItem, TranscriptCueGroup } from '../../utils/interfaces/i_types';
 import type { ExportMeta, ResolvedExportMeta } from '../../utils/formatting';
 
+export const EXPORT_FORMAT = {
+    TXT: 'txt',
+    JSON: 'json',
+    XLSX: 'xlsx'
+} as const;
+
+export type ExportFormat = (typeof EXPORT_FORMAT)[keyof typeof EXPORT_FORMAT];
+
 function buildDocument(sectionTitle: string, meta: ResolvedExportMeta, count: number, body: string): string {
     return `\nYCS - YouTube Comment Search\n\n${sectionTitle}\nFile created by ${meta.generatedAt}\nVideo URL: ${meta.url}\nTitle: ${meta.title}\nTotal: ${count}\n${body}`;
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "ES6" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "ES2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     "lib": ["ES2017", "DOM", "DOM.Iterable"] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -5,7 +5,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "ES6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-    "module": "ES2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+    "module": "ES2020" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'; required for dynamic import('xlsx') used by exportFormats.ts. */,
     "lib": ["ES2017", "DOM", "DOM.Iterable"] /* Specify library files to be included in the compilation. */,
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
## Summary

Add dropdown menu for multiple export formats (.TXT, .JSON, .XLSX) to replace the single save button. All three data sources (Comments, Chat replay, Transcript) now support exporting in three formats through a unified dropdown UI.

## Main Changes

### New Features
- **Multi-format export dropdown**: Replace single save button with dropdown menu offering .TXT, .JSON, and .XLSX format options
- **JSON export**: Export comments, chat, and transcript data as structured JSON files
- **XLSX export**: Export data as Excel spreadsheets with multiple worksheets (Details, Comments/Chat, Replies)
- **Lazy loading optimization**: XLSX module only loads when user selects .XLSX format

### Architecture Improvements
- **New service layer**: Add `exportFormats.ts` for format conversion logic and `exportService.ts` as facade layer
- **Builder pattern**: Use builder pattern for XLSX generation with extensible worksheet builders
- **Unified type system**: Standardize `totalLikes` as `number` type with consistent `parseLikeCount()` utility
- **Centralized dropdown management**: Implement reusable dropdown setup with global click handler for menu closing

### Technical Details
- Reuse `parseFormattedNumberToInt()` for multi-language number parsing consistency (e.g., "1.2K", "1萬")
- Add `EXPORT_FORMAT` constants with `ExportFormat` union type for type safety
- Implement like count fallback mechanism: `voteCountText ?? likeCount ?? 0`