### PR TITLE
fix(ci): resolve Node.js v22 installation issue in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'app/.nvmrc'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'app/package-lock.json'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: 'app/.nvmrc'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: 'app/package-lock.json'
 


### PR DESCRIPTION
- Change from node-version-file to direct node-version specification
- Fixes 'N/A: version "v22" is not yet installed' error
- Ensures reliable Node.js 22 installation in CI/CD environment
- Affects both release.yml and ci.yml workflows