### PR TITLE
feat(shorts): add YouTube Shorts page support with optimized layout

### DIFF
--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -1355,6 +1355,10 @@ html[dark] .ycs-floating-back-button:hover {
    Shorts Mode Customizations
    ======================================== */
 
+.ycs-app.ycs-app--shorts {
+  margin-bottom: 0;
+}
+
 /* Load all and stop buttons on same line */
 .ycs-app--shorts #ycs-load-all {
   display: inline-block;

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -1350,3 +1350,61 @@ html[dark] .ycs-floating-back-button:hover {
   background: rgba(80, 80, 80, 0.7);
   border-color: rgba(80, 80, 80, 0.5);
 }
+
+/* ========================================
+   Shorts Mode Customizations
+   ======================================== */
+
+/* Load all and stop buttons on same line */
+.ycs-app--shorts #ycs-load-all {
+  display: inline-block;
+  margin-left: 8px;
+  margin-right: 0;
+}
+
+.ycs-app--shorts .ycs-head-search {
+  overflow: hidden;
+}
+
+.ycs-app--shorts .ycs_btn_load-stop {
+  position: static;
+  display: inline-block;
+  /* Match load-all button styles for alignment */
+  padding: 6px;
+  margin: 0;
+  border: 1px solid #ececec;
+  background-color: #f8f8f8;
+}
+
+html[dark='true'] .ycs-app--shorts .ycs_btn_load-stop,
+html[dark] .ycs-app--shorts .ycs_btn_load-stop {
+  border: 1px solid #303030;
+  background-color: #313131;
+  color: #fff;
+}
+
+/* Add spacing between buttons and infobar */
+.ycs-app--shorts .ycs-infobar {
+  margin-top: 10px;
+}
+
+.ycs-app--shorts #ycs-search {
+  margin-top: 15px;
+}
+
+/* Hide transcript language selector */
+.ycs-app--shorts .ycs_language_wrap {
+  display: none;
+}
+
+/* Hide extra panel (View Mode button) */
+.ycs-app--shorts .ycs_extra_panel {
+  display: none;
+}
+
+/* Search result container adjustments */
+.ycs-app--shorts #ycs-search-result {
+  overflow-y: auto;
+  overflow-x: hidden;
+  /* max-height will be set dynamically via JS */
+}

--- a/app/src/source/utils/common.ts
+++ b/app/src/source/utils/common.ts
@@ -146,7 +146,14 @@ function getVideoId(url: string): string | undefined {
         const host = parsedUrl.hostname;
         const pathname = parsedUrl.pathname || '';
         const segments = pathname.split('/').filter(Boolean);
+
+        // Detect live channel page
         if ((host === 'www.youtube.com' || host.endsWith('youtube.com')) && segments[0] === 'live' && segments[1]) {
+            return segments[1];
+        }
+
+        // Detect shorts page
+        if ((host === 'www.youtube.com' || host.endsWith('youtube.com')) && segments[0] === 'shorts' && segments[1]) {
             return segments[1];
         }
 
@@ -183,7 +190,11 @@ function isWatchVideo(): boolean {
 
 function isVideoPage(): boolean {
     const href = window.location.href;
-    return href.includes('/watch?') || href.includes('/live/');
+    return href.includes('/watch?') || href.includes('/live/') || href.includes('/shorts/');
+}
+
+function isShortsPage(): boolean {
+    return window.location.href.includes('/shorts/');
 }
 
 function getPaginate(
@@ -392,6 +403,7 @@ export {
     getCleanUrlVideo,
     isWatchVideo,
     isVideoPage,
+    isShortsPage,
     getPaginate,
     extractChannelId,
     extractVideoId,

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { safeUrl } from '../utils/formatting';
-import { randomString } from '../utils/common';
+import { randomString, isShortsPage } from '../utils/common';
 import { markTextComment, getPiP } from '../utils/dom';
 import { options } from '../config/options';
 import {
@@ -654,7 +654,10 @@ function isElementVisible(element: Element | null): boolean {
     );
 }
 
-function renderLoadComments(selector: string, preferredInsertionMode?: 'appendChild' | 'insertAfter'): void {
+function renderLoadComments(
+    selector: string,
+    preferredInsertionMode?: 'appendChild' | 'insertAfter' | 'prepend'
+): void {
     if (typeof selector !== 'string') return;
 
     if (DEBUG) {
@@ -678,7 +681,7 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
 
     // Visibility check and fallback mechanism
     let targetElement: HTMLElement | null = node as HTMLElement | null;
-    let insertionMode: 'appendChild' | 'insertAfter' = preferredInsertionMode || 'appendChild';
+    let insertionMode: 'appendChild' | 'insertAfter' | 'prepend' = preferredInsertionMode || 'appendChild';
 
     // Only check visibility and fallback when using appendChild mode
     // insertAfter mode skips visibility check (element may be temporarily hidden during SPA navigation)
@@ -717,7 +720,7 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
     }
 
     const nodeTag = document.createElement('div');
-    nodeTag.className = 'ycs-app';
+    nodeTag.className = isShortsPage() ? 'ycs-app ycs-app--shorts' : 'ycs-app';
     nodeTag.innerHTML = `
         <div class="ycs-app-toggle"><p class="ycs-title ycs-left">YouTube Comment Search <span id="ycs-count-load-collapsed"></span></p><div class="ycs-right"><button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">Show YCS</button></div></div>
         <div class="ycs-app-main">
@@ -920,7 +923,10 @@ function renderLoadComments(selector: string, preferredInsertionMode?: 'appendCh
     `;
 
     // Execute based on insertion mode
-    if (insertionMode === 'appendChild') {
+    if (insertionMode === 'prepend') {
+        // prepend implementation: insert as first child
+        targetElement.insertBefore(nodeTag, targetElement.firstChild);
+    } else if (insertionMode === 'appendChild') {
         targetElement.appendChild(nodeTag);
     } else if (insertionMode === 'insertAfter') {
         // insertAfter implementation: check parentNode to avoid TypeError

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -6,6 +6,7 @@ import {
     getCleanUrlVideo,
     getVideoId,
     isVideoPage,
+    isShortsPage,
     extractVideoDuration
 } from '../utils/common';
 import {
@@ -216,6 +217,40 @@ export function initApp(): void {
 
     let state = createState();
 
+    /**
+     * Adjust search result max-height for Shorts pages
+     * Calculates available height based on anchored-panel and ycs-search position
+     */
+    function adjustSearchResultHeightForShorts(): void {
+        if (!isShortsPage()) return;
+
+        const anchoredPanel = document.querySelector('#anchored-panel') as HTMLElement;
+        const ycsSearch = document.querySelector('#ycs-search') as HTMLElement;
+        const searchResult = document.querySelector('#ycs-search-result') as HTMLElement;
+
+        if (!anchoredPanel || !ycsSearch || !searchResult) return;
+
+        try {
+            // Get anchored-panel height
+            const panelHeight = anchoredPanel.offsetHeight;
+
+            // Get ycs-search bottom position relative to anchored-panel top
+            const ycsSearchRect = ycsSearch.getBoundingClientRect();
+            const panelRect = anchoredPanel.getBoundingClientRect();
+            const ycsSearchBottom = ycsSearchRect.bottom - panelRect.top;
+
+            // Calculate available height
+            const availableHeight = panelHeight - ycsSearchBottom;
+
+            // Set max-height with some padding (20px)
+            if (availableHeight > 100) {
+                searchResult.style.maxHeight = `${availableHeight - 20}px`;
+            }
+        } catch (error) {
+            console.error('YCS: Failed to adjust search result height for Shorts', error);
+        }
+    }
+
     function app(): void {
         if (!isVideoPage()) return;
 
@@ -247,19 +282,29 @@ export function initApp(): void {
             handleDocumentClick = null;
         }
 
-        // Try new insertion points first (between expandable-metadata and ticket-shelf)
-        if (document.querySelector('#expandable-metadata.ytd-watch-flexy')) {
-            renderLoadComments('#expandable-metadata.ytd-watch-flexy', 'insertAfter');
-        } else if (document.querySelector('#ticket-shelf')) {
-            renderLoadComments('#ticket-shelf', 'insertAfter');
-        } else if (document.querySelector('#meta.style-scope.ytd-watch-flexy')) {
-            renderLoadComments('#meta.style-scope.ytd-watch-flexy');
-        } else if (document.querySelector('#meta.style-scope')) {
-            renderLoadComments('#meta.style-scope');
-        } else if (document.querySelector('ytd-watch-metadata')) {
-            renderLoadComments('ytd-watch-metadata', 'insertAfter');
+        // Handle Shorts pages differently
+        if (isShortsPage()) {
+            if (document.querySelector('#anchored-panel')) {
+                renderLoadComments('#anchored-panel', 'prepend');
+            } else {
+                console.warn('YCS: Shorts page detected but #anchored-panel not found');
+                return;
+            }
         } else {
-            return;
+            // Try new insertion points first (between expandable-metadata and ticket-shelf)
+            if (document.querySelector('#expandable-metadata.ytd-watch-flexy')) {
+                renderLoadComments('#expandable-metadata.ytd-watch-flexy', 'insertAfter');
+            } else if (document.querySelector('#ticket-shelf')) {
+                renderLoadComments('#ticket-shelf', 'insertAfter');
+            } else if (document.querySelector('#meta.style-scope.ytd-watch-flexy')) {
+                renderLoadComments('#meta.style-scope.ytd-watch-flexy');
+            } else if (document.querySelector('#meta.style-scope')) {
+                renderLoadComments('#meta.style-scope');
+            } else if (document.querySelector('ytd-watch-metadata')) {
+                renderLoadComments('ytd-watch-metadata', 'insertAfter');
+            } else {
+                return;
+            }
         }
 
         const elSearch = document.getElementById('ycs-search');
@@ -267,6 +312,15 @@ export function initApp(): void {
             renderSearch(elSearch);
             // Initial button loading (using default settings)
             loadFilterButtons();
+
+            // Adjust height for Shorts pages
+            if (isShortsPage()) {
+                // Use setTimeout to ensure DOM is fully rendered
+                setTimeout(() => {
+                    adjustSearchResultHeightForShorts();
+                }, 100);
+            }
+
             // Toggle collapsed/expand of app
             try {
                 const toggles = document.getElementsByClassName('ycs-btn-toggle-app');

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -198,6 +198,17 @@ const buildSearchContext = (): SearchContext => {
 let appFunction: (() => void) | null = null;
 let observeIntervalId: ReturnType<typeof setInterval> | null = null;
 
+/**
+ * Gets the appropriate meta element for the current page type.
+ * For Shorts pages, checks #anchored-panel, otherwise checks #meta.style-scope.ytd-watch-flexy
+ */
+export function getPageMetaElement(): Element | null {
+    if (isShortsPage()) {
+        return document.querySelector('#anchored-panel');
+    }
+    return document.querySelector('#meta.style-scope.ytd-watch-flexy');
+}
+
 export function retryApp(): boolean {
     if (!appFunction) {
         return false;
@@ -1875,11 +1886,7 @@ export function initApp(): void {
 
         // Store interval ID for cleanup on next initApp() call
         observeIntervalId = setInterval(() => {
-            if (
-                isVideoPage() &&
-                document.querySelector('#meta.style-scope.ytd-watch-flexy') &&
-                prevUrl !== getCleanUrlVideo(window.location.href)
-            ) {
+            if (isVideoPage() && getPageMetaElement() && prevUrl !== getCleanUrlVideo(window.location.href)) {
                 const currentUrl = getCleanUrlVideo(window.location.href);
 
                 getController(state).abort();

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -224,6 +224,13 @@ export function initApp(): void {
     function adjustSearchResultHeightForShorts(): void {
         if (!isShortsPage()) return;
 
+        // Skip calculation if app is collapsed (hidden by default)
+        // When collapsed, #ycs-search is hidden and getBoundingClientRect() returns incorrect values
+        const app = document.querySelector('.ycs-app') as HTMLElement;
+        if (app && app.classList.contains('ycs-collapsed')) {
+            return;
+        }
+
         const anchoredPanel = document.querySelector('#anchored-panel') as HTMLElement;
         const ycsSearch = document.querySelector('#ycs-search') as HTMLElement;
         const searchResult = document.querySelector('#ycs-search-result') as HTMLElement;
@@ -331,6 +338,12 @@ export function initApp(): void {
                             const app = document.getElementsByClassName('ycs-app')[0] as HTMLElement;
                             if (app) {
                                 app.classList.toggle('ycs-collapsed');
+                                // Recalculate height when app is expanded on Shorts pages
+                                if (isShortsPage() && !app.classList.contains('ycs-collapsed')) {
+                                    setTimeout(() => {
+                                        adjustSearchResultHeightForShorts();
+                                    }, 100);
+                                }
                             }
                         },
                         false
@@ -1621,6 +1634,12 @@ export function initApp(): void {
                         if (!app) return;
                         // Apply collapsed state instead of fully hiding the app to keep the top toggle visible
                         app.classList.toggle('ycs-collapsed', value);
+                        // Recalculate height when app is expanded on Shorts pages
+                        if (isShortsPage() && !value) {
+                            setTimeout(() => {
+                                adjustSearchResultHeightForShorts();
+                            }, 100);
+                        }
                     } catch (err) {
                         console.error(err);
                     }

--- a/app/src/source/web-resources/bootstrap.ts
+++ b/app/src/source/web-resources/bootstrap.ts
@@ -1,4 +1,4 @@
-import { isVideoPage } from '../utils/common';
+import { isVideoPage, isShortsPage } from '../utils/common';
 import { initApp, retryApp } from './appController';
 
 const DEBUG = false;
@@ -18,6 +18,10 @@ const POPSTATE_INIT_DELAY_MS = 100; // Wait for YouTube SPA DOM update after pop
 const POLLING_INTERVAL_MS = 2000; // Fallback polling interval (reduced since MutationObserver handles most cases)
 
 const metaElementExists = (): Element | null => {
+    // For shorts pages, check for #anchored-panel instead
+    if (isShortsPage()) {
+        return document.querySelector('#anchored-panel');
+    }
     return document.querySelector(META_SELECTOR);
 };
 

--- a/app/src/source/web-resources/bootstrap.ts
+++ b/app/src/source/web-resources/bootstrap.ts
@@ -1,9 +1,7 @@
-import { isVideoPage, isShortsPage } from '../utils/common';
-import { initApp, retryApp } from './appController';
+import { isVideoPage } from '../utils/common';
+import { initApp, retryApp, getPageMetaElement } from './appController';
 
 const DEBUG = false;
-const META_SELECTOR = '#meta.style-scope.ytd-watch-flexy';
-
 let hasStarted = false;
 let mutationObserver: MutationObserver | null = null;
 let isRetryingApp = false;
@@ -16,14 +14,6 @@ const VERIFICATION_DELAY_MS = 300; // Wait for normal re-renders to complete
 const RETRY_STATE_RESET_DELAY_MS = 500; // Prevent immediate re-trigger
 const POPSTATE_INIT_DELAY_MS = 100; // Wait for YouTube SPA DOM update after popstate
 const POLLING_INTERVAL_MS = 2000; // Fallback polling interval (reduced since MutationObserver handles most cases)
-
-const metaElementExists = (): Element | null => {
-    // For shorts pages, check for #anchored-panel instead
-    if (isShortsPage()) {
-        return document.querySelector('#anchored-panel');
-    }
-    return document.querySelector(META_SELECTOR);
-};
 
 /**
  * Throttled version of retryApp with state protection
@@ -168,7 +158,7 @@ export function startWebResources(): void {
     let isInitAppCalled = false;
 
     const ensureAppInitialized = (source: string): void => {
-        if (!isVideoPage() || !metaElementExists()) {
+        if (!isVideoPage() || !getPageMetaElement()) {
             return;
         }
 
@@ -187,7 +177,7 @@ export function startWebResources(): void {
             console.log('YCS: yt-navigate-finish detected');
             console.log('isInitAppCalled: ', isInitAppCalled);
             console.log('isVideoPage: ', isVideoPage());
-            console.log('document.querySelector(#meta.style-scope.ytd-watch-flexy): ', metaElementExists());
+            console.log('document.querySelector(#meta.style-scope.ytd-watch-flexy): ', getPageMetaElement());
         }
 
         ensureAppInitialized('yt-navigate-finish');
@@ -198,7 +188,7 @@ export function startWebResources(): void {
             console.log('YCS: popstate detected');
             console.log('isInitAppCalled: ', isInitAppCalled);
             console.log('isVideoPage: ', isVideoPage());
-            console.log('document.querySelector(#meta.style-scope.ytd-watch-flexy): ', metaElementExists());
+            console.log('document.querySelector(#meta.style-scope.ytd-watch-flexy): ', getPageMetaElement());
         }
 
         setTimeout(() => {
@@ -215,7 +205,7 @@ export function startWebResources(): void {
     // Polling fallback mechanism (runs continuously at lower frequency)
     // No need to store interval ID - runs for entire extension lifecycle
     setInterval(() => {
-        if (!isVideoPage() || !metaElementExists()) {
+        if (!isVideoPage() || !getPageMetaElement()) {
             return;
         }
 


### PR DESCRIPTION
## Summary

Add full support for YouTube Shorts pages with optimized UI layout and adaptive height calculation. Extended video detection logic now supports `/shorts/` URL pattern, with dedicated CSS styling and dynamic height adjustment mechanism to ensure smooth user experience on Shorts pages.

## Key Changes

### Core Logic

- **URL Detection Enhancement**: `getVideoId()` and `isVideoPage()` now support `/shorts/` URL pattern
- **Shorts Page Detection**: Added `isShortsPage()` utility function to detect current page type
- **DOM Insertion Strategy**: Shorts pages use `prepend` mode to insert app at top of `#anchored-panel`
- **Adaptive Height Calculation**: Added `adjustSearchResultHeightForShorts()` function to dynamically calculate search result area `max-height` based on available panel space

### UI Optimization

- **Dedicated Style Class**: Introduced `.ycs-app--shorts` CSS class for Shorts-specific layout adjustments
- **Button Layout**: Load All and Stop buttons arranged horizontally in Shorts mode
- **Component Hiding**: Auto-hide inapplicable UI components (transcript language selector, view mode toggle button)
- **Spacing Adjustment**: Optimized vertical spacing for Infobar and search box, removed excess bottom margin

---

Shorts page overview (with comments section open)
<img src=https://github.com/user-attachments/assets/d94152e8-c756-4d22-ae79-c55b17bfd73c  width=100%>

Expanded YCS panel
<img src=https://github.com/user-attachments/assets/2dc1bb80-dd77-4eaf-97ea-b83dda4356e0  width=500>

Showing comments
<img src=https://github.com/user-attachments/assets/2278736f-a88c-4e75-97cb-fa2d81bdef50  width=500>
