### PR TITLE
feat(chat): add live chat recording for YouTube live streams

### DIFF
--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -959,14 +959,19 @@ html[dark] .ycs_modal_body code {
 }
 
 /* Confirmation Modal */
+
+#ycs_confirm_modal {
+  padding-top: 20vh;
+}
+
 .ycs_confirm_content {
-  max-width: 420px;
-  text-align: center;
+  max-width: 600px;
+  text-align: inherit;
 }
 
 .ycs_confirm_buttons {
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   gap: 12px;
   margin-top: 20px;
 }

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -958,6 +958,32 @@ html[dark] .ycs_modal_body code {
   color: #303030;
 }
 
+/* Confirmation Modal */
+.ycs_confirm_content {
+  max-width: 420px;
+  text-align: center;
+}
+
+.ycs_confirm_buttons {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+.ycs_btn_primary {
+  background-color: #065fd4 !important;
+  color: white !important;
+  border-color: #065fd4 !important;
+}
+
+html[dark='true'] .ycs_btn_primary,
+html[dark] .ycs_btn_primary {
+  background-color: #3ea6ff !important;
+  border-color: #3ea6ff !important;
+  color: #0f0f0f !important;
+}
+
 .ycs_donation_block {
   margin: 0;
 }

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -1416,3 +1416,57 @@ html[dark] .ycs-app--shorts .ycs_btn_load-stop {
 #anchored-panel {
   overflow: hidden;
 }
+
+/* Live Chat Recording Button Styles */
+.ycs_record_wrap {
+  float: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ycs-btn-record {
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease;
+}
+
+/* Recording active state */
+.ycs-btn-record.ycs-recording {
+  background-color: #e74c3c !important;
+  border-color: #c0392b !important;
+  color: #fff !important;
+  animation: ycs-pulse 1.5s infinite ease-in-out;
+}
+
+html[dark='true'] .ycs-btn-record.ycs-recording,
+html[dark] .ycs-btn-record.ycs-recording {
+  background-color: #c0392b !important;
+  border-color: #a93226 !important;
+  color: #fff !important;
+}
+
+/* Pulse animation for recording indicator */
+@keyframes ycs-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+/* Recording timer display */
+.ycs-record-timer {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 12px;
+  color: #e74c3c;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+html[dark='true'] .ycs-record-timer,
+html[dark] .ycs-record-timer {
+  color: #ff6b6b;
+}

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -1423,6 +1423,7 @@ html[dark] .ycs-app--shorts .ycs_btn_load-stop {
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  margin-right: 4px;
 }
 
 .ycs-btn-record {

--- a/app/src/source/utils/dom.ts
+++ b/app/src/source/utils/dom.ts
@@ -250,7 +250,8 @@ function setCacheToIDB(value: any, url: string, title: string): void {
                     comments: value.comments,
                     commentsChat: value.commentsChat,
                     commentsTrVideo: value.commentsTrVideo,
-                    channelId: value.channelId
+                    channelId: value.channelId,
+                    chatSource: value.chatSource
                 }
             },
             window.location.origin

--- a/app/src/source/utils/export-core.ts
+++ b/app/src/source/utils/export-core.ts
@@ -1,6 +1,6 @@
 import type { ChatItem, TranscriptCueGroup, CommentItem } from './interfaces/i_types';
 import type { ISheetChatCommentsParam, ISheetCommentsParam, ISheetRepliesParam } from './interfaces/i_assist';
-import { msToRoundSec, parseFormattedNumberToInt, formatRelativeTimestamp } from './formatting';
+import { msToRoundSec, parseFormattedNumberToInt, formatRelativeTimestamp, formatDurationHMS } from './formatting';
 import { getVideoId, wrapTryCatch } from './common';
 
 export type CommentExportItem = ISheetCommentsParam;
@@ -202,8 +202,41 @@ function buildChatAuthorChannel(renderer: any): string {
     return authorChannelId ? `youtube.com/channel/${authorChannelId}` : '';
 }
 
-function createChatExportRow(renderer: any, broadcastStartTime?: string): ISheetChatCommentsParam {
+/**
+ * Check if a timestamp label is in relative format (e.g., "2:35", "1:02:35")
+ * vs absolute format (e.g., "4:30 PM", "16:30")
+ */
+function isRelativeTimestamp(label: string): boolean {
+    if (!label) return false;
+    // Relative timestamps are typically in format "M:SS" or "H:MM:SS" without AM/PM
+    // and don't contain special characters or excessive digits for hours
+    const relativePattern = /^\d{1,2}:\d{2}(:\d{2})?$/;
+    return relativePattern.test(label.trim());
+}
+
+function createChatExportRow(
+    renderer: any,
+    broadcastStartTime?: string,
+    videoOffsetTimeMsec?: string | number
+): ISheetChatCommentsParam {
     const timestampUsec = Number(renderer?.timestampUsec || 0);
+
+    // Read timestampText with fallback (consistent with viewModels logic)
+    const rawTimestampText =
+        (wrapTryCatch(() => renderer?.timestampText?.simpleText) as string | undefined) ||
+        (wrapTryCatch(() => renderer?.timestampText?.runs?.[0]?.text) as string | undefined) ||
+        '';
+
+    // Generate timestampText from videoOffsetTimeMsec if rawTimestampText is empty or not relative
+    let timestampText = rawTimestampText;
+    if (videoOffsetTimeMsec !== undefined && (!timestampText || !isRelativeTimestamp(timestampText))) {
+        const offsetMs =
+            typeof videoOffsetTimeMsec === 'string' ? parseFloat(videoOffsetTimeMsec) : videoOffsetTimeMsec;
+        if (!Number.isNaN(offsetMs) && offsetMs >= 0) {
+            timestampText = formatDurationHMS(offsetMs);
+        }
+    }
+
     const row: ISheetChatCommentsParam = {
         author: {
             nameAuthor: renderer?.authorName?.simpleText || '',
@@ -212,10 +245,18 @@ function createChatExportRow(renderer: any, broadcastStartTime?: string): ISheet
         },
         commentMessage: buildChatMessage(renderer),
         timestampUsec,
-        timestampText: renderer?.timestampText?.simpleText || ''
+        timestampText: timestampText
     };
 
-    if (broadcastStartTime && timestampUsec > 0) {
+    // Priority 1: Use pre-calculated videoOffsetTimeMsec (consistent with render logic)
+    if (videoOffsetTimeMsec !== undefined) {
+        const offsetMs =
+            typeof videoOffsetTimeMsec === 'string' ? parseFloat(videoOffsetTimeMsec) : videoOffsetTimeMsec;
+        if (!Number.isNaN(offsetMs) && offsetMs >= 0) {
+            row.relativeTimestamp = '+' + formatDurationHMS(offsetMs);
+        }
+    } else if (broadcastStartTime && timestampUsec > 0) {
+        // Fallback: Calculate from broadcastStartTime (backward compatibility)
         row.relativeTimestamp = formatRelativeTimestamp(timestampUsec, broadcastStartTime);
     }
 
@@ -317,7 +358,12 @@ export function buildChatExportPayload(
             (itemData as any)?.liveChatMembershipItemRenderer;
         if (!renderer) continue;
 
-        payload.commentsChat.push(createChatExportRow(renderer, meta?.broadcastStartTime));
+        const videoOffsetTimeMsec = wrapTryCatch(() => (item as any).replayChatItemAction?.videoOffsetTimeMsec) as
+            | string
+            | number
+            | undefined;
+
+        payload.commentsChat.push(createChatExportRow(renderer, meta?.broadcastStartTime, videoOffsetTimeMsec));
     }
 
     payload.total = payload.commentsChat.length;
@@ -412,7 +458,12 @@ export function buildChatExportPayloadFromCache(body: any): ChatExportPayload | 
             (itemData as any)?.liveChatMembershipItemRenderer;
         if (!renderer) continue;
 
-        payload.commentsChat.push(createChatExportRow(renderer));
+        const videoOffsetTimeMsec = wrapTryCatch(() => entry.replayChatItemAction?.videoOffsetTimeMsec) as
+            | string
+            | number
+            | undefined;
+
+        payload.commentsChat.push(createChatExportRow(renderer, body?.broadcastStartTime, videoOffsetTimeMsec));
     }
 
     payload.total = payload.commentsChat.length;

--- a/app/src/source/utils/export-core.ts
+++ b/app/src/source/utils/export-core.ts
@@ -254,6 +254,7 @@ function createChatExportRow(
             typeof videoOffsetTimeMsec === 'string' ? parseFloat(videoOffsetTimeMsec) : videoOffsetTimeMsec;
         if (!Number.isNaN(offsetMs) && offsetMs >= 0) {
             row.relativeTimestamp = '+' + formatDurationHMS(offsetMs);
+            row.videoOffsetMs = offsetMs;
         }
     } else if (broadcastStartTime && timestampUsec > 0) {
         // Fallback: Calculate from broadcastStartTime (backward compatibility)

--- a/app/src/source/utils/export-core.ts
+++ b/app/src/source/utils/export-core.ts
@@ -1,6 +1,6 @@
 import type { ChatItem, TranscriptCueGroup, CommentItem } from './interfaces/i_types';
 import type { ISheetChatCommentsParam, ISheetCommentsParam, ISheetRepliesParam } from './interfaces/i_assist';
-import { msToRoundSec, parseFormattedNumberToInt } from './formatting';
+import { msToRoundSec, parseFormattedNumberToInt, formatRelativeTimestamp } from './formatting';
 import { getVideoId, wrapTryCatch } from './common';
 
 export type CommentExportItem = ISheetCommentsParam;
@@ -26,6 +26,7 @@ export interface ChatExportItem {
     commentMessage: string;
     timestampUsec: number;
     timestampText: string;
+    relativeTimestamp?: string; // Format: "+H:MM:SS" (relative to broadcast start)
 }
 
 export interface ChatExportPayload {
@@ -201,17 +202,24 @@ function buildChatAuthorChannel(renderer: any): string {
     return authorChannelId ? `youtube.com/channel/${authorChannelId}` : '';
 }
 
-function createChatExportRow(renderer: any): ISheetChatCommentsParam {
-    return {
+function createChatExportRow(renderer: any, broadcastStartTime?: string): ISheetChatCommentsParam {
+    const timestampUsec = Number(renderer?.timestampUsec || 0);
+    const row: ISheetChatCommentsParam = {
         author: {
             nameAuthor: renderer?.authorName?.simpleText || '',
             channel: buildChatAuthorChannel(renderer),
             member: buildChatMemberText(renderer)
         },
         commentMessage: buildChatMessage(renderer),
-        timestampUsec: Number(renderer?.timestampUsec || 0),
+        timestampUsec,
         timestampText: renderer?.timestampText?.simpleText || ''
     };
+
+    if (broadcastStartTime && timestampUsec > 0) {
+        row.relativeTimestamp = formatRelativeTimestamp(timestampUsec, broadcastStartTime);
+    }
+
+    return row;
 }
 
 function createTranscriptExportItem(group: TranscriptCueGroup, videoId: string): TranscriptExportItem {
@@ -290,7 +298,7 @@ export function buildCommentsExportPayload(input: {
 
 export function buildChatExportPayload(
     chatMessages: ChatItem[],
-    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; broadcastStartTime?: string }
 ): ChatExportPayload {
     const payload = createChatPayloadSkeleton({
         titleVideo: meta?.titleVideo,
@@ -309,7 +317,7 @@ export function buildChatExportPayload(
             (itemData as any)?.liveChatMembershipItemRenderer;
         if (!renderer) continue;
 
-        payload.commentsChat.push(createChatExportRow(renderer));
+        payload.commentsChat.push(createChatExportRow(renderer, meta?.broadcastStartTime));
     }
 
     payload.total = payload.commentsChat.length;

--- a/app/src/source/utils/formatting.ts
+++ b/app/src/source/utils/formatting.ts
@@ -4,6 +4,7 @@ interface ExportMeta {
     url?: string;
     title?: string;
     generatedAt?: Date | string;
+    broadcastStartTime?: string;
 }
 
 interface ResolvedExportMeta {
@@ -209,6 +210,76 @@ function tmUsecToDateTime(microSec: string | number): string {
     }
 
     return '';
+}
+
+/**
+ * Format duration in milliseconds to H:MM:SS
+ */
+function formatDurationHMS(durationMs: number): string {
+    const totalSeconds = Math.floor(durationMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    const mm = minutes.toString().padStart(2, '0');
+    const ss = seconds.toString().padStart(2, '0');
+
+    return `${hours}:${mm}:${ss}`;
+}
+
+/**
+ * Format relative timestamp from broadcast start
+ * @param timestampUsec - Message timestamp in microseconds
+ * @param broadcastStartTime - Broadcast start ISO timestamp
+ * @returns Formatted string like "+0:12:34" or "+1:30:00"
+ */
+function formatRelativeTimestamp(timestampUsec: string | number, broadcastStartTime: string): string {
+    try {
+        const messageTimeMs = Number(timestampUsec) / 1000; // Convert usec to ms
+        const broadcastStartMs = new Date(broadcastStartTime).getTime();
+
+        if (Number.isNaN(messageTimeMs) || Number.isNaN(broadcastStartMs)) {
+            return '';
+        }
+
+        const offsetMs = messageTimeMs - broadcastStartMs;
+        if (offsetMs < 0) {
+            return '-' + formatDurationHMS(Math.abs(offsetMs));
+        }
+
+        return '+' + formatDurationHMS(offsetMs);
+    } catch (e) {
+        console.error('[YCS] formatRelativeTimestamp error:', e);
+        return '';
+    }
+}
+
+/**
+ * Format recording duration for timer display
+ * @param startTimeMs - Recording start timestamp in milliseconds
+ * @returns Formatted string like "00:05:30"
+ */
+function formatRecordingDuration(startTimeMs: number): string {
+    try {
+        const now = Date.now();
+        const durationMs = now - startTimeMs;
+
+        if (durationMs < 0) return '00:00:00';
+
+        const totalSeconds = Math.floor(durationMs / 1000);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const seconds = totalSeconds % 60;
+
+        const hh = hours.toString().padStart(2, '0');
+        const mm = minutes.toString().padStart(2, '0');
+        const ss = seconds.toString().padStart(2, '0');
+
+        return `${hh}:${mm}:${ss}`;
+    } catch (e) {
+        console.error('[YCS] formatRecordingDuration error:', e);
+        return '00:00:00';
+    }
 }
 
 function formatBytes(bytes: number, decimals = 2): string | void {
@@ -435,6 +506,9 @@ export {
     msToRoundSec,
     msToShareVideo,
     tmUsecToDateTime,
+    formatDurationHMS,
+    formatRelativeTimestamp,
+    formatRecordingDuration,
     formatBytes,
     getCommentsHtmlText,
     getCommentsChatHtmlText,

--- a/app/src/source/utils/formatting.ts
+++ b/app/src/source/utils/formatting.ts
@@ -206,7 +206,14 @@ function tmUsecToDateTime(microSec: string | number): string {
     if (!Number.isNaN(value) && value > 0) {
         const dateTime = new Date((value as any) / 1000);
 
-        return `${dateTime.toISOString().split('T')[0]}, ${dateTime.toISOString().split('T')[1].split('.')[0].slice(0, 5)}`;
+        // Format as local time: YYYY-MM-DD, HH:MM
+        const year = dateTime.getFullYear();
+        const month = String(dateTime.getMonth() + 1).padStart(2, '0');
+        const day = String(dateTime.getDate()).padStart(2, '0');
+        const hours = String(dateTime.getHours()).padStart(2, '0');
+        const minutes = String(dateTime.getMinutes()).padStart(2, '0');
+
+        return `${year}-${month}-${day}, ${hours}:${minutes}`;
     }
 
     return '';

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -1,5 +1,11 @@
 export { getParams, getInitYtData } from './innertube/core';
-export { getParamsForChat, getChatComments } from './innertube/chat';
+export {
+    getParamsForChat,
+    getChatComments,
+    checkIsLiveStream,
+    getLiveBroadcastStartTime,
+    pollLiveChat
+} from './innertube/chat';
 export {
     getAllCommentsModeV2,
     extractNextContinuation,

--- a/app/src/source/utils/innertube/chat.ts
+++ b/app/src/source/utils/innertube/chat.ts
@@ -493,7 +493,8 @@ export async function getLiveBroadcastStartTime(signal?: AbortSignal): Promise<s
 export async function pollLiveChat(
     signal: AbortSignal,
     existingChatMap: Map<number, object>,
-    onNewMessages?: (newCount: number, totalCount: number) => void
+    onNewMessages?: (newCount: number, totalCount: number) => void,
+    broadcastStartTime?: string
 ): Promise<{ continuation: unknown } | undefined> {
     try {
         const result = await getCDChat(signal);
@@ -516,6 +517,7 @@ export async function pollLiveChat(
         const context: ChatProcessingContext = {
             chatMap: existingChatMap,
             currentVideoId,
+            broadcastStartTime,
             onCommentAdded: (count: number) => {
                 if (onNewMessages) {
                     onNewMessages(count - previousSize, count);

--- a/app/src/source/utils/innertube/chat.ts
+++ b/app/src/source/utils/innertube/chat.ts
@@ -488,27 +488,44 @@ export async function getLiveBroadcastStartTime(signal?: AbortSignal): Promise<s
 /**
  * Poll live chat for new messages during recording
  * Uses the same endpoint as getLiveChat but designed for incremental polling
- * @returns Object with new items and continuation, or undefined on error
+ * @param existingContinuation - Continuation from previous poll (skips ytInitialData fetch)
+ * @returns Object with continuation and isLiveEnded flag, or undefined on error
  */
 export async function pollLiveChat(
     signal: AbortSignal,
     existingChatMap: Map<number, object>,
     onNewMessages?: (newCount: number, totalCount: number) => void,
-    broadcastStartTime?: string
-): Promise<{ continuation: unknown } | undefined> {
+    broadcastStartTime?: string,
+    existingContinuation?: unknown
+): Promise<{ continuation: unknown; isLiveEnded: boolean } | undefined> {
     try {
-        const result = await getCDChat(signal);
-        if (!result.continuationData) return undefined;
+        let continuationData: unknown;
 
-        const liveChatData: any = await getLiveChat(result.continuationData, signal);
+        if (existingContinuation) {
+            // Reuse continuation from previous poll (avoids ytInitialData fetch)
+            continuationData = existingContinuation;
+        } else {
+            // First poll: get initial continuation from ytInitialData
+            const result = await getCDChat(signal);
+            if (!result.continuationData) return undefined;
+            continuationData = result.continuationData;
+        }
+
+        const liveChatData: any = await getLiveChat(continuationData, signal);
         if (!liveChatData?.actions?.length) {
             // No new messages, return current continuation
             const continuations = liveChatData?.continuations;
+            const hasInvalidationContinuation = continuations?.some((c: any) => c.invalidationContinuationData);
             const nextContinuation =
                 continuations?.find((c: any) => c.invalidationContinuationData)?.invalidationContinuationData ||
                 continuations?.find((c: any) => c.timedContinuationData)?.timedContinuationData ||
                 null;
-            return { continuation: nextContinuation };
+
+            // Live stream is considered ended when invalidationContinuationData disappears
+            // and only timedContinuationData remains (or continuation is null)
+            const isLiveEnded = !hasInvalidationContinuation && nextContinuation !== null;
+
+            return { continuation: nextContinuation, isLiveEnded };
         }
 
         const currentVideoId = (getVideoId(window.location.href) || undefined) as string | undefined;
@@ -530,12 +547,17 @@ export async function pollLiveChat(
 
         // Get continuation for next poll
         const continuations = liveChatData?.continuations;
+        const hasInvalidationContinuation = continuations?.some((c: any) => c.invalidationContinuationData);
         const nextContinuation =
             continuations?.find((c: any) => c.invalidationContinuationData)?.invalidationContinuationData ||
             continuations?.find((c: any) => c.timedContinuationData)?.timedContinuationData ||
             null;
 
-        return { continuation: nextContinuation };
+        // Live stream is considered ended when invalidationContinuationData disappears
+        // and only timedContinuationData remains (or continuation is null)
+        const isLiveEnded = !hasInvalidationContinuation && nextContinuation !== null;
+
+        return { continuation: nextContinuation, isLiveEnded };
     } catch (e) {
         console.error('[YCS] pollLiveChat error:', e);
         return undefined;

--- a/app/src/source/utils/innertube/chat.ts
+++ b/app/src/source/utils/innertube/chat.ts
@@ -515,15 +515,20 @@ export async function pollLiveChat(
         if (!liveChatData?.actions?.length) {
             // No new messages, return current continuation
             const continuations = liveChatData?.continuations;
+            const hasContinuations = continuations && continuations.length > 0;
             const hasInvalidationContinuation = continuations?.some((c: any) => c.invalidationContinuationData);
+            const hasReloadContinuation = continuations?.some((c: any) => c.reloadContinuationData);
+            const hasTimedContinuation = continuations?.some((c: any) => c.timedContinuationData);
             const nextContinuation =
                 continuations?.find((c: any) => c.invalidationContinuationData)?.invalidationContinuationData ||
                 continuations?.find((c: any) => c.timedContinuationData)?.timedContinuationData ||
                 null;
 
-            // Live stream is considered ended when invalidationContinuationData disappears
-            // and only timedContinuationData remains (or continuation is null)
-            const isLiveEnded = !hasInvalidationContinuation && nextContinuation !== null;
+            // Live stream is considered ended when:
+            // 1. No invalidationContinuationData (live-only continuation type)
+            // 2. AND one of: no continuations at all, reloadContinuationData, or timedContinuationData
+            const isLiveEnded =
+                !hasInvalidationContinuation && (!hasContinuations || hasReloadContinuation || hasTimedContinuation);
 
             return { continuation: nextContinuation, isLiveEnded };
         }
@@ -547,15 +552,20 @@ export async function pollLiveChat(
 
         // Get continuation for next poll
         const continuations = liveChatData?.continuations;
+        const hasContinuations = continuations && continuations.length > 0;
         const hasInvalidationContinuation = continuations?.some((c: any) => c.invalidationContinuationData);
+        const hasReloadContinuation = continuations?.some((c: any) => c.reloadContinuationData);
+        const hasTimedContinuation = continuations?.some((c: any) => c.timedContinuationData);
         const nextContinuation =
             continuations?.find((c: any) => c.invalidationContinuationData)?.invalidationContinuationData ||
             continuations?.find((c: any) => c.timedContinuationData)?.timedContinuationData ||
             null;
 
-        // Live stream is considered ended when invalidationContinuationData disappears
-        // and only timedContinuationData remains (or continuation is null)
-        const isLiveEnded = !hasInvalidationContinuation && nextContinuation !== null;
+        // Live stream is considered ended when:
+        // 1. No invalidationContinuationData (live-only continuation type)
+        // 2. AND one of: no continuations at all, reloadContinuationData, or timedContinuationData
+        const isLiveEnded =
+            !hasInvalidationContinuation && (!hasContinuations || hasReloadContinuation || hasTimedContinuation);
 
         return { continuation: nextContinuation, isLiveEnded };
     } catch (e) {

--- a/app/src/source/utils/innertube/chat.ts
+++ b/app/src/source/utils/innertube/chat.ts
@@ -198,9 +198,16 @@ export async function getChatComments(
         const chatCmnts = container || new Map<number, object>();
         const currentVideoId = (getVideoId(window.location.href) || undefined) as string | undefined;
 
+        // Fetch broadcast start time for live chat videoOffsetTimeMsec calculation
+        const broadcastStartTime = await getLiveBroadcastStartTime(signal);
+        if (broadcastStartTime) {
+            console.log(`[getChatComments] Broadcast start time: ${broadcastStartTime}`);
+        }
+
         const context: ChatProcessingContext = {
             chatMap: chatCmnts,
             currentVideoId,
+            broadcastStartTime: broadcastStartTime ?? undefined,
             onCommentAdded: (count: number) => showLoadComments(count, elShowLoading)
         };
 

--- a/app/src/source/utils/innertube/chat.ts
+++ b/app/src/source/utils/innertube/chat.ts
@@ -428,3 +428,114 @@ export async function getChatComments(
         return undefined;
     }
 }
+
+/**
+ * Check if current video is a live stream (ongoing broadcast)
+ * Live streams use invalidationContinuationData, replays use timedContinuationData
+ * @returns true if live stream, false if replay or non-live
+ */
+export async function checkIsLiveStream(signal?: AbortSignal): Promise<boolean> {
+    try {
+        const result = await getCDChat(signal as AbortSignal);
+        if (!result.continuationData) return false;
+
+        const liveChatData: any = await getLiveChat(result.continuationData, signal as AbortSignal);
+
+        // Live streams have actions with invalidationContinuationData
+        if (liveChatData?.actions?.length > 0) {
+            const continuations = liveChatData?.continuations;
+            const hasInvalidationContinuation = continuations?.some((c: any) => c.invalidationContinuationData);
+            return hasInvalidationContinuation === true;
+        }
+
+        return false;
+    } catch (e) {
+        console.error('[YCS] checkIsLiveStream error:', e);
+        return false;
+    }
+}
+
+/**
+ * Get broadcast start timestamp from playerResponse
+ * Path: playerResponse.microformat.playerMicroformatRenderer.liveBroadcastDetails.startTimestamp
+ * @returns ISO timestamp string or null if not found
+ */
+export async function getLiveBroadcastStartTime(signal?: AbortSignal): Promise<string | null> {
+    try {
+        const ytData = (await getInitYtData(window.location.href, signal)) as any;
+        if (!ytData) return null;
+
+        // Priority 1: Modern PBJ format (has playerResponse at top level)
+        let startTimestamp =
+            ytData?.playerResponse?.microformat?.playerMicroformatRenderer?.liveBroadcastDetails?.startTimestamp;
+
+        // Priority 2: Array format (legacy)
+        if (!startTimestamp && Array.isArray(ytData)) {
+            for (const item of ytData) {
+                startTimestamp =
+                    item?.playerResponse?.microformat?.playerMicroformatRenderer?.liveBroadcastDetails?.startTimestamp;
+                if (startTimestamp) break;
+            }
+        }
+
+        return startTimestamp || null;
+    } catch (e) {
+        console.error('[YCS] getLiveBroadcastStartTime error:', e);
+        return null;
+    }
+}
+
+/**
+ * Poll live chat for new messages during recording
+ * Uses the same endpoint as getLiveChat but designed for incremental polling
+ * @returns Object with new items and continuation, or undefined on error
+ */
+export async function pollLiveChat(
+    signal: AbortSignal,
+    existingChatMap: Map<number, object>,
+    onNewMessages?: (newCount: number, totalCount: number) => void
+): Promise<{ continuation: unknown } | undefined> {
+    try {
+        const result = await getCDChat(signal);
+        if (!result.continuationData) return undefined;
+
+        const liveChatData: any = await getLiveChat(result.continuationData, signal);
+        if (!liveChatData?.actions?.length) {
+            // No new messages, return current continuation
+            const continuations = liveChatData?.continuations;
+            const nextContinuation =
+                continuations?.find((c: any) => c.invalidationContinuationData)?.invalidationContinuationData ||
+                continuations?.find((c: any) => c.timedContinuationData)?.timedContinuationData ||
+                null;
+            return { continuation: nextContinuation };
+        }
+
+        const currentVideoId = (getVideoId(window.location.href) || undefined) as string | undefined;
+        const previousSize = existingChatMap.size;
+
+        const context: ChatProcessingContext = {
+            chatMap: existingChatMap,
+            currentVideoId,
+            onCommentAdded: (count: number) => {
+                if (onNewMessages) {
+                    onNewMessages(count - previousSize, count);
+                }
+            }
+        };
+
+        // Process live chat actions
+        processLiveChatActions(liveChatData.actions, context);
+
+        // Get continuation for next poll
+        const continuations = liveChatData?.continuations;
+        const nextContinuation =
+            continuations?.find((c: any) => c.invalidationContinuationData)?.invalidationContinuationData ||
+            continuations?.find((c: any) => c.timedContinuationData)?.timedContinuationData ||
+            null;
+
+        return { continuation: nextContinuation };
+    } catch (e) {
+        console.error('[YCS] pollLiveChat error:', e);
+        return undefined;
+    }
+}

--- a/app/src/source/utils/innertube/chat/liveChat.ts
+++ b/app/src/source/utils/innertube/chat/liveChat.ts
@@ -52,6 +52,21 @@ export function processLiveChatActions(actions: any[], context: ChatProcessingCo
             if (!hasAuthor) continue;
 
             const prepared = prepareChatCommentFields(comment);
+
+            // Calculate videoOffsetTimeMsec for live chat (enables "Go to" link after stream ends)
+            if (context.broadcastStartTime && timestampUsec) {
+                const messageTimeMs = Number(timestampUsec) / 1000;
+                const broadcastStartMs = new Date(context.broadcastStartTime).getTime();
+                const videoOffsetTimeMsec = messageTimeMs - broadcastStartMs;
+
+                if (!Number.isNaN(videoOffsetTimeMsec) && videoOffsetTimeMsec >= 0) {
+                    // Add to the comment structure for later viewModel processing
+                    if (prepared.replayChatItemAction) {
+                        prepared.replayChatItemAction.videoOffsetTimeMsec = String(Math.floor(videoOffsetTimeMsec));
+                    }
+                }
+            }
+
             context.chatMap.set(timestamp, prepared);
 
             if (context.onCommentAdded) {

--- a/app/src/source/utils/innertube/chat/utils.ts
+++ b/app/src/source/utils/innertube/chat/utils.ts
@@ -4,6 +4,7 @@ export interface ChatProcessingContext {
     chatMap: Map<number, object>;
     currentVideoId?: string;
     onCommentAdded?: (count: number) => void;
+    broadcastStartTime?: string; // ISO timestamp for calculating videoOffsetTimeMsec in live chat
 }
 
 export interface FormatChatRunsOptions {

--- a/app/src/source/utils/interfaces/i_assist.ts
+++ b/app/src/source/utils/interfaces/i_assist.ts
@@ -193,6 +193,7 @@ export interface ISheetChatCommentsParam {
     commentMessage: string;
     timestampText: string;
     relativeTimestamp?: string;
+    videoOffsetMs?: number;
 }
 
 export interface ISheetChatComments {

--- a/app/src/source/utils/interfaces/i_assist.ts
+++ b/app/src/source/utils/interfaces/i_assist.ts
@@ -192,6 +192,7 @@ export interface ISheetChatCommentsParam {
     };
     commentMessage: string;
     timestampText: string;
+    relativeTimestamp?: string;
 }
 
 export interface ISheetChatComments {
@@ -202,6 +203,7 @@ export interface ISheetChatComments {
     Member: string;
     'Comment message': string;
     'Timestamp comment': string;
+    'Relative Time'?: string;
 }
 
 export interface ISheetDetailsTrVideoParam {

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -930,6 +930,19 @@ function renderLoadComments(
                 </div>
             </div>
 
+            <div id="ycs_confirm_modal" class="ycs_modal">
+                <div class="ycs_modal-content ycs_confirm_content">
+                    <div class="ycs_modal_body">
+                        <h2 id="ycs_confirm_title">Confirm</h2>
+                        <p id="ycs_confirm_message"></p>
+                        <div class="ycs_confirm_buttons">
+                            <button id="ycs_confirm_cancel" class="ycs-btn-search">Cancel</button>
+                            <button id="ycs_confirm_ok" class="ycs-btn-search ycs_btn_primary">Continue</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
         </div>
     `;
 

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -357,11 +357,11 @@ function createChatElement(model: ChatMessageViewModel, index: number): HTMLElem
 
     const timestampLink = document.createElement('a');
     timestampLink.className = 'ycs-datetime-goto';
-    timestampLink.title = 'GMT0';
+    timestampLink.title = 'Local Time';
     timestampLink.href = safeUrl(model.gotoVideoUrl || '');
     timestampLink.target = '_blank';
     timestampLink.rel = 'noopener noreferrer';
-    timestampLink.textContent = model.timestampGmtText;
+    timestampLink.textContent = model.timestampLocalText;
     meta.appendChild(timestampLink);
 
     const chatLabel = document.createElement('span');

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -796,7 +796,7 @@ function renderLoadComments(
                                         record
                                     </button>
                                     <span id="ycs-record-timer" class="ycs-record-timer" style="display: none;">
-                                        00:00:00 (0)
+                                        00:00:00
                                     </span>
                                 </div>
                                 <div class="ycs_open_wrap">

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -789,6 +789,16 @@ function renderLoadComments(
                                         load
                                     </button>
                                 </div>
+                                <div class="ycs_record_wrap">
+                                    <button id="ycs-record-chat" class="ycs-btn-search ycs-title ycs-btn-record"
+                                        name="Record live chat" type="button" title="Record live chat (live streams only)"
+                                        style="display: none;">
+                                        record
+                                    </button>
+                                    <span id="ycs-record-timer" class="ycs-record-timer" style="display: none;">
+                                        00:00:00 (0)
+                                    </span>
+                                </div>
                                 <div class="ycs_open_wrap">
                                     <button id="ycs_open_all_comments_chat_window" class="ycs-btn-search ycs-title"
                                         name="Open chat comments in the new popup window"

--- a/app/src/source/utils/sheets.ts
+++ b/app/src/source/utils/sheets.ts
@@ -81,8 +81,19 @@ function getSheetChatComments(cmnts: ISheetDetailsChatParam): Array<ISheetChatCo
         const sheetCmnts: Array<ISheetChatComments> = [];
 
         for (const cmnt of cmnts.commentsChat) {
-            const [m, s] = cmnt.timestampText.split(':');
-            const second = Number(m) * 60 + Number(s);
+            // Priority: use numeric offset, fallback to parsing timestampText
+            let second = 0;
+            if (cmnt.videoOffsetMs !== undefined) {
+                second = Math.floor(cmnt.videoOffsetMs / 1000);
+            } else {
+                // Fallback: parse timestampText (supports both MM:SS and H:MM:SS)
+                const parts = cmnt.timestampText.split(':').map(Number);
+                if (parts.length === 3) {
+                    second = parts[0] * 3600 + parts[1] * 60 + parts[2];
+                } else if (parts.length === 2) {
+                    second = parts[0] * 60 + parts[1];
+                }
+            }
 
             const row: ISheetChatComments = {
                 'Timestamp Usec': Number(cmnt?.timestampUsec),

--- a/app/src/source/utils/sheets.ts
+++ b/app/src/source/utils/sheets.ts
@@ -84,7 +84,7 @@ function getSheetChatComments(cmnts: ISheetDetailsChatParam): Array<ISheetChatCo
             const [m, s] = cmnt.timestampText.split(':');
             const second = Number(m) * 60 + Number(s);
 
-            sheetCmnts.push({
+            const row: ISheetChatComments = {
                 'Timestamp Usec': Number(cmnt?.timestampUsec),
                 URL: `https://youtu.be/${cmnts.videoId}?t=${second || 0}`,
                 'Author name': cmnt?.author?.nameAuthor,
@@ -92,7 +92,13 @@ function getSheetChatComments(cmnts: ISheetDetailsChatParam): Array<ISheetChatCo
                 Member: cmnt?.author?.member,
                 'Comment message': cmnt?.commentMessage,
                 'Timestamp comment': cmnt?.timestampText
-            });
+            };
+
+            if (cmnt?.relativeTimestamp) {
+                row['Relative Time'] = cmnt.relativeTimestamp;
+            }
+
+            sheetCmnts.push(row);
         }
 
         return sheetCmnts;

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -41,7 +41,7 @@ export interface ChatMessageViewModel {
     isVerified: boolean;
     memberBadge?: MemberBadgeViewModel;
     donatedChip?: DonatedChipViewModel;
-    timestampGmtText: string;
+    timestampLocalText: string;
     timestampLabel: string;
     gotoVideoUrl?: string;
     gotoVideoOffset?: string;
@@ -423,7 +423,7 @@ export function buildChatMessageViewModels(items: any[]): ChatMessageViewModel[]
                 wrapTryCatch(() => renderer.timestampText?.runs?.[0]?.text)
         );
         const timestampUsec = wrapTryCatch(() => renderer.timestampUsec) as string | number | undefined;
-        const timestampGmtText = timestampUsec ? tmUsecToDateTime(timestampUsec) : '';
+        const timestampLocalText = timestampUsec ? tmUsecToDateTime(timestampUsec) : '';
 
         const videoOffset = wrapTryCatch(() => item?.item?.replayChatItemAction?.videoOffsetTimeMsec);
         const gotoVideoUrlRaw = videoOffset !== undefined ? msToShareVideo(videoOffset) : undefined;
@@ -447,7 +447,7 @@ export function buildChatMessageViewModels(items: any[]): ChatMessageViewModel[]
             isVerified: Boolean(wrapTryCatch(() => renderer.verifiedAuthor)),
             memberBadge: resolveChatBadge(renderer),
             donatedChip: resolveDonatedChip(renderer),
-            timestampGmtText,
+            timestampLocalText,
             timestampLabel,
             gotoVideoUrl: gotoVideoUrl || undefined,
             gotoVideoOffset: videoOffset !== undefined ? coerceString(videoOffset) : undefined,

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { decodeHtml, escapeHtml, wrapTryCatch, convertColorToRgba } from './common';
-import { msToShareVideo, tmUsecToDateTime } from './formatting';
+import { msToShareVideo, tmUsecToDateTime, formatDurationHMS } from './formatting';
 
 export interface MemberBadgeViewModel {
     tooltip: string;
@@ -392,6 +392,18 @@ export function buildCommentViewModels(items: any[], options: { isReply?: boolea
     return models;
 }
 
+/**
+ * Check if a timestamp label is in relative format (e.g., "2:35", "1:02:35")
+ * vs absolute format (e.g., "4:30 PM", "16:30")
+ */
+function isRelativeTimestamp(label: string): boolean {
+    if (!label) return false;
+    // Relative timestamps are typically in format "M:SS" or "H:MM:SS" without AM/PM
+    // and don't contain special characters or excessive digits for hours
+    const relativePattern = /^\d{1,2}:\d{2}(:\d{2})?$/;
+    return relativePattern.test(label.trim());
+}
+
 export function buildChatMessageViewModels(items: any[]): ChatMessageViewModel[] {
     const models: ChatMessageViewModel[] = [];
 
@@ -406,7 +418,7 @@ export function buildChatMessageViewModels(items: any[]): ChatMessageViewModel[]
         const authorAvatarUrl = normalizeUrl(wrapTryCatch(() => renderer.authorPhoto?.thumbnails?.[0]?.url));
         const authorName = coerceString(wrapTryCatch(() => renderer.authorName?.simpleText));
 
-        const timestampLabel = coerceString(
+        const rawTimestampLabel = coerceString(
             wrapTryCatch(() => renderer.timestampText?.simpleText) ??
                 wrapTryCatch(() => renderer.timestampText?.runs?.[0]?.text)
         );
@@ -416,6 +428,17 @@ export function buildChatMessageViewModels(items: any[]): ChatMessageViewModel[]
         const videoOffset = wrapTryCatch(() => item?.item?.replayChatItemAction?.videoOffsetTimeMsec);
         const gotoVideoUrlRaw = videoOffset !== undefined ? msToShareVideo(videoOffset) : undefined;
         const gotoVideoUrl = gotoVideoUrlRaw ? normalizeUrl(gotoVideoUrlRaw) : '';
+
+        // For Live Chat recordings, generate timestampLabel from videoOffsetTimeMsec
+        // since the original timestampText may be in absolute time format (e.g., "4:30 PM")
+        // instead of relative format (e.g., "2:35")
+        let timestampLabel = rawTimestampLabel;
+        if (videoOffset !== undefined && (!timestampLabel || !isRelativeTimestamp(timestampLabel))) {
+            const offsetMs = typeof videoOffset === 'string' ? parseFloat(videoOffset) : videoOffset;
+            if (!Number.isNaN(offsetMs) && offsetMs >= 0) {
+                timestampLabel = formatDurationHMS(offsetMs);
+            }
+        }
 
         models.push({
             authorName,

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1153,7 +1153,7 @@ export function initApp(): void {
 
             // Save final data to cache
             const commentsChat = getCommentsChat(state);
-            const startVideoId = getVideoId(window.location.href);
+            const startVideoId = liveRecording.startVideoId;
 
             if (commentsChat.size > 0 && startVideoId) {
                 saveToCache(
@@ -1200,10 +1200,10 @@ export function initApp(): void {
          * Poll and save chat messages
          */
         async function pollAndSaveChat(startVideoId: string | null): Promise<void> {
-            // Verify video hasn't changed
+            // Verify still on the same video page (stop if left video page or navigated to different video)
             const currentVideoId = getVideoId(window.location.href);
-            if (startVideoId && currentVideoId && startVideoId !== currentVideoId) {
-                console.warn('[YCS] Video changed during recording, stopping...');
+            if (!currentVideoId || currentVideoId !== startVideoId) {
+                console.log('[YCS] Left video page during recording, stopping...');
                 await stopLiveChatRecording();
                 return;
             }
@@ -1385,6 +1385,7 @@ export function initApp(): void {
                     timerIntervalId,
                     broadcastStartTime,
                     recordingStartTime,
+                    startVideoId,
                     lastContinuation: null,
                     lastSaveTime: null
                 });

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -341,15 +341,14 @@ export function initApp(): void {
             resizeObserver = null;
         }
 
-        // Clean up recording intervals if active
+        // Clean up recording timeouts/intervals unconditionally
+        // (don't rely on isRecording flag to prevent edge case leaks)
         const liveRecording = getLiveRecording(state);
-        if (liveRecording.isRecording) {
-            if (liveRecording.pollIntervalId !== null) {
-                clearInterval(liveRecording.pollIntervalId);
-            }
-            if (liveRecording.timerIntervalId !== null) {
-                clearInterval(liveRecording.timerIntervalId);
-            }
+        if (liveRecording.pollTimeoutId !== null) {
+            clearTimeout(liveRecording.pollTimeoutId);
+        }
+        if (liveRecording.timerIntervalId !== null) {
+            clearInterval(liveRecording.timerIntervalId);
         }
 
         // Abort old controller BEFORE creating new state to prevent race conditions
@@ -1129,15 +1128,18 @@ export function initApp(): void {
         async function stopLiveChatRecording(): Promise<void> {
             const liveRecording = getLiveRecording(state);
 
-            // Clear poll interval
-            if (liveRecording.pollIntervalId !== null) {
-                clearInterval(liveRecording.pollIntervalId);
+            // Clear poll timeout (serial pattern uses setTimeout, not setInterval)
+            if (liveRecording.pollTimeoutId !== null) {
+                clearTimeout(liveRecording.pollTimeoutId);
             }
 
             // Clear timer interval
             if (liveRecording.timerIntervalId !== null) {
                 clearInterval(liveRecording.timerIntervalId);
             }
+
+            // Abort in-flight requests to prevent them from continuing after stop
+            getController(state).abort();
 
             // Update UI
             if (elRecordChat) {
@@ -1175,6 +1177,9 @@ export function initApp(): void {
 
             // Reset recording state
             state = resetLiveRecording(state);
+
+            // Create new AbortController for future operations
+            state = resetController(state);
 
             console.log('[YCS] Live chat recording stopped. Total messages:', commentsChat.size);
         }
@@ -1228,16 +1233,21 @@ export function initApp(): void {
                     liveRecording.broadcastStartTime ?? undefined
                 );
 
-                // Check abort before saving to prevent race condition
+                // Check abort to stop processing
                 if (controller.signal.aborted) {
                     if (DEBUG) {
-                        console.log('[YCS] pollAndSaveChat aborted, skipping cache save');
+                        console.log('[YCS] pollAndSaveChat aborted');
                     }
                     return;
                 }
 
-                // Save to cache after each successful poll
-                if (commentsChat.size > 0 && startVideoId) {
+                // Throttled cache save: every 1 minute instead of every poll
+                // This reduces memory pressure from frequent JSON.stringify + postMessage structured clone
+                const CACHE_SAVE_INTERVAL_MS = 60000; // 1 minute
+                const lastSaveTime = liveRecording.lastSaveTime ?? 0;
+                const now = Date.now();
+
+                if (commentsChat.size > 0 && startVideoId && now - lastSaveTime >= CACHE_SAVE_INTERVAL_MS) {
                     saveToCache(
                         {
                             videoId: startVideoId,
@@ -1249,11 +1259,43 @@ export function initApp(): void {
                         },
                         buildCacheMeta()
                     );
+                    state = setLiveRecording(state, { lastSaveTime: now });
+                    console.log('[YCS] Periodic cache save:', commentsChat.size, 'messages');
                 }
             } catch (e) {
                 // Silent retry - just log error and continue polling
                 console.error('[YCS] pollAndSaveChat error:', e);
             }
+        }
+
+        /**
+         * Schedule next poll using setTimeout (serial pattern)
+         * Prevents request stacking when polls take longer than interval
+         */
+        async function scheduleNextPoll(startVideoId: string): Promise<void> {
+            const liveRecording = getLiveRecording(state);
+
+            // Check if still recording before polling
+            if (!liveRecording.isRecording) {
+                return;
+            }
+
+            // Execute poll
+            await pollAndSaveChat(startVideoId);
+
+            // Re-check after poll (recording may have stopped during poll)
+            const currentRecording = getLiveRecording(state);
+            if (!currentRecording.isRecording) {
+                return;
+            }
+
+            // Schedule next poll
+            const timeoutId = setTimeout(() => {
+                scheduleNextPoll(startVideoId);
+            }, RECORDING_POLL_INTERVAL);
+
+            // Update timeout ID in state
+            state = setLiveRecording(state, { pollTimeoutId: timeoutId });
         }
 
         /**
@@ -1318,24 +1360,20 @@ export function initApp(): void {
 
                 const recordingStartTime = Date.now();
 
-                // Start polling interval
-                const pollIntervalId = setInterval(() => {
-                    pollAndSaveChat(startVideoId);
-                }, RECORDING_POLL_INTERVAL);
-
-                // Start timer interval
+                // Start timer interval (pure UI update, doesn't need serial pattern)
                 const timerIntervalId = setInterval(() => {
                     updateRecordingTimer();
                 }, RECORDING_TIMER_INTERVAL);
 
-                // Update state
+                // Update state (pollTimeoutId starts as null, updated by scheduleNextPoll)
                 state = setLiveRecording(state, {
                     isRecording: true,
-                    pollIntervalId,
+                    pollTimeoutId: null,
                     timerIntervalId,
                     broadcastStartTime,
                     recordingStartTime,
-                    lastContinuation: null
+                    lastContinuation: null,
+                    lastSaveTime: null
                 });
 
                 // Re-enable button AFTER isRecording is set to prevent double-click race condition
@@ -1343,8 +1381,8 @@ export function initApp(): void {
 
                 console.log('[YCS] Live chat recording started. Broadcast start time:', broadcastStartTime);
 
-                // Perform first poll immediately
-                await pollAndSaveChat(startVideoId);
+                // Start serial polling (first poll runs immediately, then schedules next)
+                scheduleNextPoll(startVideoId);
             } catch (e) {
                 console.error('[YCS] startLiveChatRecording error:', e);
                 // Restore button and UI state on error
@@ -2361,9 +2399,9 @@ export function initApp(): void {
                 const liveRecording = getLiveRecording(state);
                 if (liveRecording.isRecording) {
                     console.log('[YCS] Video switch detected, stopping live recording...');
-                    // Clear intervals
-                    if (liveRecording.pollIntervalId !== null) {
-                        clearInterval(liveRecording.pollIntervalId);
+                    // Clear timeout/intervals
+                    if (liveRecording.pollTimeoutId !== null) {
+                        clearTimeout(liveRecording.pollTimeoutId);
                     }
                     if (liveRecording.timerIntervalId !== null) {
                         clearInterval(liveRecording.timerIntervalId);

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1115,11 +1115,10 @@ export function initApp(): void {
          */
         function updateRecordingTimer(): void {
             const liveRecording = getLiveRecording(state);
-            const commentsChat = getCommentsChat(state);
 
             if (liveRecording.recordingStartTime && elRecordTimer) {
                 const duration = formatRecordingDuration(liveRecording.recordingStartTime);
-                elRecordTimer.textContent = `${duration} (${commentsChat.size})`;
+                elRecordTimer.textContent = duration;
             }
         }
 
@@ -1137,26 +1136,34 @@ export function initApp(): void {
 
             const controller = getController(state);
             const commentsChat = getCommentsChat(state);
+            const liveRecording = getLiveRecording(state);
 
             try {
-                await pollLiveChat(controller.signal, commentsChat, (newCount, totalCount) => {
-                    // Update counter display
-                    const elLoadChat = document.getElementById('ycs_cmnts_chat');
-                    if (elLoadChat) {
-                        elLoadChat.textContent = totalCount.toString();
-                    }
+                await pollLiveChat(
+                    controller.signal,
+                    commentsChat,
+                    (newCount, totalCount) => {
+                        // Update counter display
+                        const elLoadChat = document.getElementById('ycs_cmnts_chat');
+                        if (elLoadChat) {
+                            elLoadChat.textContent = totalCount.toString();
+                        }
 
-                    // Update state count
-                    state = setCount(state, 'commentsChat', totalCount);
+                        // Update state count
+                        state = setCount(state, 'commentsChat', totalCount);
 
-                    if (newCount > 0) {
-                        console.log(`[YCS] Recording: +${newCount} new messages, total: ${totalCount}`);
-                    }
-                });
+                        if (DEBUG && newCount > 0) {
+                            console.log(`[YCS] Recording: +${newCount} new messages, total: ${totalCount}`);
+                        }
+                    },
+                    liveRecording.broadcastStartTime ?? undefined
+                );
 
                 // Check abort before saving to prevent race condition
                 if (controller.signal.aborted) {
-                    console.log('[YCS] pollAndSaveChat aborted, skipping cache save');
+                    if (DEBUG) {
+                        console.log('[YCS] pollAndSaveChat aborted, skipping cache save');
+                    }
                     return;
                 }
 
@@ -1196,8 +1203,17 @@ export function initApp(): void {
             elRecordChat.textContent = 'loading...';
 
             try {
-                // Clear previous chat data
-                state = clearCommentsChat(state);
+                // Check if we have cached chat data to resume recording
+                const existingCommentsChat = getCommentsChat(state);
+                const hasCachedData = existingCommentsChat.size > 0;
+
+                if (hasCachedData) {
+                    console.log('[YCS] Resuming recording with existing data:', existingCommentsChat.size, 'messages');
+                } else {
+                    // Clear chat data only if no cached data exists
+                    state = clearCommentsChat(state);
+                    console.log('[YCS] Starting new recording session');
+                }
 
                 // Get broadcast start time
                 const controller = getController(state);
@@ -1213,7 +1229,7 @@ export function initApp(): void {
 
                 if (elRecordTimer) {
                     elRecordTimer.style.display = 'inline';
-                    elRecordTimer.textContent = '00:00:00 (0)';
+                    elRecordTimer.textContent = '00:00:00';
                 }
 
                 // Update status icon
@@ -1223,7 +1239,8 @@ export function initApp(): void {
                     elStatusChat.innerHTML = iconReload();
                 }
                 if (elLoadChat) {
-                    elLoadChat.textContent = '0';
+                    // Show current count if resuming, otherwise 0
+                    elLoadChat.textContent = hasCachedData ? existingCommentsChat.size.toString() : '0';
                 }
 
                 const recordingStartTime = Date.now();
@@ -1269,25 +1286,34 @@ export function initApp(): void {
 
         /**
          * Check if current video is live and show/hide record button
+         * Load and record buttons are mutually exclusive
          */
         async function updateRecordButtonVisibility(): Promise<void> {
             if (!elRecordChat) return;
+
+            const elLoadChat = document.getElementById('ycs-load-chat');
+            if (!elLoadChat) return;
 
             try {
                 const controller = getController(state);
                 const isLive = await checkIsLiveStream(controller.signal);
 
                 if (isLive) {
+                    // Show record button, hide load button (mutually exclusive)
                     elRecordChat.style.display = 'inline-block';
+                    elLoadChat.style.display = 'none';
                     console.log('[YCS] Live stream detected, showing Record button');
                 } else {
+                    // Show load button, hide record button (mutually exclusive)
                     elRecordChat.style.display = 'none';
-                    console.log('[YCS] Not a live stream, hiding Record button');
+                    elLoadChat.style.display = 'inline-block';
+                    console.log('[YCS] Not a live stream, showing Load button');
                 }
             } catch (e) {
                 console.error('[YCS] updateRecordButtonVisibility error:', e);
-                // Hide on error
+                // Default to load button on error
                 elRecordChat.style.display = 'none';
+                elLoadChat.style.display = 'inline-block';
             }
         }
 

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -83,7 +83,9 @@ import {
     WebResourcesState,
     getLiveRecording,
     setLiveRecording,
-    resetLiveRecording
+    resetLiveRecording,
+    getChatSource,
+    setChatSource
 } from './state';
 import {
     FILTER_BUTTONS,
@@ -354,6 +356,54 @@ export function initApp(): void {
         getController(state).abort();
 
         state = createState();
+
+        /**
+         * Show confirmation modal and return Promise<boolean>
+         */
+        function showConfirmModal(title: string, message: string): Promise<boolean> {
+            return new Promise((resolve) => {
+                const modal = document.getElementById('ycs_confirm_modal');
+                const titleEl = document.getElementById('ycs_confirm_title');
+                const messageEl = document.getElementById('ycs_confirm_message');
+                const okBtn = document.getElementById('ycs_confirm_ok');
+                const cancelBtn = document.getElementById('ycs_confirm_cancel');
+
+                if (!modal || !titleEl || !messageEl || !okBtn || !cancelBtn) {
+                    resolve(window.confirm(message)); // Fallback
+                    return;
+                }
+
+                titleEl.textContent = title;
+                messageEl.textContent = message;
+                modal.style.display = 'block';
+
+                const cleanup = () => {
+                    modal.style.display = 'none';
+                    okBtn.removeEventListener('click', onOk);
+                    cancelBtn.removeEventListener('click', onCancel);
+                    modal.removeEventListener('click', onBackdrop);
+                };
+
+                const onOk = () => {
+                    cleanup();
+                    resolve(true);
+                };
+                const onCancel = () => {
+                    cleanup();
+                    resolve(false);
+                };
+                const onBackdrop = (e: Event) => {
+                    if (e.target === modal) {
+                        cleanup();
+                        resolve(false);
+                    }
+                };
+
+                okBtn.addEventListener('click', onOk);
+                cancelBtn.addEventListener('click', onCancel);
+                modal.addEventListener('click', onBackdrop);
+            });
+        }
 
         updateBadge('NUMBER_COMMENTS', '');
 
@@ -974,11 +1024,27 @@ export function initApp(): void {
             elLoadCommentsChat.addEventListener('click', async function (e: MouseEvent): Promise<void> {
                 if (!elLiveApp.parentNode || !elLiveApp.parentElement) return;
 
+                // Check for live recording data before proceeding
+                const currentChatSource = getChatSource(state);
+                const currentChatCount = getCommentsChat(state).size;
+
+                if (currentChatSource === 'live-recording' && currentChatCount > 0) {
+                    const confirmed = await showConfirmModal(
+                        'Replace Recorded Chat?',
+                        `You have previously recorded ${currentChatCount.toLocaleString()} live chat messages. Are you sure you want to replace them with new chat replay data?`
+                    );
+
+                    if (!confirmed) {
+                        return; // User cancelled
+                    }
+                }
+
                 // Capture URL and videoId at the start of async operation
                 const startUrl = window.location.href;
                 const startVideoId = getVideoId(startUrl);
 
                 state = clearCommentsChat(state);
+                state = setChatSource(state, undefined); // Clear source when loading new data
                 const commentsChat = getCommentsChat(state);
 
                 const currentTarget = e.currentTarget as HTMLButtonElement;
@@ -1017,13 +1083,15 @@ export function initApp(): void {
                         if (commentsChat.size > 0) {
                             elLoadChat.textContent = commentsChat.size.toString();
                             elStatusChat.innerHTML = iconOk();
+                            state = setChatSource(state, 'chat-replay');
                             saveToCache(
                                 {
                                     videoId: startVideoId,
                                     comments: getComments(state),
                                     commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
                                     commentsTrVideo: getCommentsTrVideo(state),
-                                    channelId: extractChannelId()
+                                    channelId: extractChannelId(),
+                                    chatSource: 'chat-replay'
                                 },
                                 buildCacheMeta()
                             );
@@ -1092,7 +1160,8 @@ export function initApp(): void {
                         comments: getComments(state),
                         commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
                         commentsTrVideo: getCommentsTrVideo(state),
-                        channelId: extractChannelId()
+                        channelId: extractChannelId(),
+                        chatSource: 'live-recording'
                     },
                     buildCacheMeta()
                 );
@@ -1175,7 +1244,8 @@ export function initApp(): void {
                             comments: getComments(state),
                             commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
                             commentsTrVideo: getCommentsTrVideo(state),
-                            channelId: extractChannelId()
+                            channelId: extractChannelId(),
+                            chatSource: 'live-recording'
                         },
                         buildCacheMeta()
                     );
@@ -1214,6 +1284,9 @@ export function initApp(): void {
                     state = clearCommentsChat(state);
                     console.log('[YCS] Starting new recording session');
                 }
+
+                // Mark chat source as live-recording
+                state = setChatSource(state, 'live-recording');
 
                 // Get broadcast start time
                 const controller = getController(state);
@@ -2148,6 +2221,7 @@ export function initApp(): void {
 
                     const chatEntries = JSON.parse(body.commentsChat || '[]') as Array<[number, ChatItem]>;
                     state = setCommentsChat(state, new Map<number, ChatItem>(chatEntries));
+                    state = setChatSource(state, body.chatSource);
                     state = setCommentsTrVideo(state, body.commentsTrVideo);
 
                     // Restore GlobalStore.getInitYtData with minimal structure for author filter
@@ -2306,7 +2380,8 @@ export function initApp(): void {
                                 comments: getComments(state),
                                 commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
                                 commentsTrVideo: getCommentsTrVideo(state),
-                                channelId: extractChannelId()
+                                channelId: extractChannelId(),
+                                chatSource: getChatSource(state)
                             },
                             { url: prevUrl, title: document.title }
                         );

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1213,7 +1213,7 @@ export function initApp(): void {
             const liveRecording = getLiveRecording(state);
 
             try {
-                await pollLiveChat(
+                const pollResult = await pollLiveChat(
                     controller.signal,
                     commentsChat,
                     (newCount, totalCount) => {
@@ -1230,14 +1230,27 @@ export function initApp(): void {
                             console.log(`[YCS] Recording: +${newCount} new messages, total: ${totalCount}`);
                         }
                     },
-                    liveRecording.broadcastStartTime ?? undefined
+                    liveRecording.broadcastStartTime ?? undefined,
+                    liveRecording.lastContinuation ?? undefined
                 );
+
+                // Save continuation for next poll (avoids re-fetching ytInitialData every time)
+                if (pollResult?.continuation) {
+                    state = setLiveRecording(state, { lastContinuation: pollResult.continuation });
+                }
 
                 // Check abort to stop processing
                 if (controller.signal.aborted) {
                     if (DEBUG) {
                         console.log('[YCS] pollAndSaveChat aborted');
                     }
+                    return;
+                }
+
+                // Auto-stop when live stream ends (detected by isLiveEnded flag)
+                if (pollResult?.isLiveEnded) {
+                    console.log('[YCS] Live stream ended, auto-stopping recording...');
+                    await stopLiveChatRecording();
                     return;
                 }
 

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -339,6 +339,20 @@ export function initApp(): void {
             resizeObserver = null;
         }
 
+        // Clean up recording intervals if active
+        const liveRecording = getLiveRecording(state);
+        if (liveRecording.isRecording) {
+            if (liveRecording.pollIntervalId !== null) {
+                clearInterval(liveRecording.pollIntervalId);
+            }
+            if (liveRecording.timerIntervalId !== null) {
+                clearInterval(liveRecording.timerIntervalId);
+            }
+        }
+
+        // Abort old controller BEFORE creating new state to prevent race conditions
+        getController(state).abort();
+
         state = createState();
 
         updateBadge('NUMBER_COMMENTS', '');
@@ -1140,6 +1154,12 @@ export function initApp(): void {
                     }
                 });
 
+                // Check abort before saving to prevent race condition
+                if (controller.signal.aborted) {
+                    console.log('[YCS] pollAndSaveChat aborted, skipping cache save');
+                    return;
+                }
+
                 // Save to cache after each successful poll
                 if (commentsChat.size > 0 && startVideoId) {
                     saveToCache(
@@ -1171,58 +1191,80 @@ export function initApp(): void {
                 return;
             }
 
-            // Clear previous chat data
-            state = clearCommentsChat(state);
+            // Disable button during initialization
+            elRecordChat.disabled = true;
+            elRecordChat.textContent = 'loading...';
 
-            // Get broadcast start time
-            const controller = getController(state);
-            const broadcastStartTime = await getLiveBroadcastStartTime(controller.signal);
+            try {
+                // Clear previous chat data
+                state = clearCommentsChat(state);
 
-            // Update UI
-            elRecordChat.classList.add('ycs-recording');
-            elRecordChat.textContent = 'stop';
+                // Get broadcast start time
+                const controller = getController(state);
+                const broadcastStartTime = await getLiveBroadcastStartTime(controller.signal);
 
-            if (elRecordTimer) {
-                elRecordTimer.style.display = 'inline';
-                elRecordTimer.textContent = '00:00:00 (0)';
+                if (!broadcastStartTime) {
+                    console.warn('[YCS] Could not get broadcast start time, relative timestamps will be unavailable');
+                }
+
+                // Update UI (but keep button disabled until isRecording is set)
+                elRecordChat.classList.add('ycs-recording');
+                elRecordChat.textContent = 'stop';
+
+                if (elRecordTimer) {
+                    elRecordTimer.style.display = 'inline';
+                    elRecordTimer.textContent = '00:00:00 (0)';
+                }
+
+                // Update status icon
+                const elStatusChat = document.getElementById('ycs_status_chat');
+                const elLoadChat = document.getElementById('ycs_cmnts_chat');
+                if (elStatusChat) {
+                    elStatusChat.innerHTML = iconReload();
+                }
+                if (elLoadChat) {
+                    elLoadChat.textContent = '0';
+                }
+
+                const recordingStartTime = Date.now();
+
+                // Start polling interval
+                const pollIntervalId = setInterval(() => {
+                    pollAndSaveChat(startVideoId);
+                }, RECORDING_POLL_INTERVAL);
+
+                // Start timer interval
+                const timerIntervalId = setInterval(() => {
+                    updateRecordingTimer();
+                }, RECORDING_TIMER_INTERVAL);
+
+                // Update state
+                state = setLiveRecording(state, {
+                    isRecording: true,
+                    pollIntervalId,
+                    timerIntervalId,
+                    broadcastStartTime,
+                    recordingStartTime,
+                    lastContinuation: null
+                });
+
+                // Re-enable button AFTER isRecording is set to prevent double-click race condition
+                elRecordChat.disabled = false;
+
+                console.log('[YCS] Live chat recording started. Broadcast start time:', broadcastStartTime);
+
+                // Perform first poll immediately
+                await pollAndSaveChat(startVideoId);
+            } catch (e) {
+                console.error('[YCS] startLiveChatRecording error:', e);
+                // Restore button and UI state on error
+                elRecordChat.disabled = false;
+                elRecordChat.textContent = 'record';
+                elRecordChat.classList.remove('ycs-recording');
+                if (elRecordTimer) {
+                    elRecordTimer.style.display = 'none';
+                }
             }
-
-            // Update status icon
-            const elStatusChat = document.getElementById('ycs_status_chat');
-            const elLoadChat = document.getElementById('ycs_cmnts_chat');
-            if (elStatusChat) {
-                elStatusChat.innerHTML = iconReload();
-            }
-            if (elLoadChat) {
-                elLoadChat.textContent = '0';
-            }
-
-            const recordingStartTime = Date.now();
-
-            // Start polling interval
-            const pollIntervalId = setInterval(() => {
-                pollAndSaveChat(startVideoId);
-            }, RECORDING_POLL_INTERVAL);
-
-            // Start timer interval
-            const timerIntervalId = setInterval(() => {
-                updateRecordingTimer();
-            }, RECORDING_TIMER_INTERVAL);
-
-            // Update state
-            state = setLiveRecording(state, {
-                isRecording: true,
-                pollIntervalId,
-                timerIntervalId,
-                broadcastStartTime,
-                recordingStartTime,
-                lastContinuation: null
-            });
-
-            console.log('[YCS] Live chat recording started. Broadcast start time:', broadcastStartTime);
-
-            // Perform first poll immediately
-            await pollAndSaveChat(startVideoId);
         }
 
         /**
@@ -2226,10 +2268,35 @@ export function initApp(): void {
                     if (liveRecording.timerIntervalId !== null) {
                         clearInterval(liveRecording.timerIntervalId);
                     }
+
+                    // Save final chat data to cache before video switch
+                    // Use prevUrl (old video) instead of window.location.href (new video)
+                    const commentsChat = getCommentsChat(state);
+                    const oldVideoId = prevUrl ? getVideoId(prevUrl) : null;
+                    if (commentsChat.size > 0 && oldVideoId && prevUrl) {
+                        saveToCache(
+                            {
+                                videoId: oldVideoId,
+                                comments: getComments(state),
+                                commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
+                                commentsTrVideo: getCommentsTrVideo(state),
+                                channelId: extractChannelId()
+                            },
+                            { url: prevUrl, title: document.title }
+                        );
+                        console.log('[YCS] Saved', commentsChat.size, 'chat messages for old video before switch');
+                    }
+
+                    // Abort controller BEFORE resetting to stop pending requests
+                    getController(state).abort();
                     state = resetLiveRecording(state);
                 }
 
-                getController(state).abort();
+                // Note: If recording was active, controller was already aborted above
+                // If not recording, abort here before calling app()
+                if (!liveRecording.isRecording) {
+                    getController(state).abort();
+                }
                 app();
 
                 // Only update prevUrl after confirming .ycs-app was successfully created

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -21,7 +21,10 @@ import {
     getChatComments,
     getTranscriptTracks,
     getTranscriptVideo,
-    clearCurrentVideoMemberOnly
+    clearCurrentVideoMemberOnly,
+    checkIsLiveStream,
+    getLiveBroadcastStartTime,
+    pollLiveChat
 } from '../utils/innertube';
 
 import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
@@ -34,6 +37,7 @@ import type {
 } from '../utils/interfaces/i_types';
 
 import { iconOk, iconReload } from '../utils/icons';
+import { formatRecordingDuration } from '../utils/formatting';
 import { renderLoadComments, renderSearch, loadFilterButtons } from '../utils/renderView';
 import { loadFromCache, saveToCache, updateBadge } from './services/cacheService';
 import type { CacheData } from './services/cacheService';
@@ -76,7 +80,10 @@ import {
     setTranscriptTracks,
     setCount,
     setSearchCount,
-    WebResourcesState
+    WebResourcesState,
+    getLiveRecording,
+    setLiveRecording,
+    resetLiveRecording
 } from './state';
 import {
     FILTER_BUTTONS,
@@ -815,11 +822,13 @@ export function initApp(): void {
 
         const buildExportMeta = (): ExportMeta => {
             const videoUrl = getCleanUrlVideo(window.location.href);
+            const liveRecording = getLiveRecording(state);
 
             return {
                 url: videoUrl ?? window.location.href,
                 title: document.title,
-                generatedAt: new Date()
+                generatedAt: new Date(),
+                broadcastStartTime: liveRecording?.broadcastStartTime ?? undefined
             };
         };
 
@@ -1022,6 +1031,239 @@ export function initApp(): void {
                 }
             });
         }
+
+        // ============================================
+        // Live Chat Recording Logic
+        // ============================================
+        const RECORDING_POLL_INTERVAL = 5000; // 5 seconds
+        const RECORDING_TIMER_INTERVAL = 1000; // 1 second
+
+        const elRecordChat = document.getElementById('ycs-record-chat') as HTMLButtonElement | null;
+        const elRecordTimer = document.getElementById('ycs-record-timer');
+
+        /**
+         * Stop live chat recording
+         */
+        async function stopLiveChatRecording(): Promise<void> {
+            const liveRecording = getLiveRecording(state);
+
+            // Clear poll interval
+            if (liveRecording.pollIntervalId !== null) {
+                clearInterval(liveRecording.pollIntervalId);
+            }
+
+            // Clear timer interval
+            if (liveRecording.timerIntervalId !== null) {
+                clearInterval(liveRecording.timerIntervalId);
+            }
+
+            // Update UI
+            if (elRecordChat) {
+                elRecordChat.classList.remove('ycs-recording');
+                elRecordChat.textContent = 'record';
+            }
+
+            if (elRecordTimer) {
+                elRecordTimer.style.display = 'none';
+            }
+
+            // Save final data to cache
+            const commentsChat = getCommentsChat(state);
+            const startVideoId = getVideoId(window.location.href);
+
+            if (commentsChat.size > 0 && startVideoId) {
+                saveToCache(
+                    {
+                        videoId: startVideoId,
+                        comments: getComments(state),
+                        commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
+                        commentsTrVideo: getCommentsTrVideo(state),
+                        channelId: extractChannelId()
+                    },
+                    buildCacheMeta()
+                );
+            }
+
+            // Update badge
+            const counts = getCounts(state);
+            const totalCount = counts.comments + counts.commentsChat + counts.commentsTrVideo;
+            updateBadge('NUMBER_COMMENTS', totalCount);
+            updateTitleCount(totalCount);
+
+            // Reset recording state
+            state = resetLiveRecording(state);
+
+            console.log('[YCS] Live chat recording stopped. Total messages:', commentsChat.size);
+        }
+
+        /**
+         * Update recording timer display
+         */
+        function updateRecordingTimer(): void {
+            const liveRecording = getLiveRecording(state);
+            const commentsChat = getCommentsChat(state);
+
+            if (liveRecording.recordingStartTime && elRecordTimer) {
+                const duration = formatRecordingDuration(liveRecording.recordingStartTime);
+                elRecordTimer.textContent = `${duration} (${commentsChat.size})`;
+            }
+        }
+
+        /**
+         * Poll and save chat messages
+         */
+        async function pollAndSaveChat(startVideoId: string | null): Promise<void> {
+            // Verify video hasn't changed
+            const currentVideoId = getVideoId(window.location.href);
+            if (startVideoId && currentVideoId && startVideoId !== currentVideoId) {
+                console.warn('[YCS] Video changed during recording, stopping...');
+                await stopLiveChatRecording();
+                return;
+            }
+
+            const controller = getController(state);
+            const commentsChat = getCommentsChat(state);
+
+            try {
+                await pollLiveChat(controller.signal, commentsChat, (newCount, totalCount) => {
+                    // Update counter display
+                    const elLoadChat = document.getElementById('ycs_cmnts_chat');
+                    if (elLoadChat) {
+                        elLoadChat.textContent = totalCount.toString();
+                    }
+
+                    // Update state count
+                    state = setCount(state, 'commentsChat', totalCount);
+
+                    if (newCount > 0) {
+                        console.log(`[YCS] Recording: +${newCount} new messages, total: ${totalCount}`);
+                    }
+                });
+
+                // Save to cache after each successful poll
+                if (commentsChat.size > 0 && startVideoId) {
+                    saveToCache(
+                        {
+                            videoId: startVideoId,
+                            comments: getComments(state),
+                            commentsChat: JSON.stringify(Array.from(commentsChat.entries())),
+                            commentsTrVideo: getCommentsTrVideo(state),
+                            channelId: extractChannelId()
+                        },
+                        buildCacheMeta()
+                    );
+                }
+            } catch (e) {
+                // Silent retry - just log error and continue polling
+                console.error('[YCS] pollAndSaveChat error:', e);
+            }
+        }
+
+        /**
+         * Start live chat recording
+         */
+        async function startLiveChatRecording(): Promise<void> {
+            if (!elRecordChat) return;
+
+            const startVideoId = getVideoId(window.location.href);
+            if (!startVideoId) {
+                console.warn('[YCS] Cannot start recording: no video ID');
+                return;
+            }
+
+            // Clear previous chat data
+            state = clearCommentsChat(state);
+
+            // Get broadcast start time
+            const controller = getController(state);
+            const broadcastStartTime = await getLiveBroadcastStartTime(controller.signal);
+
+            // Update UI
+            elRecordChat.classList.add('ycs-recording');
+            elRecordChat.textContent = 'stop';
+
+            if (elRecordTimer) {
+                elRecordTimer.style.display = 'inline';
+                elRecordTimer.textContent = '00:00:00 (0)';
+            }
+
+            // Update status icon
+            const elStatusChat = document.getElementById('ycs_status_chat');
+            const elLoadChat = document.getElementById('ycs_cmnts_chat');
+            if (elStatusChat) {
+                elStatusChat.innerHTML = iconReload();
+            }
+            if (elLoadChat) {
+                elLoadChat.textContent = '0';
+            }
+
+            const recordingStartTime = Date.now();
+
+            // Start polling interval
+            const pollIntervalId = setInterval(() => {
+                pollAndSaveChat(startVideoId);
+            }, RECORDING_POLL_INTERVAL);
+
+            // Start timer interval
+            const timerIntervalId = setInterval(() => {
+                updateRecordingTimer();
+            }, RECORDING_TIMER_INTERVAL);
+
+            // Update state
+            state = setLiveRecording(state, {
+                isRecording: true,
+                pollIntervalId,
+                timerIntervalId,
+                broadcastStartTime,
+                recordingStartTime,
+                lastContinuation: null
+            });
+
+            console.log('[YCS] Live chat recording started. Broadcast start time:', broadcastStartTime);
+
+            // Perform first poll immediately
+            await pollAndSaveChat(startVideoId);
+        }
+
+        /**
+         * Check if current video is live and show/hide record button
+         */
+        async function updateRecordButtonVisibility(): Promise<void> {
+            if (!elRecordChat) return;
+
+            try {
+                const controller = getController(state);
+                const isLive = await checkIsLiveStream(controller.signal);
+
+                if (isLive) {
+                    elRecordChat.style.display = 'inline-block';
+                    console.log('[YCS] Live stream detected, showing Record button');
+                } else {
+                    elRecordChat.style.display = 'none';
+                    console.log('[YCS] Not a live stream, hiding Record button');
+                }
+            } catch (e) {
+                console.error('[YCS] updateRecordButtonVisibility error:', e);
+                // Hide on error
+                elRecordChat.style.display = 'none';
+            }
+        }
+
+        // Record button click handler
+        if (elRecordChat) {
+            elRecordChat.addEventListener('click', async function (): Promise<void> {
+                const liveRecording = getLiveRecording(state);
+
+                if (liveRecording.isRecording) {
+                    await stopLiveChatRecording();
+                } else {
+                    await startLiveChatRecording();
+                }
+            });
+        }
+
+        // Auto-check live stream on page load
+        updateRecordButtonVisibility();
 
         const elLoadTranscriptVideo = document.getElementById('ycs-load-transcript-video');
         const elTranscriptLangButton = document.getElementById('ycs_transcript_language');
@@ -1972,6 +2214,20 @@ export function initApp(): void {
         observeIntervalId = setInterval(() => {
             if (isVideoPage() && getPageMetaElement() && prevUrl !== getCleanUrlVideo(window.location.href)) {
                 const currentUrl = getCleanUrlVideo(window.location.href);
+
+                // Stop live recording if active (video switch detected)
+                const liveRecording = getLiveRecording(state);
+                if (liveRecording.isRecording) {
+                    console.log('[YCS] Video switch detected, stopping live recording...');
+                    // Clear intervals
+                    if (liveRecording.pollIntervalId !== null) {
+                        clearInterval(liveRecording.pollIntervalId);
+                    }
+                    if (liveRecording.timerIntervalId !== null) {
+                        clearInterval(liveRecording.timerIntervalId);
+                    }
+                    state = resetLiveRecording(state);
+                }
 
                 getController(state).abort();
                 app();

--- a/app/src/source/web-resources/services/cacheService.ts
+++ b/app/src/source/web-resources/services/cacheService.ts
@@ -1,6 +1,8 @@
 import { sendGetCacheInIDB, setCacheToIDB, sendMsgToBadge } from '../../utils/dom';
 import type { CommentItem, TranscriptData } from '../../utils/interfaces/i_types';
 
+export type ChatSource = 'live-recording' | 'chat-replay';
+
 interface CacheMeta {
     url: string;
     title: string;
@@ -12,6 +14,7 @@ interface CacheData {
     commentsChat: string;
     commentsTrVideo?: TranscriptData;
     channelId?: string | null;
+    chatSource?: ChatSource;
 }
 
 export function loadFromCache(url: string): void {

--- a/app/src/source/web-resources/services/exportFormats.ts
+++ b/app/src/source/web-resources/services/exportFormats.ts
@@ -109,7 +109,7 @@ export function exportCommentsAsXLSX(input: {
 // Chat and Transcript exporters: simple JSON wrappers (XLSX can be added similarly)
 export function exportChatAsJSON(
     chatMessages: ChatItem[],
-    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; broadcastStartTime?: string }
 ): { content: string; fileName: string; mime: string } | void {
     try {
         const payload = buildChatExportPayload(chatMessages, meta);
@@ -122,7 +122,7 @@ export function exportChatAsJSON(
 
 export function exportChatAsXLSX(
     chatMessages: ChatItem[],
-    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number }
+    meta: { titleVideo?: string; url?: string; videoId?: string; cachedDate?: number; broadcastStartTime?: string }
 ): { writeFunc: () => void } | void {
     try {
         const payload = buildChatExportPayload(chatMessages, meta);

--- a/app/src/source/web-resources/services/exportService.ts
+++ b/app/src/source/web-resources/services/exportService.ts
@@ -107,7 +107,11 @@ export function downloadCommentsFileXLSX(comments: CommentItem[], meta?: ExportM
 
 export function downloadChatFileJSON(chatMessages: ChatItem[], meta?: ExportMeta): void {
     try {
-        const body = { titleVideo: meta?.title || '', url: meta?.url || '' } as any;
+        const body = {
+            titleVideo: meta?.title || '',
+            url: meta?.url || '',
+            broadcastStartTime: meta?.broadcastStartTime
+        } as any;
         const payload = exportChatAsJSON(chatMessages, body);
         if (!payload) return;
 
@@ -119,7 +123,11 @@ export function downloadChatFileJSON(chatMessages: ChatItem[], meta?: ExportMeta
 
 export function downloadChatFileXLSX(chatMessages: ChatItem[], meta?: ExportMeta): void {
     try {
-        const body = { titleVideo: meta?.title || '', url: meta?.url || '' } as any;
+        const body = {
+            titleVideo: meta?.title || '',
+            url: meta?.url || '',
+            broadcastStartTime: meta?.broadcastStartTime
+        } as any;
         const payload = exportChatAsXLSX(chatMessages, body);
         if (!payload || !payload.writeFunc) return;
 

--- a/app/src/source/web-resources/state.ts
+++ b/app/src/source/web-resources/state.ts
@@ -16,6 +16,7 @@ export interface LiveRecordingState {
     timerIntervalId: ReturnType<typeof setInterval> | null; // 1s timer display interval
     broadcastStartTime: string | null; // ISO timestamp from YouTube API
     recordingStartTime: number | null; // Local timestamp when recording started
+    startVideoId: string | null; // Video ID when recording started (preserved for cache save on navigation)
     lastContinuation: unknown; // Continuation token for next poll
     lastSaveTime: number | null; // Timestamp of last cache save (throttle saves to reduce memory pressure)
 }
@@ -48,6 +49,7 @@ function createLiveRecordingState(): LiveRecordingState {
         timerIntervalId: null,
         broadcastStartTime: null,
         recordingStartTime: null,
+        startVideoId: null,
         lastContinuation: null,
         lastSaveTime: null
     };

--- a/app/src/source/web-resources/state.ts
+++ b/app/src/source/web-resources/state.ts
@@ -12,11 +12,12 @@ export interface CountBuckets {
  */
 export interface LiveRecordingState {
     isRecording: boolean;
-    pollIntervalId: ReturnType<typeof setInterval> | null; // 5s polling interval
+    pollTimeoutId: ReturnType<typeof setTimeout> | null; // Serial polling timeout (not interval)
     timerIntervalId: ReturnType<typeof setInterval> | null; // 1s timer display interval
     broadcastStartTime: string | null; // ISO timestamp from YouTube API
     recordingStartTime: number | null; // Local timestamp when recording started
     lastContinuation: unknown; // Continuation token for next poll
+    lastSaveTime: number | null; // Timestamp of last cache save (throttle saves to reduce memory pressure)
 }
 
 export interface WebResourcesState {
@@ -43,11 +44,12 @@ function createCounts(): CountBuckets {
 function createLiveRecordingState(): LiveRecordingState {
     return {
         isRecording: false,
-        pollIntervalId: null,
+        pollTimeoutId: null,
         timerIntervalId: null,
         broadcastStartTime: null,
         recordingStartTime: null,
-        lastContinuation: null
+        lastContinuation: null,
+        lastSaveTime: null
     };
 }
 

--- a/app/src/source/web-resources/state.ts
+++ b/app/src/source/web-resources/state.ts
@@ -6,6 +6,18 @@ export interface CountBuckets {
     commentsTrVideo: number;
 }
 
+/**
+ * State for live chat recording feature
+ */
+export interface LiveRecordingState {
+    isRecording: boolean;
+    pollIntervalId: ReturnType<typeof setInterval> | null; // 5s polling interval
+    timerIntervalId: ReturnType<typeof setInterval> | null; // 1s timer display interval
+    broadcastStartTime: string | null; // ISO timestamp from YouTube API
+    recordingStartTime: number | null; // Local timestamp when recording started
+    lastContinuation: unknown; // Continuation token for next poll
+}
+
 export interface WebResourcesState {
     comments: CommentItem[];
     commentsChat: Map<number, ChatItem>;
@@ -15,6 +27,7 @@ export interface WebResourcesState {
     count: CountBuckets;
     countSearch: CountBuckets;
     controller: AbortController;
+    liveRecording: LiveRecordingState;
 }
 
 function createCounts(): CountBuckets {
@@ -22,6 +35,17 @@ function createCounts(): CountBuckets {
         comments: 0,
         commentsChat: 0,
         commentsTrVideo: 0
+    };
+}
+
+function createLiveRecordingState(): LiveRecordingState {
+    return {
+        isRecording: false,
+        pollIntervalId: null,
+        timerIntervalId: null,
+        broadcastStartTime: null,
+        recordingStartTime: null,
+        lastContinuation: null
     };
 }
 
@@ -34,7 +58,8 @@ export function createState(): WebResourcesState {
         selectedTranscriptLanguage: undefined,
         count: createCounts(),
         countSearch: createCounts(),
-        controller: new AbortController()
+        controller: new AbortController(),
+        liveRecording: createLiveRecordingState()
     };
 }
 
@@ -177,4 +202,28 @@ export function setController(state: WebResourcesState, controller: AbortControl
 
 export function resetController(state: WebResourcesState): WebResourcesState {
     return setController(state, new AbortController());
+}
+
+export function getLiveRecording(state: WebResourcesState): LiveRecordingState {
+    return state.liveRecording;
+}
+
+export function setLiveRecording(
+    state: WebResourcesState,
+    liveRecording: Partial<LiveRecordingState>
+): WebResourcesState {
+    return {
+        ...state,
+        liveRecording: {
+            ...state.liveRecording,
+            ...liveRecording
+        }
+    };
+}
+
+export function resetLiveRecording(state: WebResourcesState): WebResourcesState {
+    return {
+        ...state,
+        liveRecording: createLiveRecordingState()
+    };
 }

--- a/app/src/source/web-resources/state.ts
+++ b/app/src/source/web-resources/state.ts
@@ -1,4 +1,5 @@
 import type { ChatItem, CommentItem, TranscriptData, TranscriptTrackInfo } from '../utils/interfaces/i_types';
+import type { ChatSource } from './services/cacheService';
 
 export interface CountBuckets {
     comments: number;
@@ -21,6 +22,7 @@ export interface LiveRecordingState {
 export interface WebResourcesState {
     comments: CommentItem[];
     commentsChat: Map<number, ChatItem>;
+    chatSource?: ChatSource;
     commentsTrVideo?: TranscriptData;
     transcriptTracks?: TranscriptTrackInfo[];
     selectedTranscriptLanguage?: string;
@@ -53,6 +55,7 @@ export function createState(): WebResourcesState {
     return {
         comments: [],
         commentsChat: new Map<number, ChatItem>(),
+        chatSource: undefined,
         commentsTrVideo: undefined,
         transcriptTracks: undefined,
         selectedTranscriptLanguage: undefined,
@@ -225,5 +228,16 @@ export function resetLiveRecording(state: WebResourcesState): WebResourcesState 
     return {
         ...state,
         liveRecording: createLiveRecordingState()
+    };
+}
+
+export function getChatSource(state: WebResourcesState): ChatSource | undefined {
+    return state.chatSource;
+}
+
+export function setChatSource(state: WebResourcesState, chatSource?: ChatSource): WebResourcesState {
+    return {
+        ...state,
+        chatSource
     };
 }

--- a/app/tests/export-core.test.ts
+++ b/app/tests/export-core.test.ts
@@ -127,6 +127,41 @@ test('buildChatExportPayload extracts member badge text and channel IDs', () => 
     assert.equal(payload.commentsChat[0].author.member, 'member (1 year)');
 });
 
+test('buildChatExportPayload populates videoOffsetMs from videoOffsetTimeMsec', () => {
+    const chatMessages = [
+        {
+            replayChatItemAction: {
+                videoOffsetTimeMsec: '330000', // 5 minutes 30 seconds
+                actions: [
+                    {
+                        addChatItemAction: {
+                            item: {
+                                liveChatTextMessageRenderer: {
+                                    authorName: { simpleText: 'TestUser' },
+                                    authorExternalChannelId: 'UC456',
+                                    message: { simpleText: 'Test message' },
+                                    timestampUsec: '1234567890',
+                                    timestampText: { simpleText: '' }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ];
+
+    const payload = buildChatExportPayload(chatMessages, {
+        titleVideo: 'Test video',
+        url: 'https://www.youtube.com/watch?v=test',
+        videoId: 'test'
+    });
+
+    assert.equal(payload.commentsChat[0].videoOffsetMs, 330000);
+    assert.equal(payload.commentsChat[0].timestampText, '0:05:30');
+    assert.equal(payload.commentsChat[0].relativeTimestamp, '+0:05:30');
+});
+
 test('buildCommentsExportPayloadFromCache returns undefined when cache is empty', () => {
     const payload = buildCommentsExportPayloadFromCache({ comments: [] });
     assert.equal(payload, undefined);

--- a/app/tests/innertube-chat.test.ts
+++ b/app/tests/innertube-chat.test.ts
@@ -4,25 +4,22 @@ import { getChatComments } from '../src/source/utils/innertube/chat';
 import { setFetchImplementation } from '../src/source/utils/libs';
 
 /**
- * Test: Verify that getChatComments does not trigger duplicate pbj=1 requests
+ * Test: Verify that getChatComments triggers expected pbj=1 requests
  *
  * Background:
- * - Previously, clicking Chat Replay button would trigger 2 pbj=1 requests
- * - Root cause: getChatComments called getCDChat twice:
- *   1. Directly at line 186
- *   2. Inside getLiveChat at line 153
+ * - getChatComments calls getInitYtData (pbj=1) to get continuation data
+ * - getLiveBroadcastStartTime also calls getInitYtData (pbj=1) to get broadcast start time
  *
- * Fix:
- * - Modified getLiveChat to accept continuationData as parameter
- * - Removed duplicate getCDChat call inside getLiveChat
+ * Expected behavior:
+ * - Total 2 pbj=1 requests: one for continuation, one for broadcast start time
  *
- * This test verifies the fix by:
+ * This test verifies by:
  * 1. Mocking fetch to track pbj=1 request count
  * 2. Calling getChatComments
- * 3. Asserting pbj=1 is only called once
+ * 3. Asserting pbj=1 is called exactly twice
  */
 
-test('getChatComments should only trigger pbj=1 request once', async () => {
+test('getChatComments should trigger expected pbj=1 requests', async () => {
     let pbj1CallCount = 0;
     let liveChatCallCount = 0;
 
@@ -127,11 +124,11 @@ test('getChatComments should only trigger pbj=1 request once', async () => {
             // We only need to verify pbj=1 call count
         }
 
-        // Assert: pbj=1 should only be called ONCE
+        // Assert: pbj=1 should be called twice (continuation + broadcastStartTime)
         assert.strictEqual(
             pbj1CallCount,
-            1,
-            `Expected pbj=1 to be called once, but was called ${pbj1CallCount} times`
+            2,
+            `Expected pbj=1 to be called twice, but was called ${pbj1CallCount} times`
         );
 
         // Assert: live chat API should be called at least once
@@ -140,7 +137,7 @@ test('getChatComments should only trigger pbj=1 request once', async () => {
             `Expected live chat API to be called at least once, but was called ${liveChatCallCount} times`
         );
 
-        console.log(`✓ pbj=1 request count: ${pbj1CallCount} (expected: 1)`);
+        console.log(`✓ pbj=1 request count: ${pbj1CallCount} (expected: 2)`);
         console.log(`✓ live_chat API call count: ${liveChatCallCount} (expected: >= 1)`);
     } finally {
         // Restore original fetch
@@ -153,9 +150,10 @@ test('getChatComments should only trigger pbj=1 request once', async () => {
 });
 
 test('getChatComments should pass continuation data to getLiveChat', async () => {
-    // This is an indirect test to verify that getLiveChat receives
-    // continuation data from the first getCDChat call, rather than
-    // making its own getCDChat call
+    // This test verifies that getLiveChat receives continuation data
+    // from getCDChat. Note: getChatComments now calls getInitYtData twice:
+    // 1. For continuation data (via getCDChat)
+    // 2. For broadcast start time (via getLiveBroadcastStartTime)
 
     // Mock window object
     (global as any).window = {
@@ -246,11 +244,11 @@ test('getChatComments should pass continuation data to getLiveChat', async () =>
             // Expected
         }
 
-        // Verify no duplicate calls
+        // Verify expected number of calls (continuation + broadcastStartTime)
         assert.strictEqual(
             pbj1Calls.length,
-            1,
-            `pbj=1 should be called exactly once. Calls: ${pbj1Calls.join(', ')}`
+            2,
+            `pbj=1 should be called exactly twice. Calls: ${pbj1Calls.join(', ')}`
         );
 
         // Verify continuation token was passed to getLiveChat
@@ -265,7 +263,7 @@ test('getChatComments should pass continuation data to getLiveChat', async () =>
             `Expected continuation token to be 'test-continuation', but got '${liveChatRequestBody?.continuation}'`
         );
 
-        console.log(`✓ Verified single pbj=1 call: ${pbj1Calls[0]}`);
+        console.log(`✓ Verified pbj=1 calls: ${pbj1Calls.join(', ')}`);
         console.log(`✓ Verified continuation token passed: ${liveChatRequestBody.continuation}`);
     } finally {
         global.fetch = originalFetch;


### PR DESCRIPTION
## Summary

Issue: #110 

This PR adds real-time live chat recording functionality for YouTube live streams. Users can now record chat messages as they happen during live broadcasts, with support for resume recording, automatic stream end detection, and proper timestamp handling in exports.

## Key Changes

### Live Chat Recording Feature
- Add `record` button that appears exclusively on live streams (replaces `load` button)
- Implement serial polling pattern with 5-second intervals to capture live chat messages
- Support recording resume: existing cached data is preserved when restarting recording
- Add confirmation modal when attempting to replace previously recorded data with chat replay
- Display real-time recording timer (`HH:MM:SS`) during active recording

### Stream Detection and Lifecycle
- Add `checkIsLiveStream()` function to detect ongoing broadcasts via `invalidationContinuationData`
- Add `getLiveBroadcastStartTime()` to fetch broadcast start timestamp for relative time calculation
- Implement `pollLiveChat()` for incremental message polling with continuation token reuse
- Auto-detect stream end via `reloadContinuationData` presence
- Auto-stop recording when leaving video page (homepage, other videos, etc.) and save data under original video ID

### Timestamp and Export Improvements
- Add `relativeTimestamp` field (`+H:MM:SS`) calculated from `videoOffsetTimeMsec` or broadcast start time
- Fix chat timestamp display: switch from GMT to local time format
- Improve `videoOffset` parsing in Excel export with `videoOffsetMs` fallback for `H:MM:SS` format
- Add `isRelativeTimestamp()` helper to detect and convert absolute timestamps in live recordings

### State Management
- Add `LiveRecordingState` interface with recording lifecycle fields
- Add `chatSource` field (`'live-recording'` | `'chat-replay'`) to distinguish data origin
- Implement `setLiveRecording()`, `resetLiveRecording()`, `getChatSource()`, `setChatSource()` state functions
- Properly clean up recording timeouts and intervals on video navigation

### Performance Optimization
- Use serial polling pattern (`setTimeout`) instead of interval to prevent request stacking
- Throttle cache saves during recording to reduce memory pressure
- Abort in-flight requests immediately when stopping recording

---

Recording live video
<img src=https://github.com/user-attachments/assets/294de2fc-227a-4333-809b-f087b57e5255  width=600>

Overwrite protection modal
<img src=https://github.com/user-attachments/assets/be5453e7-dfad-4876-932a-f596274b27d3  width=500>
