### PR TITLE
fix(shorts): dynamically adjust engagement panel height based on ycs-app

### DIFF
--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -1412,3 +1412,7 @@ html[dark] .ycs-app--shorts .ycs_btn_load-stop {
   overflow-x: hidden;
   /* max-height will be set dynamically via JS */
 }
+
+#anchored-panel {
+  overflow: hidden;
+}

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -231,6 +231,7 @@ export function retryApp(): boolean {
 
 export function initApp(): void {
     let handleMessageEvent: ((ev: MessageEvent<ExtensionMessagePayload>) => void) | null = null;
+    let resizeObserver: ResizeObserver | null = null;
 
     let state = createState();
 
@@ -275,6 +276,35 @@ export function initApp(): void {
         }
     }
 
+    /**
+     * Adjust engagement panel content height and min-height for Shorts pages
+     * Dynamically calculates height by subtracting .ycs-app height from the base calculation
+     * Always subtracts .ycs-app height regardless of collapsed/expanded state
+     */
+    function adjustEngagementPanelHeightForShorts(): void {
+        if (!isShortsPage()) return;
+
+        const app = document.querySelector('.ycs-app') as HTMLElement;
+        const engagementPanelContent = document.querySelector(
+            '#content.ytd-engagement-panel-section-list-renderer'
+        ) as HTMLElement;
+
+        if (!engagementPanelContent || !app) return;
+
+        try {
+            // Get .ycs-app current height (even when collapsed, it still has height for toggle button)
+            const ycsAppHeight = app.offsetHeight;
+
+            // Set height and min-height using calc() expression
+            // Original: calc(var(--ytd-engagement-panel-content-height) - 56px)
+            // New: calc(var(--ytd-engagement-panel-content-height) - 56px - [.ycs-app height]px)
+            engagementPanelContent.style.height = `calc(var(--ytd-engagement-panel-content-height) - 56px - ${ycsAppHeight}px)`;
+            engagementPanelContent.style.minHeight = `calc(var(--ytd-engagement-panel-content-min-height) - 56px - ${ycsAppHeight}px)`;
+        } catch (error) {
+            console.error('YCS: Failed to adjust engagement panel height for Shorts', error);
+        }
+    }
+
     function app(): void {
         if (!isVideoPage()) return;
 
@@ -294,6 +324,12 @@ export function initApp(): void {
 
         if (handleMessageEvent) {
             window.removeEventListener('message', handleMessageEvent);
+        }
+
+        // Clean up ResizeObserver when switching videos
+        if (resizeObserver) {
+            resizeObserver.disconnect();
+            resizeObserver = null;
         }
 
         state = createState();
@@ -343,7 +379,33 @@ export function initApp(): void {
                 // Use setTimeout to ensure DOM is fully rendered
                 setTimeout(() => {
                     adjustSearchResultHeightForShorts();
+                    adjustEngagementPanelHeightForShorts();
+
+                    // Set up ResizeObserver to watch .ycs-app height changes
+                    const app = document.querySelector('.ycs-app') as HTMLElement;
+                    if (app && typeof ResizeObserver !== 'undefined') {
+                        // Clean up existing observer if any
+                        if (resizeObserver) {
+                            resizeObserver.disconnect();
+                        }
+
+                        // Create new ResizeObserver
+                        resizeObserver = new ResizeObserver(() => {
+                            // Debounce the adjustment to avoid excessive calls
+                            setTimeout(() => {
+                                adjustEngagementPanelHeightForShorts();
+                            }, 50);
+                        });
+
+                        resizeObserver.observe(app);
+                    }
                 }, 100);
+            } else {
+                // Clean up ResizeObserver for non-Shorts pages
+                if (resizeObserver !== null) {
+                    (resizeObserver as ResizeObserver).disconnect();
+                    resizeObserver = null;
+                }
             }
 
             // Toggle collapsed/expand of app
@@ -356,10 +418,11 @@ export function initApp(): void {
                             const app = document.getElementsByClassName('ycs-app')[0] as HTMLElement;
                             if (app) {
                                 app.classList.toggle('ycs-collapsed');
-                                // Recalculate height when app is expanded on Shorts pages
-                                if (isShortsPage() && !app.classList.contains('ycs-collapsed')) {
+                                // Recalculate height when app is toggled on Shorts pages
+                                if (isShortsPage()) {
                                     setTimeout(() => {
                                         adjustSearchResultHeightForShorts();
+                                        adjustEngagementPanelHeightForShorts();
                                     }, 100);
                                 }
                             }
@@ -1652,10 +1715,11 @@ export function initApp(): void {
                         if (!app) return;
                         // Apply collapsed state instead of fully hiding the app to keep the top toggle visible
                         app.classList.toggle('ycs-collapsed', value);
-                        // Recalculate height when app is expanded on Shorts pages
-                        if (isShortsPage() && !value) {
+                        // Recalculate height when app visibility changes on Shorts pages
+                        if (isShortsPage()) {
                             setTimeout(() => {
                                 adjustSearchResultHeightForShorts();
+                                adjustEngagementPanelHeightForShorts();
                             }, 100);
                         }
                     } catch (err) {


### PR DESCRIPTION
## Summary

ref: #103 

Fix engagement panel height calculation on YouTube Shorts pages to properly account for YCS app height, preventing content overflow and layout conflicts.

## Main Changes

- **Dynamic height adjustment**: Added `adjustEngagementPanelHeightForShorts()` function to calculate engagement panel `height` and `min-height` by subtracting `.ycs-app` height from the base calculation
- **Automatic updates**: Integrated `ResizeObserver` to monitor `.ycs-app` height changes and automatically update engagement panel height when app is toggled, expanded/collapsed, or resized
- **CSS overflow fix**: Added `overflow: hidden` to `#anchored-panel` to prevent content overflow issues
- **Lifecycle management**: Properly clean up `ResizeObserver` when navigating between videos or switching between Shorts and non-Shorts pages
- **Consistent behavior**: Always subtract `.ycs-app` height regardless of collapsed/expanded state to maintain proper layout

---

Hide
<img src=https://github.com/user-attachments/assets/669996ea-78e9-4d00-918f-f7193ff458a7  width=400>

Show
<img src=https://github.com/user-attachments/assets/cc932835-8470-44d4-8cca-d26d81854dcf  width=400>

