### PR TITLE
feat(api): add YouTube Data API v3 support with security improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ app/src/static/manifest.json
 CLAUDE_PLANS
 .factory
 .claude
+.gemini-clipboard
 
 PR_MESSAGE.md
 specs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,11 @@ YouTube.com Page
   │  └─ chrome.runtime.sendMessage() ↕️
   └─ background.ts (Service Worker)
      └─ IndexedDB cache, storage monitoring, badge updates
+     └─ YouTube Data API requests (API key stored securely)
 ```
 
 **Why this structure?**
-MV3 security restrictions require web page code to run in isolated context. The content script acts as a secure bridge between web page and extension background.
+MV3 security restrictions require web page code to run in isolated context. The content script acts as a secure bridge between web page and extension background. For YouTube Data API integration, API keys are stored securely in the background and never exposed to the web page.
 
 ### Key Directories
 
@@ -76,10 +77,15 @@ MV3 security restrictions require web page code to run in isolated context. The 
     - `common.ts`: Shared utilities and GlobalStore
     - `libs.ts`: External library wrappers (fetchR, IndexedDB)
     - `dom.ts`, `formatting.ts`: DOM and data transformation
-    - `innertube/`: Modularized YouTube API integration
+    - `innertube/`: Modularized YouTube Innertube API integration
       - `comments/`: Comment fetching and processing pipeline
       - `chat/`: Chat replay modules (live/replay)
       - `core.ts`, `request.ts`, `authHeaders.ts`, `transcript.ts`: Core utilities
+    - `youtubeDataApi/`: YouTube Data API v3 integration (optional, requires API key)
+      - `client.ts`: API client with error handling
+      - `comments.ts`: Comment fetching logic
+      - `transform.ts`: Response transformation to CommentItem
+      - `index.ts`: Module exports
     - `filters/`: Comment and chat filtering modules
     - `sheets.ts`: Excel export functionality
     - `renderView.ts`, `viewModels.ts`: HTML rendering and view models
@@ -164,6 +170,8 @@ Runtime state management using IIFE closure pattern. See `app/src/source/web-res
 ### Message Passing
 
 Three-layer communication using `window.postMessage()` (Web Page ↔ Content Script) and `chrome.runtime.sendMessage()` (Content Script ↔ Service Worker). See Architecture section above.
+
+**YouTube Data API Messaging**: When YouTube Data API is enabled, a specialized messaging protocol handles comment fetching with chunked transfer (to overcome Chrome's ~50-64 MB message size limit) and secure API key isolation. See `app/docs/youtube-data-api-messaging.md` for detailed architecture.
 
 ### Retry Mechanism
 
@@ -283,6 +291,25 @@ The extension integrates with YouTube's internal Innertube API for fetching comm
 - **Documentation**: See `app/docs/innertube-*.md` and `app/docs/sap-sid-authorization.md` for detailed implementation guides
 
 Implementation: `app/src/source/utils/innertube/` with type definitions in `utils/interfaces/i_assist.ts`
+
+## YouTube Data API v3 Integration (Optional)
+
+The extension optionally supports YouTube Data API v3 as an alternative to Innertube for comment fetching.
+
+- **API key required**: Users must provide their own API key in extension settings
+- **Security**: API key is stored in background service worker and never exposed to web page
+- **Chunked transfer**: Large comment datasets are transferred in chunks to avoid Chrome's message size limit (~50-64 MB)
+- **Partial results**: Supports returning partial results on errors or user cancellation
+- **Fallback**: When API key is not configured or disabled, falls back to Innertube API
+
+**Message Types**:
+- `YCS_YT_API_COMMENTS_START` / `YCS_YT_API_COMMENTS_ABORT`: Request control
+- `YCS_YT_API_COMMENTS_PROGRESS` / `YCS_YT_API_COMMENTS_CHUNK`: Response streaming
+- `YCS_YT_API_COMMENTS_ERROR`: Error handling with partial results
+
+**Documentation**: See `app/docs/youtube-data-api-messaging.md` for detailed messaging architecture.
+
+Implementation: `app/src/source/utils/youtubeDataApi/` with background handling in `background.ts`
 
 ### Member-Only Video Detection and Authorization Strategy
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,10 @@ YouTube.com Page
   │  └─ chrome.runtime.sendMessage() ↕️
   └─ background.ts (Service Worker)
      └─ IndexedDB cache, storage monitoring, badge updates
+     └─ YouTube Data API requests (API key stored securely)
 ```
 
-**Why this structure?** Manifest V3 security restrictions require web page code to run in isolated context. The content script acts as a secure bridge between web page and extension background.
+**Why this structure?** Manifest V3 security restrictions require web page code to run in isolated context. The content script acts as a secure bridge between web page and extension background. For YouTube Data API integration, API keys are stored securely in the background and never exposed to the web page.
 
 **Build system**: Parcel 2.0.1 with TypeScript (ES6 target, strict mode)
 
@@ -126,6 +127,7 @@ The extension integrates with YouTube's internal Innertube API for comments, cha
 - [continuation-processing.md](app/docs/continuation-processing.md) - Implementation reference
 - [sap-sid-authorization.md](app/docs/sap-sid-authorization.md) - SAPISID authorization header generation
 - [adaptive-authorization-headers.md](app/docs/adaptive-authorization-headers.md) - Adaptive authorization for member-only videos
+- [youtube-data-api-messaging.md](app/docs/youtube-data-api-messaging.md) - YouTube Data API v3 messaging architecture
 
 ## Credits
 - Original YCS by **sonigy**

--- a/app/README.md
+++ b/app/README.md
@@ -44,7 +44,7 @@ app/
 │   │       ├── constants.ts  # Application constants
 │   │       ├── libs.ts       # External library wrappers (fetchR, IndexedDB)
 │   │       ├── export-core.ts # Core export functionality
-│   │       ├── innertube/    # Modularized YouTube API integration
+│   │       ├── innertube/    # Modularized YouTube Innertube API integration
 │   │       │   ├── innertube.ts      # Module facade
 │   │       │   ├── core.ts           # Configuration & initialization
 │   │       │   ├── request.ts        # Request building utilities
@@ -60,6 +60,11 @@ app/
 │   │       │   │   ├── replayChat.ts # Replay chat handling
 │   │       │   │   └── utils.ts      # Chat utilities
 │   │       │   └── transcript.ts     # Transcript fetching
+│   │       ├── youtubeDataApi/  # YouTube Data API v3 integration (optional)
+│   │       │   ├── client.ts         # API client with error handling
+│   │       │   ├── comments.ts       # Comment fetching logic
+│   │       │   ├── transform.ts      # Response transformation to CommentItem
+│   │       │   └── index.ts          # Module exports
 │   │       ├── filters/      # Comment and chat filtering modules
 │   │       ├── formatting.ts # Data transformation and HTML output
 │   │       ├── dom.ts        # DOM manipulation and UI interactions
@@ -205,18 +210,20 @@ YouTube.com Page
   │  └─ chrome.runtime.sendMessage() ↕️
   └─ background.ts (Service Worker)
      └─ IndexedDB cache, storage monitoring, badge updates
+     └─ YouTube Data API requests (API key stored securely)
 ```
 
-**Why this structure?** Manifest V3 security restrictions require web page code to run in isolated context. The content script acts as a secure bridge between the web page and extension background.
+**Why this structure?** Manifest V3 security restrictions require web page code to run in isolated context. The content script acts as a secure bridge between the web page and extension background. For YouTube Data API integration, API keys are stored securely in the background and never exposed to the web page.
 
 ### Key Components
 
 | Component | File | Purpose |
 |-----------|------|---------|
-| Service Worker | `background.ts` | Cache management, badge updates, message listening |
+| Service Worker | `background.ts` | Cache management, badge updates, YouTube Data API requests |
 | Web Resources | `wresources.ts` | Main UI, search logic, GlobalStore state management |
-| Content Script | `cscripts.ts` | Bridge layer, script injection |
-| YouTube API | `innertube.ts` | Innertube API integration, request handling |
+| Content Script | `cscripts.ts` | Bridge layer, script injection, message relay |
+| Innertube API | `innertube/*.ts` | YouTube Innertube API integration (default) |
+| YouTube Data API | `youtubeDataApi/*.ts` | YouTube Data API v3 integration (optional, requires API key) |
 | Filtering | `filters/*.ts` | Comment and chat filtering logic |
 | Data Export | `sheets.ts` | Excel export functionality |
 | Formatting | `formatting.ts` | Data transformation and HTML generation |
@@ -236,6 +243,7 @@ For detailed information on Innertube API integration and implementation:
 | [Implementation Alignment](docs/continuation-processing.md) | JS/TS code correspondence |
 | [SAPISID Authorization](docs/sap-sid-authorization.md) | SAPISID/APISID cookie-based auth headers |
 | [Adaptive Authorization Headers](docs/adaptive-authorization-headers.md) | Member-only video detection and conditional auth |
+| [YouTube Data API Messaging](docs/youtube-data-api-messaging.md) | YouTube Data API v3 messaging architecture |
 
 **Reading order**: Start with `innertube-comments-integration.md`, then refer to other docs as needed.
 

--- a/app/docs/youtube-data-api-messaging.md
+++ b/app/docs/youtube-data-api-messaging.md
@@ -1,0 +1,315 @@
+# YouTube Data API Messaging Architecture
+
+This document describes the messaging architecture introduced to support YouTube Data API v3 integration in the `feat/youtube-data-api-support` branch.
+
+## Overview
+
+The YouTube Data API integration requires a new messaging layer between the web page and background service worker. This is necessary because:
+
+1. **Security**: API keys must be stored securely in the background and never exposed to the web page context
+2. **MV3 Constraints**: Web page code cannot directly access `chrome.storage` or make authenticated API requests
+3. **Message Size Limits**: Chrome has a ~50-64 MB limit on `chrome.runtime.sendMessage()` payloads, requiring chunked transfer for large comment datasets
+
+## Three-Layer Communication Model
+
+```
+YouTube.com Page (Web Resources)
+├── appController.ts
+│   └── requestYouTubeApiComments()
+│   └── window.postMessage() ↕️
+│
+├── Content Script (cscripts.ts)
+│   └── Message relay bridge
+│   └── window.addEventListener('message') ↔ chrome.runtime.sendMessage() ↕️
+│
+└── Background Service Worker (background.ts)
+    └── fetchAllCommentsBackground()
+    └── YouTube Data API v3 requests
+    └── API key storage (chrome.storage.local)
+```
+
+## Message Types
+
+### Request Messages (Web Page → Background)
+
+| Message Type | Direction | Purpose |
+|-------------|-----------|---------|
+| `YCS_YT_API_COMMENTS_START` | Web → BG | Start fetching comments for a video |
+| `YCS_YT_API_COMMENTS_ABORT` | Web → BG | Cancel an in-progress fetch request |
+
+### Response Messages (Background → Web Page)
+
+| Message Type | Direction | Purpose |
+|-------------|-----------|---------|
+| `YCS_YT_API_COMMENTS_PROGRESS` | BG → Web | Progress update with current comment count |
+| `YCS_YT_API_COMMENTS_CHUNK` | BG → Web | Chunked comment data (handles large payloads) |
+| `YCS_YT_API_COMMENTS_COMPLETE` | BG → Web | Backward compatibility for small payloads |
+| `YCS_YT_API_COMMENTS_ERROR` | BG → Web | Error response with optional partial results |
+
+## Message Flow
+
+### Normal Flow (Success)
+
+```
+Web Page                    Content Script              Background
+    |                            |                          |
+    |-- START ------------------>|                          |
+    |                            |-- START ---------------->|
+    |                            |                          |-- API Request
+    |                            |                          |<- Response
+    |                            |<-- PROGRESS -------------|
+    |<-- PROGRESS ---------------|                          |
+    |                            |                          |-- More requests...
+    |                            |<-- CHUNK (0/3) ---------|
+    |<-- CHUNK (0/3) ------------|                          |
+    |                            |<-- CHUNK (1/3) ---------|
+    |<-- CHUNK (1/3) ------------|                          |
+    |                            |<-- CHUNK (2/3, last) ---|
+    |<-- CHUNK (2/3, last) ------|                          |
+    |                            |                          |
+```
+
+### Abort Flow
+
+```
+Web Page                    Content Script              Background
+    |                            |                          |
+    |-- ABORT ------------------>|                          |
+    |                            |-- ABORT ---------------->|
+    |                            |                          |-- controller.abort()
+    |                            |<-- CHUNK (partial) -----|
+    |<-- CHUNK (partial) --------|                          |
+    |                            |                          |
+```
+
+## Message Payloads
+
+### YCS_YT_API_COMMENTS_START
+
+```typescript
+{
+    type: 'YCS_YT_API_COMMENTS_START',
+    body: {
+        videoId: string,    // YouTube video ID (11 characters)
+        requestId: string   // UUID for tracking this request
+    }
+}
+```
+
+### YCS_YT_API_COMMENTS_ABORT
+
+```typescript
+{
+    type: 'YCS_YT_API_COMMENTS_ABORT',
+    body: {
+        requestId: string   // UUID of the request to abort
+    }
+}
+```
+
+### YCS_YT_API_COMMENTS_PROGRESS
+
+```typescript
+{
+    type: 'YCS_YT_API_COMMENTS_PROGRESS',
+    body: {
+        requestId: string,
+        totalCount: number,  // Current number of comments fetched
+        quotaUsed: number    // API quota units consumed
+    }
+}
+```
+
+### YCS_YT_API_COMMENTS_CHUNK
+
+```typescript
+{
+    type: 'YCS_YT_API_COMMENTS_CHUNK',
+    body: {
+        requestId: string,
+        comments: CommentItem[],  // Chunk of comments (max 20,000 per chunk)
+        chunkIndex: number,       // 0-based index
+        totalChunks: number,
+        isLastChunk: boolean,
+        // Only present in last chunk:
+        quotaUsed?: number,
+        incomplete?: boolean,      // true if some replies failed to fetch
+        replyFetchErrors?: number, // Count of failed reply fetches
+        // Present if error occurred:
+        error?: { type: string, message: string, code?: number },
+        isError?: boolean
+    }
+}
+```
+
+### YCS_YT_API_COMMENTS_ERROR
+
+```typescript
+{
+    type: 'YCS_YT_API_COMMENTS_ERROR',
+    body: {
+        requestId: string,
+        error: {
+            type: string,     // 'quotaExceeded' | 'invalidApiKey' | 'unsupported' | 'apiError' | 'aborted' | 'unknown'
+            message: string,
+            code?: number     // HTTP status code if applicable
+        },
+        partialComments?: CommentItem[]  // Partial results if available
+    }
+}
+```
+
+## Chunked Transfer Mechanism
+
+Chrome's `chrome.runtime.sendMessage()` has a message size limit of approximately 50-64 MB. For videos with hundreds of thousands of comments, this limit can be exceeded.
+
+### Implementation
+
+**Chunk Size**: 20,000 comments per chunk (defined as `CHUNK_SIZE` in `background.ts:63`)
+
+**Chunking Logic** (`background.ts:68`):
+
+```typescript
+function chunkArray<T>(array: T[], chunkSize: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += chunkSize) {
+        chunks.push(array.slice(i, i + chunkSize));
+    }
+    return chunks;
+}
+```
+
+**Reassembly Logic** (`appController.ts:195`):
+
+```typescript
+// Chunk accumulation
+const receivedChunks: CommentItem[][] = [];
+
+// On receiving chunk
+receivedChunks[chunkIndex] = comments;
+
+if (isLastChunk) {
+    const allComments: CommentItem[] = [];
+    for (const chunk of receivedChunks) {
+        if (chunk) allComments.push(...chunk);
+    }
+    // Use allComments...
+}
+```
+
+### Metadata Handling
+
+- Metadata (quotaUsed, incomplete, error) is only included in the **last chunk**
+- This ensures the web page receives complete status information after all data is received
+- Implementation: `background.ts:128-133`
+
+## Security Design
+
+### API Key Isolation
+
+The API key is stored exclusively in the background service worker and **never exposed to the web page**:
+
+1. **Storage**: API key is stored in `chrome.storage.local` under `youtubeApiKey`
+2. **Flag Exposure**: Only a boolean `hasYoutubeApiKey` flag is sent to the web page
+3. **Request Handling**: All YouTube Data API requests are made from the background service worker
+
+**Content Script Filtering** (`cscripts.ts:106-111`):
+
+```typescript
+// Security: Filter out sensitive data, only expose hasYoutubeApiKey flag
+const { youtubeApiKey, ...safeOpts } = opts;
+const sanitizedOpts = {
+    ...safeOpts,
+    hasYoutubeApiKey: !!(youtubeApiKey as string)?.trim()
+};
+```
+
+### Request Validation
+
+- Video IDs are validated against regex pattern before processing
+- Request IDs are UUIDs generated by `crypto.randomUUID()`
+- Message origin is verified: `e.origin !== window.location.origin`
+
+## Error Handling
+
+### Error Types
+
+| Type | Description | User Action |
+|------|-------------|-------------|
+| `quotaExceeded` | Daily API quota (10,000 units) exhausted | Wait until tomorrow or use different API key |
+| `invalidApiKey` | API key is invalid or not configured | Check API key in settings |
+| `unsupported` | Comments disabled or video not found | None (graceful skip) |
+| `apiError` | Other YouTube API errors | Check console for details |
+| `aborted` | User cancelled via STOP button | None (intentional) |
+| `unknown` | Unexpected errors | Check console for details |
+
+### Partial Results
+
+When errors occur mid-fetch, partial results are preserved and returned:
+
+1. Background sends partial comments in the error response
+2. Web page displays appropriate status icon (warning/error/stop/info)
+3. User can still search within the partial results
+
+**Implementation**: `background.ts:288-297` (error handling with partial results)
+
+## Abort Handling
+
+### User-Initiated Abort
+
+When user clicks STOP button:
+
+1. Web page sends `YCS_YT_API_COMMENTS_ABORT` message
+2. Background calls `controller.abort()` on the AbortController
+3. All in-flight fetch requests are cancelled
+4. Partial results (if any) are sent back via `YCS_YT_API_COMMENTS_CHUNK`
+
+### Tab Close Handling
+
+When user closes the tab or navigates away:
+
+1. `chrome.tabs.onRemoved` listener triggers
+2. All requests associated with that tab are aborted
+3. Resources are cleaned up
+
+**Implementation**: `background.ts:445-453`
+
+### Timeout Safety
+
+Web page has a 3-second timeout after sending abort:
+
+```typescript
+// Safety timeout: if background doesn't respond within 3 seconds, reject
+abortTimeoutId = setTimeout(() => {
+    window.removeEventListener('message', handleMessage);
+    reject(new DOMException('Aborted', 'AbortError'));
+}, 3000);
+```
+
+## Active Request Tracking
+
+Background maintains a map of active requests for abort handling:
+
+```typescript
+interface ActiveRequest {
+    controller: AbortController;
+    tabId: number;
+}
+const activeYouTubeApiRequests = new Map<string, ActiveRequest>();
+```
+
+- Keyed by `requestId` (UUID)
+- Stores AbortController for cancellation
+- Stores tabId for tab-close cleanup
+- Automatically cleaned up on completion or abort
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `background.ts:1-300` | Background service worker with YouTube API handling |
+| `cscripts.ts:7-175` | Content script message relay |
+| `appController.ts:118-260` | Web page request handling and chunk reassembly |
+| `i_types.ts:311-412` | TypeScript interfaces for YouTube Data API |
+| `youtubeDataApi/client.ts` | YouTube Data API client |
+| `youtubeDataApi/transform.ts` | Response transformation to CommentItem |

--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -33,6 +33,9 @@ function mapYouTubeApiError(error: unknown): { type: string; message: string; co
         if (error.isInvalidApiKey) {
             return { type: 'invalidApiKey', message: error.message, code: error.code };
         }
+        if (error.isUnsupported) {
+            return { type: 'unsupported', message: error.message, code: error.code };
+        }
         return { type: 'apiError', message: error.message, code: error.code };
     }
     if (error instanceof DOMException && error.name === 'AbortError') {

--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -58,6 +58,92 @@ async function safeSendMessage(tabId: number, message: unknown): Promise<boolean
 }
 
 /**
+ * Chunk size for splitting large comment arrays to avoid Chrome message size limits (~50-64 MB)
+ */
+const CHUNK_SIZE = 20000;
+
+/**
+ * Split an array into chunks of specified size
+ */
+function chunkArray<T>(array: T[], chunkSize: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += chunkSize) {
+        chunks.push(array.slice(i, i + chunkSize));
+    }
+    return chunks;
+}
+
+/**
+ * Send comments in chunks to avoid Chrome's runtime message size limit.
+ * Returns false if any chunk fails to send (tab closed).
+ */
+async function sendCommentsInChunks(
+    tabId: number,
+    requestId: string,
+    comments: CommentItem[],
+    metadata: {
+        quotaUsed?: number;
+        incomplete?: boolean;
+        replyFetchErrors?: number;
+        error?: { type: string; message: string; code?: number };
+        isError?: boolean;
+    }
+): Promise<boolean> {
+    // Handle empty array case - send single chunk with empty array
+    if (comments.length === 0) {
+        const success = await safeSendMessage(tabId, {
+            type: 'YCS_YT_API_COMMENTS_CHUNK',
+            body: {
+                requestId,
+                comments: [],
+                chunkIndex: 0,
+                totalChunks: 1,
+                isLastChunk: true,
+                ...(metadata.quotaUsed !== undefined && { quotaUsed: metadata.quotaUsed }),
+                ...(metadata.incomplete !== undefined && { incomplete: metadata.incomplete }),
+                ...(metadata.replyFetchErrors !== undefined && { replyFetchErrors: metadata.replyFetchErrors }),
+                ...(metadata.error && { error: metadata.error, isError: true })
+            }
+        });
+        if (!success) {
+            console.warn('[YCS Background] Failed to send empty chunk - tab may be closed');
+        }
+        return success;
+    }
+
+    const chunks = chunkArray(comments, CHUNK_SIZE);
+    const totalChunks = chunks.length;
+
+    for (let i = 0; i < totalChunks; i++) {
+        const isLastChunk = i === totalChunks - 1;
+        const success = await safeSendMessage(tabId, {
+            type: 'YCS_YT_API_COMMENTS_CHUNK',
+            body: {
+                requestId,
+                comments: chunks[i],
+                chunkIndex: i,
+                totalChunks,
+                isLastChunk,
+                // Include metadata only in last chunk
+                ...(isLastChunk && {
+                    ...(metadata.quotaUsed !== undefined && { quotaUsed: metadata.quotaUsed }),
+                    ...(metadata.incomplete !== undefined && { incomplete: metadata.incomplete }),
+                    ...(metadata.replyFetchErrors !== undefined && { replyFetchErrors: metadata.replyFetchErrors }),
+                    ...(metadata.error && { error: metadata.error, isError: true })
+                })
+            }
+        });
+
+        if (!success) {
+            console.warn(`[YCS Background] Failed to send chunk ${i + 1}/${totalChunks} - tab may be closed`);
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
  * Fetch all replies for a parent comment (background version)
  */
 async function fetchAllRepliesBackground(
@@ -182,18 +268,17 @@ async function fetchAllCommentsBackground(
             comments[idx]._index = idx;
         }
 
-        // Send completion (with incomplete flag if any reply fetches failed)
-        await safeSendMessage(tabId, {
-            type: 'YCS_YT_API_COMMENTS_COMPLETE',
-            body: {
-                requestId,
-                comments,
-                totalCount: comments.length,
-                quotaUsed: fetchState.quotaUsed,
-                incomplete: fetchState.replyFetchErrors > 0,
-                replyFetchErrors: fetchState.replyFetchErrors
-            }
+        // Send completion in chunks (handles Chrome message size limit)
+        const sendSuccess = await sendCommentsInChunks(tabId, requestId, comments, {
+            quotaUsed: fetchState.quotaUsed,
+            incomplete: fetchState.replyFetchErrors > 0,
+            replyFetchErrors: fetchState.replyFetchErrors
         });
+
+        // If send failed (tab closed or message size exceeded), abort gracefully
+        if (!sendSuccess) {
+            return;
+        }
 
         if (fetchState.replyFetchErrors > 0) {
             console.warn(
@@ -206,14 +291,9 @@ async function fetchAllCommentsBackground(
             comments[idx]._index = idx;
         }
 
-        // Send error with partial results
-        await safeSendMessage(tabId, {
-            type: 'YCS_YT_API_COMMENTS_ERROR',
-            body: {
-                requestId,
-                error: mapYouTubeApiError(error),
-                partialComments: comments.length > 0 ? comments : undefined
-            }
+        // Send error with partial comments (if any) using unified chunking
+        await sendCommentsInChunks(tabId, requestId, comments, {
+            error: mapYouTubeApiError(error)
         });
     }
 }

--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -1,6 +1,189 @@
 import { options } from './config/options';
-import { IStorageEstimate } from './utils/interfaces/i_types';
+import { IStorageEstimate, CommentItem } from './utils/interfaces/i_types';
 import { idb } from './utils/libs';
+import PQueue from 'p-queue';
+import { fetchCommentThreads, fetchCommentReplies, YouTubeDataApiError } from './utils/youtubeDataApi/client';
+import { transformThreadToCommentItems, transformReplyToCommentItem } from './utils/youtubeDataApi/transform';
+
+// Track active YouTube API requests for abort handling
+const activeYouTubeApiRequests = new Map<string, AbortController>();
+
+/**
+ * Shared state for tracking fetch progress across async operations
+ */
+interface FetchState {
+    quotaUsed: number;
+    maxComments: number;
+    signal: AbortSignal | undefined;
+    replyFetchErrors: number; // Track failed reply fetches
+}
+
+/**
+ * Map YouTube Data API errors to error response format
+ */
+function mapYouTubeApiError(error: unknown): { type: string; message: string; code?: number } {
+    if (error instanceof YouTubeDataApiError) {
+        if (error.isQuotaExceeded) {
+            return { type: 'quotaExceeded', message: error.message, code: error.code };
+        }
+        if (error.isInvalidApiKey) {
+            return { type: 'invalidApiKey', message: error.message, code: error.code };
+        }
+        return { type: 'apiError', message: error.message, code: error.code };
+    }
+    if (error instanceof DOMException && error.name === 'AbortError') {
+        return { type: 'aborted', message: 'Request was aborted' };
+    }
+    return { type: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' };
+}
+
+/**
+ * Fetch all replies for a parent comment (background version)
+ */
+async function fetchAllRepliesBackground(
+    parentId: string,
+    apiKey: string,
+    videoId: string,
+    parentItem: CommentItem,
+    comments: CommentItem[],
+    fetchState: FetchState
+): Promise<void> {
+    let pageToken: string | undefined;
+
+    do {
+        if (fetchState.signal?.aborted) break;
+        if (comments.length >= fetchState.maxComments) break;
+
+        try {
+            const response = await fetchCommentReplies(parentId, apiKey, pageToken, fetchState.signal);
+            fetchState.quotaUsed += 1;
+
+            for (const apiComment of response.items) {
+                if (comments.length >= fetchState.maxComments) break;
+                const replyItem = transformReplyToCommentItem(apiComment, videoId, parentItem);
+                comments.push(replyItem);
+            }
+
+            pageToken = response.nextPageToken;
+        } catch (error) {
+            console.error(`[YCS Background] Failed to fetch replies for ${parentId}:`, error);
+            fetchState.replyFetchErrors += 1;
+            break;
+        }
+    } while (pageToken && comments.length < fetchState.maxComments && !fetchState.signal?.aborted);
+}
+
+/**
+ * Fetch all comments for a video using YouTube Data API v3 (background version)
+ */
+async function fetchAllCommentsBackground(
+    videoId: string,
+    apiKey: string,
+    tabId: number,
+    requestId: string,
+    signal: AbortSignal
+): Promise<void> {
+    const comments: CommentItem[] = [];
+    let pageToken: string | undefined;
+    const maxComments = 500000;
+
+    const fetchState: FetchState = {
+        quotaUsed: 0,
+        maxComments,
+        signal,
+        replyFetchErrors: 0
+    };
+
+    const replyQueue = new PQueue({ concurrency: 4 });
+    const replyPromises: Promise<void>[] = [];
+
+    try {
+        do {
+            if (signal.aborted) break;
+            if (comments.length >= maxComments) break;
+
+            const response = await fetchCommentThreads(videoId, apiKey, pageToken, signal);
+            fetchState.quotaUsed += 1;
+
+            for (const thread of response.items) {
+                if (comments.length >= maxComments) break;
+
+                const threadItems = transformThreadToCommentItems(thread, videoId);
+                const parentItem = threadItems[0];
+                comments.push(parentItem);
+
+                // Add inline replies
+                const inlineReplies = threadItems.slice(1);
+                for (const reply of inlineReplies) {
+                    if (comments.length >= maxComments) break;
+                    comments.push(reply);
+                }
+
+                // Queue additional replies if needed
+                const totalReplyCount = thread.snippet.totalReplyCount;
+                const inlineReplyCount = thread.replies?.comments?.length ?? 0;
+
+                if (totalReplyCount > inlineReplyCount && comments.length < maxComments) {
+                    const parentId = thread.snippet.topLevelComment.id;
+                    const replyPromise = replyQueue.add(async () => {
+                        await fetchAllRepliesBackground(parentId, apiKey, videoId, parentItem, comments, fetchState);
+                    });
+                    replyPromises.push(replyPromise as Promise<void>);
+                }
+            }
+
+            // Send progress update
+            chrome.tabs.sendMessage(tabId, {
+                type: 'YCS_YT_API_COMMENTS_PROGRESS',
+                body: {
+                    requestId,
+                    totalCount: comments.length,
+                    quotaUsed: fetchState.quotaUsed
+                }
+            });
+
+            pageToken = response.nextPageToken;
+        } while (pageToken && comments.length < maxComments && !signal.aborted);
+
+        // Wait for all reply fetches
+        await Promise.all(replyPromises);
+        await replyQueue.onIdle();
+
+        // Assign indices sequentially
+        for (let idx = 0; idx < comments.length; idx++) {
+            comments[idx]._index = idx;
+        }
+
+        // Send completion (with incomplete flag if any reply fetches failed)
+        chrome.tabs.sendMessage(tabId, {
+            type: 'YCS_YT_API_COMMENTS_COMPLETE',
+            body: {
+                requestId,
+                comments,
+                totalCount: comments.length,
+                quotaUsed: fetchState.quotaUsed,
+                incomplete: fetchState.replyFetchErrors > 0,
+                replyFetchErrors: fetchState.replyFetchErrors
+            }
+        });
+
+        if (fetchState.replyFetchErrors > 0) {
+            console.warn(
+                `[YCS Background] Completed with ${fetchState.replyFetchErrors} reply fetch errors - some replies may be missing`
+            );
+        }
+    } catch (error) {
+        // Send error with partial results
+        chrome.tabs.sendMessage(tabId, {
+            type: 'YCS_YT_API_COMMENTS_ERROR',
+            body: {
+                requestId,
+                error: mapYouTubeApiError(error),
+                partialComments: comments.length > 0 ? comments : undefined
+            }
+        });
+    }
+}
 
 const STORE_CACHE_YCS = 'STORE_CACHE_YCS';
 
@@ -93,6 +276,54 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
                 await db.clear(STORE_CACHE_YCS);
                 await db.put(STORE_CACHE_YCS, message, message.body.videoId);
             }
+        }
+    }
+
+    // YouTube Data API: Start loading comments
+    if (message?.type === 'YCS_YT_API_COMMENTS_START') {
+        const { videoId, requestId } = message.body ?? {};
+        const tabId = sender.tab?.id;
+
+        if (!tabId || !videoId || !requestId) {
+            console.warn('[YCS Background] Invalid YCS_YT_API_COMMENTS_START message:', message);
+            return;
+        }
+
+        // Read API key from storage (secure - never sent to web page)
+        const opts = await chrome.storage.local.get(['youtubeApiKey', 'youtubeApiEnabled']);
+        const apiKey = (opts.youtubeApiKey as string)?.trim();
+        const apiEnabled = opts.youtubeApiEnabled !== false;
+
+        if (!apiKey || !apiEnabled) {
+            chrome.tabs.sendMessage(tabId, {
+                type: 'YCS_YT_API_COMMENTS_ERROR',
+                body: {
+                    requestId,
+                    error: { type: 'invalidApiKey', message: 'API key not configured or disabled' }
+                }
+            });
+            return;
+        }
+
+        // Create AbortController for this request
+        const controller = new AbortController();
+        activeYouTubeApiRequests.set(requestId, controller);
+
+        // Execute fetch (non-blocking)
+        fetchAllCommentsBackground(videoId, apiKey, tabId, requestId, controller.signal).then(
+            () => activeYouTubeApiRequests.delete(requestId),
+            () => activeYouTubeApiRequests.delete(requestId)
+        );
+    }
+
+    // YouTube Data API: Abort loading
+    if (message?.type === 'YCS_YT_API_COMMENTS_ABORT') {
+        const { requestId } = message.body ?? {};
+        const controller = activeYouTubeApiRequests.get(requestId);
+        if (controller) {
+            controller.abort();
+            activeYouTubeApiRequests.delete(requestId);
+            console.log('[YCS Background] Aborted request:', requestId);
         }
     }
 });

--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -158,7 +158,14 @@ async function fetchAllCommentsBackground(
                     quotaUsed: fetchState.quotaUsed
                 }
             });
-            if (!tabExists) return; // Tab closed or navigated away, exit gracefully
+            if (!tabExists) {
+                // Tab closed or navigated away - abort controller to cancel all in-flight requests
+                const request = activeYouTubeApiRequests.get(requestId);
+                if (request) {
+                    request.controller.abort();
+                }
+                return;
+            }
 
             pageToken = response.nextPageToken;
         } while (pageToken && comments.length < maxComments && !signal.aborted);

--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -198,6 +198,11 @@ async function fetchAllCommentsBackground(
             );
         }
     } catch (error) {
+        // Assign indices to partial results before sending
+        for (let idx = 0; idx < comments.length; idx++) {
+            comments[idx]._index = idx;
+        }
+
         // Send error with partial results
         await safeSendMessage(tabId, {
             type: 'YCS_YT_API_COMMENTS_ERROR',

--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -6,7 +6,11 @@ import { fetchCommentThreads, fetchCommentReplies, YouTubeDataApiError } from '.
 import { transformThreadToCommentItems, transformReplyToCommentItem } from './utils/youtubeDataApi/transform';
 
 // Track active YouTube API requests for abort handling
-const activeYouTubeApiRequests = new Map<string, AbortController>();
+interface ActiveRequest {
+    controller: AbortController;
+    tabId: number;
+}
+const activeYouTubeApiRequests = new Map<string, ActiveRequest>();
 
 /**
  * Shared state for tracking fetch progress across async operations
@@ -35,6 +39,19 @@ function mapYouTubeApiError(error: unknown): { type: string; message: string; co
         return { type: 'aborted', message: 'Request was aborted' };
     }
     return { type: 'unknown', message: error instanceof Error ? error.message : 'Unknown error' };
+}
+
+/**
+ * Safely send message to tab, returning false if tab no longer exists
+ */
+async function safeSendMessage(tabId: number, message: unknown): Promise<boolean> {
+    try {
+        await chrome.tabs.sendMessage(tabId, message);
+        return true;
+    } catch {
+        // Tab closed or navigated away - expected behavior
+        return false;
+    }
 }
 
 /**
@@ -133,7 +150,7 @@ async function fetchAllCommentsBackground(
             }
 
             // Send progress update
-            chrome.tabs.sendMessage(tabId, {
+            const tabExists = await safeSendMessage(tabId, {
                 type: 'YCS_YT_API_COMMENTS_PROGRESS',
                 body: {
                     requestId,
@@ -141,6 +158,7 @@ async function fetchAllCommentsBackground(
                     quotaUsed: fetchState.quotaUsed
                 }
             });
+            if (!tabExists) return; // Tab closed or navigated away, exit gracefully
 
             pageToken = response.nextPageToken;
         } while (pageToken && comments.length < maxComments && !signal.aborted);
@@ -155,7 +173,7 @@ async function fetchAllCommentsBackground(
         }
 
         // Send completion (with incomplete flag if any reply fetches failed)
-        chrome.tabs.sendMessage(tabId, {
+        await safeSendMessage(tabId, {
             type: 'YCS_YT_API_COMMENTS_COMPLETE',
             body: {
                 requestId,
@@ -174,7 +192,7 @@ async function fetchAllCommentsBackground(
         }
     } catch (error) {
         // Send error with partial results
-        chrome.tabs.sendMessage(tabId, {
+        await safeSendMessage(tabId, {
             type: 'YCS_YT_API_COMMENTS_ERROR',
             body: {
                 requestId,
@@ -307,7 +325,7 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
 
         // Create AbortController for this request
         const controller = new AbortController();
-        activeYouTubeApiRequests.set(requestId, controller);
+        activeYouTubeApiRequests.set(requestId, { controller, tabId });
 
         // Execute fetch (non-blocking)
         fetchAllCommentsBackground(videoId, apiKey, tabId, requestId, controller.signal).then(
@@ -319,11 +337,22 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
     // YouTube Data API: Abort loading
     if (message?.type === 'YCS_YT_API_COMMENTS_ABORT') {
         const { requestId } = message.body ?? {};
-        const controller = activeYouTubeApiRequests.get(requestId);
-        if (controller) {
-            controller.abort();
+        const request = activeYouTubeApiRequests.get(requestId);
+        if (request) {
+            request.controller.abort();
             activeYouTubeApiRequests.delete(requestId);
             console.log('[YCS Background] Aborted request:', requestId);
+        }
+    }
+});
+
+// Abort all YouTube API requests when tab closes
+chrome.tabs.onRemoved.addListener((closedTabId: number) => {
+    for (const [requestId, request] of activeYouTubeApiRequests) {
+        if (request.tabId === closedTabId) {
+            request.controller.abort();
+            activeYouTubeApiRequests.delete(requestId);
+            console.log('[YCS Background] Aborted request due to tab close:', requestId);
         }
     }
 });

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -7,6 +7,8 @@ const options = {
     hiddenByDefault: false,
     hiddenByDefaultShorts: false,
     transcriptLanguage: '',
+    youtubeApiKey: '', // Empty = use Innertube (default); Filled = use YouTube Data API
+    youtubeApiEnabled: true, // Enable YouTube Data API (requires API key to take effect)
     filterButtons: [
         { id: 'ycs_btn_timestamps', enabled: true },
         { id: 'ycs_btn_timestamp_viz', enabled: true },

--- a/app/src/source/content-scripts/cscripts.ts
+++ b/app/src/source/content-scripts/cscripts.ts
@@ -12,7 +12,8 @@ const DEBUG = false;
             'YCS_AUTOLOAD',
             'YCS_YT_API_COMMENTS_PROGRESS',
             'YCS_YT_API_COMMENTS_COMPLETE',
-            'YCS_YT_API_COMMENTS_ERROR'
+            'YCS_YT_API_COMMENTS_ERROR',
+            'YCS_YT_API_COMMENTS_CHUNK'
         ]);
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -44,7 +45,8 @@ const DEBUG = false;
                 if (
                     type === 'YCS_YT_API_COMMENTS_PROGRESS' ||
                     type === 'YCS_YT_API_COMMENTS_COMPLETE' ||
-                    type === 'YCS_YT_API_COMMENTS_ERROR'
+                    type === 'YCS_YT_API_COMMENTS_ERROR' ||
+                    type === 'YCS_YT_API_COMMENTS_CHUNK'
                 ) {
                     if (DEBUG) console.log('[YCS] Forwarding YouTube API response:', type);
                     window.postMessage(message, window.location.origin);

--- a/app/src/source/content-scripts/cscripts.ts
+++ b/app/src/source/content-scripts/cscripts.ts
@@ -7,7 +7,13 @@ const DEBUG = false;
 
     function initContentScript(): void {
         // Whitelist of allowed runtime message types
-        const ALLOWED_RUNTIME_MESSAGE_TYPES = new Set<string>(['YCS_CACHE_STORAGE_GET_SEND', 'YCS_AUTOLOAD']);
+        const ALLOWED_RUNTIME_MESSAGE_TYPES = new Set<string>([
+            'YCS_CACHE_STORAGE_GET_SEND',
+            'YCS_AUTOLOAD',
+            'YCS_YT_API_COMMENTS_PROGRESS',
+            'YCS_YT_API_COMMENTS_COMPLETE',
+            'YCS_YT_API_COMMENTS_ERROR'
+        ]);
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -33,6 +39,16 @@ const DEBUG = false;
                     if (DEBUG) console.log('[YCS] RESPONSE BG SEND AUTOLOAD. Now postMessage in Window');
                     window.postMessage({ type: 'YCS_AUTOLOAD' }, window.location.origin);
                 }
+
+                // Forward YouTube API responses to web page
+                if (
+                    type === 'YCS_YT_API_COMMENTS_PROGRESS' ||
+                    type === 'YCS_YT_API_COMMENTS_COMPLETE' ||
+                    type === 'YCS_YT_API_COMMENTS_ERROR'
+                ) {
+                    if (DEBUG) console.log('[YCS] Forwarding YouTube API response:', type);
+                    window.postMessage(message, window.location.origin);
+                }
             } catch (err) {
                 console.error(err);
             }
@@ -43,7 +59,9 @@ const DEBUG = false;
             'NUMBER_COMMENTS',
             'GET_OPTIONS',
             'YCS_CACHE_STORAGE_SET',
-            'YCS_CACHE_STORAGE_GET'
+            'YCS_CACHE_STORAGE_GET',
+            'YCS_YT_API_COMMENTS_START',
+            'YCS_YT_API_COMMENTS_ABORT'
         ]);
 
         const VIDEO_ID_REGEX = /^[a-zA-Z0-9_-]{11}$/;
@@ -83,7 +101,14 @@ const DEBUG = false;
 
                             const opts = await chrome.storage.local.get();
 
-                            window.postMessage({ type: 'YCS_OPTIONS', text: opts }, window.location.origin);
+                            // Security: Filter out sensitive data, only expose hasYoutubeApiKey flag
+                            const { youtubeApiKey, ...safeOpts } = opts;
+                            const sanitizedOpts = {
+                                ...safeOpts,
+                                hasYoutubeApiKey: !!(youtubeApiKey as string)?.trim()
+                            };
+
+                            window.postMessage({ type: 'YCS_OPTIONS', text: sanitizedOpts }, window.location.origin);
                         } catch (err) {
                             console.error(err);
                         }
@@ -107,6 +132,21 @@ const DEBUG = false;
                         chrome.runtime.sendMessage(`${chrome.runtime.id}`, msg, (res) => {
                             if (DEBUG) console.log('[YCS] Response YCS_CACHE_STORAGE GET:', res);
                         });
+                    }
+
+                    // Forward YouTube API requests to background
+                    if (msg.type === 'YCS_YT_API_COMMENTS_START' && msg?.body) {
+                        if (!isValidVideoId(msg.body?.videoId)) {
+                            if (DEBUG) console.warn('[YCS] Invalid video ID format for YouTube API');
+                            return;
+                        }
+                        if (DEBUG) console.log('[YCS] Forwarding YouTube API START:', msg);
+                        chrome.runtime.sendMessage(`${chrome.runtime.id}`, msg);
+                    }
+
+                    if (msg.type === 'YCS_YT_API_COMMENTS_ABORT' && msg?.body) {
+                        if (DEBUG) console.log('[YCS] Forwarding YouTube API ABORT:', msg);
+                        chrome.runtime.sendMessage(`${chrome.runtime.id}`, msg);
                     }
                 } catch (err) {
                     console.error(err);

--- a/app/src/source/options/assets/css/style.css
+++ b/app/src/source/options/assets/css/style.css
@@ -505,3 +505,93 @@ code {
   font-size: 13px;
   border: 1px solid #3a3a3a;
 }
+
+/* YouTube Data API Settings */
+.ycs_api_settings_wrap {
+  border: 2px solid #adadad;
+  padding: 16px;
+  margin-bottom: 25px;
+}
+
+.ycs_api_key_input {
+  margin-top: 15px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ycs_api_key_input label {
+  font-size: 18px;
+  min-width: 80px;
+}
+
+.ycs_opts_input_api_key {
+  height: 30px;
+  width: 320px;
+  font-size: 16px;
+  padding: 0px 10px;
+  background-color: #1f1f1f;
+  color: #fff;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+  font-family: 'Ubuntu Mono', monospace;
+}
+
+.ycs_opts_input_api_key:focus {
+  outline: none;
+  border-color: #ffa500;
+  box-shadow: 0 0 0 2px rgba(255, 165, 0, 0.2);
+}
+
+.ycs_opts_input_api_key::placeholder {
+  color: #666;
+  font-size: 14px;
+}
+
+.ycs_btn_toggle_key {
+  padding: 4px 12px;
+  font-size: 14px;
+  min-width: 60px;
+}
+
+.ycs_api_status {
+  margin-top: 15px;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ycs_api_mode_label {
+  color: #adadad;
+}
+
+.ycs_api_mode_value {
+  color: #ffa500;
+  font-weight: bold;
+}
+
+.ycs_api_mode_value.youtube-api {
+  color: #4caf50;
+}
+
+.ycs_api_note {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #1f1f1f;
+  border-left: 3px solid #ffa500;
+  border-radius: 0 4px 4px 0;
+}
+
+.ycs_api_note p {
+  margin: 0;
+}
+
+.ycs_api_settings_wrap a {
+  color: #4da6ff;
+  text-decoration: none;
+}
+
+.ycs_api_settings_wrap a:hover {
+  text-decoration: underline;
+}

--- a/app/src/source/options/assets/css/style.css
+++ b/app/src/source/options/assets/css/style.css
@@ -76,6 +76,10 @@ button:hover {
   display: inline-block;
 }
 
+.ycs_opts_cache.ycs_opts_cache_auto_clear {
+  margin-top: 30px;
+}
+
 .ycs_opts_btn {
   margin: 0;
   padding: 6px;
@@ -513,11 +517,44 @@ code {
   margin-bottom: 25px;
 }
 
+.ycs_api_header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.ycs_api_title {
+  font-size: 20px;
+  font-weight: bold;
+  color: #fff;
+}
+
+.ycs_api_enable_control {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ycs_api_enable_control label {
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.ycs_api_desc p {
+  color: #adadad;
+  margin: 8px 0 20px 0;
+  font-size: 15px;
+}
+.ycs_api_desc.ycs_api_desc--no-bottom-margin p {
+  margin-bottom: 0;
+}
+
 .ycs_api_key_input {
   margin-top: 15px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 15px;
 }
 
 .ycs_api_key_input label {
@@ -525,22 +562,46 @@ code {
   min-width: 80px;
 }
 
+.ycs_input_group {
+  display: flex;
+  flex: 1;
+}
+
 .ycs_opts_input_api_key {
-  height: 30px;
-  width: 320px;
+  height: 34px;
+  flex: 1;
   font-size: 16px;
-  padding: 0px 10px;
+  padding: 0px 12px;
   background-color: #1f1f1f;
   color: #fff;
   border: 1px solid #3a3a3a;
-  border-radius: 4px;
+  border-right: none;
+  border-radius: 4px 0 0 4px;
   font-family: 'Ubuntu Mono', monospace;
+  max-width: 400px;
 }
 
 .ycs_opts_input_api_key:focus {
   outline: none;
   border-color: #ffa500;
-  box-shadow: 0 0 0 2px rgba(255, 165, 0, 0.2);
+  box-shadow: none;
+  z-index: 2;
+}
+
+.ycs_btn_toggle_key {
+  height: 34px;
+  padding: 0 16px;
+  font-size: 14px;
+  min-width: 60px;
+  border: 1px solid #adadad;
+  background-color: #2f3640;
+  border-radius: 0 4px 4px 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.ycs_btn_toggle_key:hover {
+  background-color: #262626;
 }
 
 .ycs_opts_input_api_key::placeholder {
@@ -548,18 +609,13 @@ code {
   font-size: 14px;
 }
 
-.ycs_btn_toggle_key {
-  padding: 4px 12px;
-  font-size: 14px;
-  min-width: 60px;
-}
-
 .ycs_api_status {
-  margin-top: 15px;
+  margin-top: 20px;
   font-size: 16px;
   display: flex;
   align-items: center;
   gap: 8px;
+  padding-left: 2px;
 }
 
 .ycs_api_mode_label {
@@ -576,8 +632,8 @@ code {
 }
 
 .ycs_api_note {
-  margin-top: 15px;
-  padding: 10px;
+  margin-top: 20px;
+  padding: 12px 16px;
   background-color: #1f1f1f;
   border-left: 3px solid #ffa500;
   border-radius: 0 4px 4px 0;
@@ -585,6 +641,7 @@ code {
 
 .ycs_api_note p {
   margin: 0;
+  line-height: 1.4;
 }
 
 .ycs_api_settings_wrap a {

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -125,6 +125,102 @@ window.onload = async (): Promise<void> => {
             }
         };
 
+        // YouTube Data API handlers
+        let currentApiEnabled = true;
+        let currentApiKey = '';
+
+        const setRenderYoutubeApiEnabled = (param: boolean): void => {
+            const checkbox = document.getElementById('y_opts_youtube_api_enabled') as HTMLInputElement | null;
+            if (!checkbox) return;
+            checkbox.checked = param !== false; // default true
+            currentApiEnabled = param !== false;
+            updateApiModeDisplay();
+        };
+
+        const optSetYoutubeApiEnabled = async (enabled: boolean): Promise<void> => {
+            try {
+                await chrome.storage.local.set({
+                    youtubeApiEnabled: enabled
+                });
+                currentApiEnabled = enabled;
+                updateApiModeDisplay();
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
+        const setRenderYoutubeApiKey = (param?: string): void => {
+            const input = document.getElementById('y_opts_youtube_api_key') as HTMLInputElement | null;
+            if (!input) return;
+            input.value = param ?? '';
+            currentApiKey = param ?? '';
+            updateApiModeDisplay();
+        };
+
+        const optSetYoutubeApiKey = async (value: string): Promise<void> => {
+            try {
+                const trimmedValue = value.trim();
+                await chrome.storage.local.set({
+                    youtubeApiKey: trimmedValue
+                });
+                currentApiKey = trimmedValue;
+                updateApiModeDisplay();
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
+        const updateApiModeDisplay = (): void => {
+            const modeValue = document.getElementById('ycs_api_mode_value') as HTMLElement | null;
+            if (!modeValue) return;
+
+            const hasKey = currentApiKey && currentApiKey.trim();
+            const isEnabled = currentApiEnabled && hasKey;
+
+            if (isEnabled) {
+                modeValue.textContent = 'YouTube Data API';
+                modeValue.classList.add('youtube-api');
+                modeValue.classList.remove('disabled');
+            } else if (hasKey && !currentApiEnabled) {
+                modeValue.textContent = 'YouTube Data API (disabled)';
+                modeValue.classList.remove('youtube-api');
+                modeValue.classList.add('disabled');
+            } else {
+                modeValue.textContent = 'Innertube (default)';
+                modeValue.classList.remove('youtube-api');
+                modeValue.classList.remove('disabled');
+            }
+        };
+
+        const initYoutubeApiKeyEvents = (): void => {
+            const apiKeyInput = document.getElementById('y_opts_youtube_api_key') as HTMLInputElement | null;
+            const toggleBtn = document.getElementById('ycs_toggle_api_key') as HTMLButtonElement | null;
+
+            if (apiKeyInput) {
+                apiKeyInput.addEventListener('input', (e: Event) => {
+                    const target = e.target as HTMLInputElement;
+                    optSetYoutubeApiKey(target.value);
+                });
+
+                apiKeyInput.addEventListener('change', (e: Event) => {
+                    const target = e.target as HTMLInputElement;
+                    optSetYoutubeApiKey(target.value);
+                });
+            }
+
+            if (toggleBtn && apiKeyInput) {
+                toggleBtn.addEventListener('click', () => {
+                    if (apiKeyInput.type === 'password') {
+                        apiKeyInput.type = 'text';
+                        toggleBtn.textContent = 'Hide';
+                    } else {
+                        apiKeyInput.type = 'password';
+                        toggleBtn.textContent = 'Show';
+                    }
+                });
+            }
+        };
+
         const setRenderFilterButtons = (filterButtons: Array<{ id: string; enabled: boolean }>): void => {
             if (!Array.isArray(filterButtons)) return;
 
@@ -554,6 +650,14 @@ window.onload = async (): Promise<void> => {
                         setRenderFilterButtons(storageOpts[key]);
                         break;
 
+                    case 'youtubeApiKey':
+                        setRenderYoutubeApiKey(storageOpts[key]);
+                        break;
+
+                    case 'youtubeApiEnabled':
+                        setRenderYoutubeApiEnabled(storageOpts[key]);
+                        break;
+
                     default:
                         break;
                 }
@@ -562,6 +666,9 @@ window.onload = async (): Promise<void> => {
 
         // Initialize filter buttons events once after initial render
         initFilterButtonsEvents();
+
+        // Initialize YouTube API key events
+        initYoutubeApiKeyEvents();
 
         const elAutoload = document.getElementsByClassName('ycs_inner_wrap')[0];
         elAutoload?.addEventListener('click', async (e: Event) => {
@@ -603,6 +710,10 @@ window.onload = async (): Promise<void> => {
 
                 case 'ycs_opts_btn_reset_filters':
                     await resetFilterButtonsToDefault();
+                    break;
+
+                case 'y_opts_youtube_api_enabled':
+                    optSetYoutubeApiEnabled((e.target as HTMLInputElement).checked);
                     break;
 
                 default:

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -21,8 +21,8 @@
           <label for="y_opts_autoload">Autoloading comments:</label>
           <input type="checkbox" name="Autoloading comments" id="y_opts_autoload" class="ycs_opts_checkbox" />
 
-          <div class="ycs_description_option">
-            <p>(Automatically loading all comments when the user navigates to the video page.)</p>
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Automatically loading all comments when the user navigates to the video page.</p>
           </div>
         </div>
 
@@ -31,15 +31,15 @@
             <label for="y_opts_highlight">Highlight text:</label>
             <input type="checkbox" name="Highlight text" id="y_opts_highlight" class="ycs_opts_checkbox" />
 
-            <div class="ycs_description_option">
-              <p>(Highlight text in search results.)</p>
+            <div class="ycs_description_option ycs_api_desc">
+              <p>Highlight text in search results.</p>
             </div>
           </div>
           <div class="ycs_group_subgroup">
             <label for="y_opts_highlight_exact">Exact:</label>
             <input type="checkbox" name="Highlight text exact" id="y_opts_highlight_exact" class="ycs_opts_checkbox" />
-            <div class="ycs_description_option">
-              <p>(Highlight, be exact.)</p>
+            <div class="ycs_description_option ycs_api_desc">
+              <p>Highlight, be exact.</p>
             </div>
           </div>
         </div>
@@ -47,8 +47,8 @@
         <div>
           <label for="y_opts_hidden_by_default">Hidden by default:</label>
           <input type="checkbox" name="Hidden by default" id="y_opts_hidden_by_default" class="ycs_opts_checkbox" />
-          <div class="ycs_description_option">
-            <p>(Show only the YCS toggle bar by default; click to expand. Applies to regular video pages only.)</p>
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Show only the YCS toggle bar by default; click to expand. Applies to regular video pages only.</p>
           </div>
         </div>
 
@@ -60,8 +60,8 @@
             id="y_opts_hidden_by_default_shorts"
             class="ycs_opts_checkbox"
           />
-          <div class="ycs_description_option">
-            <p>(Show only the YCS toggle bar by default; click to expand. Applies to Shorts pages only.)</p>
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Show only the YCS toggle bar by default; click to expand. Applies to Shorts pages only.</p>
           </div>
         </div>
 
@@ -98,52 +98,50 @@
             />
           </div>
 
-          <div class="ycs_description_option">
-            <p>(Select a language or enter a custom BCP-47 code like <code>en</code> or <code>ja</code>.)</p>
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Select a language or enter a custom BCP-47 code like <code>en</code> or <code>ja</code>.</p>
           </div>
         </div>
 
         <div class="ycs_api_settings_wrap">
-          <div>
+          <div class="ycs_api_header">
             <label>YouTube Data API (Optional):</label>
-            <div class="ycs_description_option">
-              <p>
-                (Use official YouTube Data API instead of Innertube. Leave empty to use Innertube (default).
-                <a
-                  href="https://developers.google.com/youtube/registering_an_application"
-                  target="_blank"
-                  rel="noopener"
-                  >Get your API key</a
-                >)
-              </p>
+            <div class="ycs_api_enable_control">
+              <label for="y_opts_youtube_api_enabled">Enable:</label>
+              <input
+                type="checkbox"
+                name="Enable YouTube Data API"
+                id="y_opts_youtube_api_enabled"
+                class="ycs_opts_checkbox"
+                checked
+              />
             </div>
           </div>
 
-          <div class="ycs_api_enable_wrap">
-            <label for="y_opts_youtube_api_enabled">Enable YouTube Data API:</label>
-            <input
-              type="checkbox"
-              name="Enable YouTube Data API"
-              id="y_opts_youtube_api_enabled"
-              class="ycs_opts_checkbox"
-              checked
-            />
-            <div class="ycs_description_option">
-              <p>(Requires API key below to take effect. Uncheck to temporarily use Innertube.)</p>
-            </div>
+          <div class="ycs_description_option ycs_api_desc">
+            <p>
+              Use official YouTube Data API instead of Innertube. (<a
+                href="https://developers.google.com/youtube/registering_an_application"
+                target="_blank"
+                rel="noopener"
+                >Get your API key</a
+              >)
+            </p>
           </div>
 
           <div class="ycs_api_key_input">
             <label for="y_opts_youtube_api_key">API Key:</label>
-            <input
-              type="password"
-              name="YouTube API Key"
-              id="y_opts_youtube_api_key"
-              class="ycs_opts_input_api_key"
-              placeholder="Enter your API key"
-              maxlength="255"
-            />
-            <button type="button" id="ycs_toggle_api_key" class="ycs_opts_btn ycs_btn_toggle_key">Show</button>
+            <div class="ycs_input_group">
+              <input
+                type="password"
+                name="YouTube API Key"
+                id="y_opts_youtube_api_key"
+                class="ycs_opts_input_api_key"
+                placeholder="Enter your API key"
+                maxlength="255"
+              />
+              <button type="button" id="ycs_toggle_api_key" class="ycs_opts_btn ycs_btn_toggle_key">Show</button>
+            </div>
           </div>
 
           <div class="ycs_api_status" id="ycs_api_status">
@@ -162,8 +160,8 @@
         <div class="ycs_filter_buttons_wrap">
           <div>
             <label>Filter Buttons:</label>
-            <div class="ycs_description_option">
-              <p>(Customize which filter buttons to show and their order on YouTube video pages.)</p>
+            <div class="ycs_description_option ycs_api_desc">
+              <p>Customize which filter buttons to show and their order on YouTube video pages.</p>
             </div>
           </div>
 
@@ -260,8 +258,8 @@
           <div class="ycs_opts_cache">
             <label for="y_opts_cache">Cache:</label>
             <input type="checkbox" name="Cache" id="y_opts_cache" class="ycs_opts_checkbox" />
-            <div class="ycs_description_option">
-              <p>(Puts all loaded comments in the cache.)</p>
+            <div class="ycs_description_option ycs_api_desc">
+              <p>Puts all loaded comments in the cache.</p>
             </div>
           </div>
 
@@ -300,12 +298,12 @@
             </div>
           </div>
 
-          <div class="ycs_opts_cache">
+          <div class="ycs_opts_cache ycs_opts_cache_auto_clear">
             <label for="y_opts_cache_quota">Auto clear:</label>
             <input type="text" name="Cache limit" id="y_opts_cache_quota" class="ycs_opts_input_quota" value="200" />
             <span class="ycs_opts_cache_q_mb ycs_opt_mark">MB</span>
-            <div class="ycs_description_option">
-              <p>(Automatically clears the cache when the specified MB limit is reached.)</p>
+            <div class="ycs_description_option ycs_api_desc ycs_api_desc--no-bottom-margin">
+              <p>Automatically clears the cache when the specified MB limit is reached.</p>
             </div>
           </div>
         </div>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -103,6 +103,62 @@
           </div>
         </div>
 
+        <div class="ycs_api_settings_wrap">
+          <div>
+            <label>YouTube Data API (Optional):</label>
+            <div class="ycs_description_option">
+              <p>
+                (Use official YouTube Data API instead of Innertube. Leave empty to use Innertube (default).
+                <a
+                  href="https://developers.google.com/youtube/registering_an_application"
+                  target="_blank"
+                  rel="noopener"
+                  >Get your API key</a
+                >)
+              </p>
+            </div>
+          </div>
+
+          <div class="ycs_api_enable_wrap">
+            <label for="y_opts_youtube_api_enabled">Enable YouTube Data API:</label>
+            <input
+              type="checkbox"
+              name="Enable YouTube Data API"
+              id="y_opts_youtube_api_enabled"
+              class="ycs_opts_checkbox"
+              checked
+            />
+            <div class="ycs_description_option">
+              <p>(Requires API key below to take effect. Uncheck to temporarily use Innertube.)</p>
+            </div>
+          </div>
+
+          <div class="ycs_api_key_input">
+            <label for="y_opts_youtube_api_key">API Key:</label>
+            <input
+              type="password"
+              name="YouTube API Key"
+              id="y_opts_youtube_api_key"
+              class="ycs_opts_input_api_key"
+              placeholder="Enter your API key"
+              maxlength="255"
+            />
+            <button type="button" id="ycs_toggle_api_key" class="ycs_opts_btn ycs_btn_toggle_key">Show</button>
+          </div>
+
+          <div class="ycs_api_status" id="ycs_api_status">
+            <span class="ycs_api_mode_label">Current mode:</span>
+            <span class="ycs_api_mode_value" id="ycs_api_mode_value">Innertube (default)</span>
+          </div>
+
+          <div class="ycs_description_option ycs_api_note">
+            <p>
+              <strong>Note:</strong> YouTube Data API has a quota limit of 10,000 units/day. Member badges, hearts, and
+              Super Chat markers are only available with Innertube.
+            </p>
+          </div>
+        </div>
+
         <div class="ycs_filter_buttons_wrap">
           <div>
             <label>Filter Buttons:</label>

--- a/app/src/source/utils/assist.ts
+++ b/app/src/source/utils/assist.ts
@@ -128,7 +128,12 @@ export {
     clearCurrentVideoMemberOnly,
     normalizeYtInitialData,
     updateMemberOnlyStatus,
-    shouldDisableAuth
+    shouldDisableAuth,
+    // YouTube Data API v3
+    getAllCommentsYouTubeApi,
+    isQuotaExceeded,
+    isInvalidApiKey,
+    YouTubeDataApiError
 } from './innertube';
 
 export { EXPORT_FORMAT } from './constants';

--- a/app/src/source/utils/icons.ts
+++ b/app/src/source/utils/icons.ts
@@ -66,4 +66,53 @@ function iconPlay(): string {
     `;
 }
 
-export { iconCollapse, iconExpand, iconExpandShowMore, iconOk, iconPlay, iconReload, iconSortDown, iconSortUp };
+function iconWarning(title?: string): string {
+    const titleAttr = title ? ` title="${title}"` : '';
+    return `
+        <span class="ycs-icons"${titleAttr}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"></path><path d="M12 9v4"></path><path d="M12 17h.01"></path></svg>
+        </span>
+    `;
+}
+
+function iconError(title?: string): string {
+    const titleAttr = title ? ` title="${title}"` : '';
+    return `
+        <span class="ycs-icons"${titleAttr}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="m15 9-6 6"></path><path d="m9 9 6 6"></path></svg>
+        </span>
+    `;
+}
+
+function iconStop(title?: string): string {
+    const titleAttr = title ? ` title="${title}"` : '';
+    return `
+        <span class="ycs-icons"${titleAttr}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#6b7280" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"></rect><rect x="9" y="9" width="6" height="6" rx="1"></rect></svg>
+        </span>
+    `;
+}
+
+function iconInfo(title?: string): string {
+    const titleAttr = title ? ` title="${title}"` : '';
+    return `
+        <span class="ycs-icons"${titleAttr}>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M12 16v-4"></path><path d="M12 8h.01"></path></svg>
+        </span>
+    `;
+}
+
+export {
+    iconCollapse,
+    iconError,
+    iconExpand,
+    iconExpandShowMore,
+    iconInfo,
+    iconOk,
+    iconPlay,
+    iconReload,
+    iconSortDown,
+    iconSortUp,
+    iconStop,
+    iconWarning
+};

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -23,3 +23,11 @@ export {
     updateMemberOnlyStatus,
     shouldDisableAuth
 } from './innertube/memberOnly';
+
+// YouTube Data API v3 (alternative to Innertube)
+export {
+    getAllCommentsYouTubeApi,
+    isQuotaExceeded,
+    isInvalidApiKey,
+    YouTubeDataApiError
+} from './youtubeDataApi/index';

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -308,4 +308,104 @@ export interface IYCSOptions {
     hiddenByDefaultShorts?: boolean;
     filterButtons?: Array<{ id: string; enabled: boolean }>;
     transcriptLanguage?: string;
+    youtubeApiKey?: string; // Empty = use Innertube; Filled = use YouTube Data API
+    youtubeApiEnabled?: boolean; // Enable YouTube Data API (default: true, requires API key)
+}
+
+// =============================================================================
+// YouTube Data API v3 Response Types
+// https://developers.google.com/youtube/v3/docs
+// =============================================================================
+
+/**
+ * YouTube Data API v3 Comment Resource
+ * https://developers.google.com/youtube/v3/docs/comments
+ */
+export interface YouTubeApiComment {
+    kind: 'youtube#comment';
+    etag: string;
+    id: string;
+    snippet: {
+        authorDisplayName: string;
+        authorProfileImageUrl: string;
+        authorChannelUrl: string;
+        authorChannelId: { value: string };
+        channelId?: string;
+        videoId?: string;
+        textDisplay: string;
+        textOriginal: string;
+        parentId?: string; // Present for replies
+        canRate: boolean;
+        viewerRating: string; // 'like' | 'dislike' | 'none'
+        likeCount: number;
+        moderationStatus?: string; // Only for channel/video owner
+        publishedAt: string; // ISO 8601 datetime
+        updatedAt: string; // ISO 8601 datetime
+    };
+}
+
+/**
+ * YouTube Data API v3 CommentThread Resource
+ * https://developers.google.com/youtube/v3/docs/commentThreads
+ */
+export interface YouTubeApiCommentThread {
+    kind: 'youtube#commentThread';
+    etag: string;
+    id: string;
+    snippet: {
+        channelId: string;
+        videoId: string;
+        topLevelComment: YouTubeApiComment;
+        canReply: boolean;
+        totalReplyCount: number;
+        isPublic: boolean;
+    };
+    replies?: {
+        comments: YouTubeApiComment[]; // Subset of replies, use comments.list for all
+    };
+}
+
+/**
+ * YouTube Data API v3 CommentThreads.list Response
+ * https://developers.google.com/youtube/v3/docs/commentThreads/list
+ */
+export interface YouTubeApiCommentThreadListResponse {
+    kind: 'youtube#commentThreadListResponse';
+    etag: string;
+    nextPageToken?: string;
+    pageInfo: {
+        totalResults: number;
+        resultsPerPage: number;
+    };
+    items: YouTubeApiCommentThread[];
+}
+
+/**
+ * YouTube Data API v3 Comments.list Response
+ * https://developers.google.com/youtube/v3/docs/comments/list
+ */
+export interface YouTubeApiCommentListResponse {
+    kind: 'youtube#commentListResponse';
+    etag: string;
+    nextPageToken?: string;
+    pageInfo: {
+        totalResults: number;
+        resultsPerPage: number;
+    };
+    items: YouTubeApiComment[];
+}
+
+/**
+ * YouTube Data API Error Response
+ */
+export interface YouTubeApiError {
+    error: {
+        code: number;
+        message: string;
+        errors: Array<{
+            message: string;
+            domain: string;
+            reason: string;
+        }>;
+    };
 }

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -308,7 +308,8 @@ export interface IYCSOptions {
     hiddenByDefaultShorts?: boolean;
     filterButtons?: Array<{ id: string; enabled: boolean }>;
     transcriptLanguage?: string;
-    youtubeApiKey?: string; // Empty = use Innertube; Filled = use YouTube Data API
+    youtubeApiKey?: string; // Empty = use Innertube; Filled = use YouTube Data API (storage only)
+    hasYoutubeApiKey?: boolean; // Flag exposed to web page (API key never exposed)
     youtubeApiEnabled?: boolean; // Enable YouTube Data API (default: true, requires API key)
 }
 

--- a/app/src/source/utils/youtubeDataApi/client.ts
+++ b/app/src/source/utils/youtubeDataApi/client.ts
@@ -1,0 +1,125 @@
+/**
+ * YouTube Data API v3 Client
+ *
+ * Provides a wrapper around the YouTube Data API v3 for fetching comments.
+ * https://developers.google.com/youtube/v3/docs
+ */
+
+import type {
+    YouTubeApiCommentThreadListResponse,
+    YouTubeApiCommentListResponse,
+    YouTubeApiError
+} from '../interfaces/i_types';
+
+const YOUTUBE_API_BASE_URL = 'https://www.googleapis.com/youtube/v3';
+
+/**
+ * YouTube Data API error with additional context
+ */
+export class YouTubeDataApiError extends Error {
+    code: number;
+    reason: string;
+    isQuotaExceeded: boolean;
+    isInvalidApiKey: boolean;
+
+    constructor(error: YouTubeApiError['error']) {
+        super(error.message);
+        this.name = 'YouTubeDataApiError';
+        this.code = error.code;
+        this.reason = error.errors?.[0]?.reason ?? 'unknown';
+        this.isQuotaExceeded = this.reason === 'quotaExceeded' || this.reason === 'dailyLimitExceeded';
+        this.isInvalidApiKey = this.code === 400 || this.reason === 'keyInvalid';
+    }
+}
+
+/**
+ * Check if an error is a quota exceeded error
+ */
+export function isQuotaExceeded(error: unknown): boolean {
+    return error instanceof YouTubeDataApiError && error.isQuotaExceeded;
+}
+
+/**
+ * Check if an error is an invalid API key error
+ */
+export function isInvalidApiKey(error: unknown): boolean {
+    return error instanceof YouTubeDataApiError && error.isInvalidApiKey;
+}
+
+/**
+ * Fetch comment threads for a video
+ *
+ * @param videoId - YouTube video ID
+ * @param apiKey - YouTube Data API key
+ * @param pageToken - Optional page token for pagination
+ * @param signal - Optional abort signal
+ * @returns Comment threads list response
+ */
+export async function fetchCommentThreads(
+    videoId: string,
+    apiKey: string,
+    pageToken?: string,
+    signal?: AbortSignal
+): Promise<YouTubeApiCommentThreadListResponse> {
+    const params = new URLSearchParams({
+        part: 'snippet,replies',
+        videoId: videoId,
+        maxResults: '100',
+        textFormat: 'html',
+        key: apiKey
+    });
+
+    if (pageToken) {
+        params.set('pageToken', pageToken);
+    }
+
+    const url = `${YOUTUBE_API_BASE_URL}/commentThreads?${params.toString()}`;
+
+    const response = await fetch(url, { signal });
+
+    if (!response.ok) {
+        const errorData = (await response.json()) as YouTubeApiError;
+        throw new YouTubeDataApiError(errorData.error);
+    }
+
+    return response.json() as Promise<YouTubeApiCommentThreadListResponse>;
+}
+
+/**
+ * Fetch replies for a specific comment
+ *
+ * @param parentId - Parent comment ID
+ * @param apiKey - YouTube Data API key
+ * @param pageToken - Optional page token for pagination
+ * @param signal - Optional abort signal
+ * @returns Comments list response
+ */
+export async function fetchCommentReplies(
+    parentId: string,
+    apiKey: string,
+    pageToken?: string,
+    signal?: AbortSignal
+): Promise<YouTubeApiCommentListResponse> {
+    const params = new URLSearchParams({
+        part: 'snippet',
+        parentId: parentId,
+        maxResults: '100',
+        textFormat: 'html',
+        key: apiKey
+    });
+
+    if (pageToken) {
+        params.set('pageToken', pageToken);
+    }
+
+    const url = `${YOUTUBE_API_BASE_URL}/comments?${params.toString()}`;
+
+    const response = await fetch(url, { signal });
+
+    if (!response.ok) {
+        const errorData = (await response.json()) as YouTubeApiError;
+        throw new YouTubeDataApiError(errorData.error);
+    }
+
+    return response.json() as Promise<YouTubeApiCommentListResponse>;
+}

--- a/app/src/source/utils/youtubeDataApi/client.ts
+++ b/app/src/source/utils/youtubeDataApi/client.ts
@@ -21,6 +21,7 @@ export class YouTubeDataApiError extends Error {
     reason: string;
     isQuotaExceeded: boolean;
     isInvalidApiKey: boolean;
+    isUnsupported: boolean;
 
     constructor(error: YouTubeApiError['error']) {
         super(error.message);
@@ -29,6 +30,8 @@ export class YouTubeDataApiError extends Error {
         this.reason = error.errors?.[0]?.reason ?? 'unknown';
         this.isQuotaExceeded = this.reason === 'quotaExceeded' || this.reason === 'dailyLimitExceeded';
         this.isInvalidApiKey = this.code === 400 || this.reason === 'keyInvalid';
+        // Unsupported: comments disabled or video not found (not forbidden - may be fixable)
+        this.isUnsupported = this.reason === 'commentsDisabled' || this.reason === 'videoNotFound';
     }
 }
 

--- a/app/src/source/utils/youtubeDataApi/comments.ts
+++ b/app/src/source/utils/youtubeDataApi/comments.ts
@@ -1,0 +1,219 @@
+/**
+ * YouTube Data API v3 Comments Fetching
+ *
+ * Fetches comments using the official YouTube Data API v3.
+ * This is an alternative to the Innertube API when users provide their API key.
+ */
+
+import PQueue from 'p-queue';
+import type { CommentItem } from '../interfaces/i_types';
+import { fetchCommentThreads, fetchCommentReplies, YouTubeDataApiError } from './client';
+import { transformThreadToCommentItems, transformReplyToCommentItem } from './transform';
+import { showLoadComments } from '../dom';
+
+/**
+ * Result of comment fetching operation
+ */
+export interface YouTubeApiCommentsResult {
+    comments: CommentItem[];
+    quotaUsed: number;
+    totalCount: number;
+}
+
+/**
+ * Shared state for tracking fetch progress across async operations
+ */
+interface FetchState {
+    quotaUsed: number;
+    maxComments: number;
+    signal: AbortSignal | undefined;
+}
+
+/**
+ * Fetch all comments for a video using YouTube Data API v3
+ *
+ * @param videoId - YouTube video ID
+ * @param apiKey - YouTube Data API key
+ * @param elShowLoading - Element to show loading progress
+ * @param signal - AbortSignal for cancellation
+ * @param container - Optional existing comments array to append to
+ * @param maxComments - Maximum number of comments to fetch (default: 500000)
+ * @returns Promise resolving to comments result
+ */
+export async function getAllCommentsYouTubeApi(
+    videoId: string,
+    apiKey: string,
+    elShowLoading: HTMLElement,
+    signal: AbortSignal | undefined,
+    container: CommentItem[] = [],
+    maxComments = 500000
+): Promise<YouTubeApiCommentsResult> {
+    const comments: CommentItem[] = container;
+    let pageToken: string | undefined;
+
+    // Shared state for tracking across async operations
+    const fetchState: FetchState = {
+        quotaUsed: 0,
+        maxComments,
+        signal
+    };
+
+    // Queue for fetching additional replies (when thread has more than inline replies)
+    const replyQueue = new PQueue({ concurrency: 4 });
+    const replyPromises: Promise<void>[] = [];
+
+    try {
+        // Fetch comment threads page by page
+        do {
+            if (signal?.aborted) {
+                break;
+            }
+
+            // Check if we've reached the limit
+            if (comments.length >= maxComments) {
+                break;
+            }
+
+            // Fetch a page of comment threads
+            const response = await fetchCommentThreads(videoId, apiKey, pageToken, signal);
+            fetchState.quotaUsed += 1; // commentThreads.list costs 1 unit
+
+            // Process each thread
+            for (const thread of response.items) {
+                // Check limit before adding each comment
+                if (comments.length >= maxComments) {
+                    break;
+                }
+
+                // Transform thread to CommentItems
+                const threadItems = transformThreadToCommentItems(thread, videoId);
+                const parentItem = threadItems[0];
+
+                // Add parent comment
+                comments.push(parentItem);
+
+                // Add inline replies (YouTube API includes up to 5 replies in the thread response)
+                const inlineReplies = threadItems.slice(1);
+                for (const reply of inlineReplies) {
+                    if (comments.length >= maxComments) {
+                        break;
+                    }
+                    comments.push(reply);
+                }
+
+                // Check if we need to fetch additional replies
+                const totalReplyCount = thread.snippet.totalReplyCount;
+                const inlineReplyCount = thread.replies?.comments?.length ?? 0;
+
+                if (totalReplyCount > inlineReplyCount && comments.length < maxComments) {
+                    // Queue fetching of remaining replies
+                    const parentId = thread.snippet.topLevelComment.id;
+
+                    const replyPromise = replyQueue.add(async () => {
+                        await fetchAllReplies(parentId, apiKey, videoId, parentItem, comments, fetchState);
+                    });
+
+                    replyPromises.push(replyPromise as Promise<void>);
+                }
+            }
+
+            // Update loading indicator
+            showLoadComments(comments.length, elShowLoading);
+
+            // Get next page token
+            pageToken = response.nextPageToken;
+        } while (pageToken && comments.length < maxComments && !signal?.aborted);
+
+        // Wait for all reply fetches to complete
+        await Promise.all(replyPromises);
+        await replyQueue.onIdle();
+
+        // Assign indices sequentially after all fetching completes
+        // This ensures correct ordering regardless of async completion order
+        for (let idx = 0; idx < comments.length; idx++) {
+            comments[idx]._index = idx;
+        }
+
+        // Final count update
+        showLoadComments(comments.length, elShowLoading);
+
+        return {
+            comments,
+            quotaUsed: fetchState.quotaUsed,
+            totalCount: comments.length
+        };
+    } catch (error) {
+        // Re-throw YouTubeDataApiError for proper handling upstream
+        if (error instanceof YouTubeDataApiError) {
+            throw error;
+        }
+
+        // Handle abort
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            return {
+                comments,
+                quotaUsed: fetchState.quotaUsed,
+                totalCount: comments.length
+            };
+        }
+
+        // Re-throw other errors
+        throw error;
+    }
+}
+
+/**
+ * Fetch all replies for a parent comment
+ *
+ * Uses comments.length for unique indices and respects maxComments limit.
+ *
+ * @param parentId - Parent comment ID
+ * @param apiKey - YouTube Data API key
+ * @param videoId - Video ID for transformation
+ * @param parentItem - Parent CommentItem for linking
+ * @param comments - Comments array to append to (shared, used for unique indices)
+ * @param fetchState - Shared state for quota tracking and limits
+ */
+async function fetchAllReplies(
+    parentId: string,
+    apiKey: string,
+    videoId: string,
+    parentItem: CommentItem,
+    comments: CommentItem[],
+    fetchState: FetchState
+): Promise<void> {
+    let pageToken: string | undefined;
+
+    do {
+        if (fetchState.signal?.aborted) {
+            break;
+        }
+
+        // Check maxComments limit before fetching more replies
+        if (comments.length >= fetchState.maxComments) {
+            break;
+        }
+
+        try {
+            const response = await fetchCommentReplies(parentId, apiKey, pageToken, fetchState.signal);
+            fetchState.quotaUsed += 1; // comments.list costs 1 unit
+
+            // Transform and add replies
+            for (const apiComment of response.items) {
+                // Check limit before adding each reply
+                if (comments.length >= fetchState.maxComments) {
+                    break;
+                }
+
+                const replyItem = transformReplyToCommentItem(apiComment, videoId, parentItem);
+                comments.push(replyItem);
+            }
+
+            pageToken = response.nextPageToken;
+        } catch (error) {
+            // Log error but don't fail the entire operation
+            console.error(`[YCS] Failed to fetch replies for ${parentId}:`, error);
+            break;
+        }
+    } while (pageToken && comments.length < fetchState.maxComments && !fetchState.signal?.aborted);
+}

--- a/app/src/source/utils/youtubeDataApi/index.ts
+++ b/app/src/source/utils/youtubeDataApi/index.ts
@@ -1,0 +1,38 @@
+/**
+ * YouTube Data API v3 Module
+ *
+ * Provides functionality to fetch YouTube comments using the official YouTube Data API v3.
+ * This is an alternative to the Innertube API when users provide their own API key.
+ *
+ * Usage:
+ * ```typescript
+ * import { getAllCommentsYouTubeApi, isQuotaExceeded, isInvalidApiKey } from './youtubeDataApi';
+ *
+ * try {
+ *     const result = await getAllCommentsYouTubeApi(videoId, apiKey, el, signal, [], 10000);
+ *     console.log(`Fetched ${result.totalCount} comments, used ${result.quotaUsed} quota units`);
+ * } catch (error) {
+ *     if (isQuotaExceeded(error)) {
+ *         console.log('Quota exceeded! Try again tomorrow.');
+ *     } else if (isInvalidApiKey(error)) {
+ *         console.log('Invalid API key. Please check your settings.');
+ *     }
+ * }
+ * ```
+ */
+
+// Client exports
+export {
+    YouTubeDataApiError,
+    isQuotaExceeded,
+    isInvalidApiKey,
+    fetchCommentThreads,
+    fetchCommentReplies
+} from './client';
+
+// Comment fetching exports
+export { getAllCommentsYouTubeApi } from './comments';
+export type { YouTubeApiCommentsResult } from './comments';
+
+// Transform exports
+export { transformThreadToCommentItems, transformReplyToCommentItem } from './transform';

--- a/app/src/source/utils/youtubeDataApi/transform.ts
+++ b/app/src/source/utils/youtubeDataApi/transform.ts
@@ -1,0 +1,381 @@
+/**
+ * YouTube Data API to CommentItem Transformation
+ *
+ * Transforms YouTube Data API v3 responses to the internal CommentItem format
+ * used by YCS for rendering and searching.
+ */
+
+import type {
+    CommentItem,
+    CommentRenderer,
+    CommentRun,
+    YouTubeApiComment,
+    YouTubeApiCommentThread
+} from '../interfaces/i_types';
+import { decodeHtml } from '../common';
+
+/**
+ * Regex pattern to match timestamps in comment text (e.g., "1:23", "1:23:45")
+ */
+const TIMESTAMP_REGEX = /\b(\d{1,2}):(\d{2})(?::(\d{2}))?\b/g;
+
+/**
+ * Parse timestamp string to seconds
+ */
+function parseTimestampToSeconds(match: string): number | null {
+    const parts = match.split(':').map(Number);
+    if (parts.length === 2) {
+        // MM:SS format
+        const [minutes, seconds] = parts;
+        return minutes * 60 + seconds;
+    } else if (parts.length === 3) {
+        // HH:MM:SS format
+        const [hours, minutes, seconds] = parts;
+        return hours * 3600 + minutes * 60 + seconds;
+    }
+    return null;
+}
+
+/**
+ * Parse HTML text content and extract runs with timestamp detection
+ *
+ * @param textDisplay - HTML formatted text from YouTube API
+ * @param videoId - Current video ID for timestamp link validation
+ * @returns Array of CommentRun objects
+ */
+function parseTextToRuns(textDisplay: string, videoId: string): { runs: CommentRun[]; hasTimeline: boolean } {
+    const runs: CommentRun[] = [];
+    let hasTimeline = false;
+
+    // Simple HTML to text conversion (preserve structure for runs)
+    // YouTube API returns textDisplay with <a> tags for links and <br> for newlines
+    let text = textDisplay;
+
+    // Replace <br> with newlines
+    text = text.replace(/<br\s*\/?>/gi, '\n');
+
+    // Extract links and convert to runs
+    const linkRegex = /<a[^>]*href="([^"]*)"[^>]*>([^<]*)<\/a>/gi;
+    let lastIndex = 0;
+    let match;
+
+    // Create a working copy to extract links
+    const tempText = text;
+    const segments: Array<{ type: 'text' | 'link'; content: string; url?: string; start: number; end: number }> = [];
+
+    while ((match = linkRegex.exec(tempText)) !== null) {
+        // Add text before the link
+        if (match.index > lastIndex) {
+            segments.push({
+                type: 'text',
+                content: tempText.slice(lastIndex, match.index),
+                start: lastIndex,
+                end: match.index
+            });
+        }
+
+        // Add the link
+        segments.push({
+            type: 'link',
+            content: match[2], // Link text
+            url: match[1], // URL
+            start: match.index,
+            end: match.index + match[0].length
+        });
+
+        lastIndex = match.index + match[0].length;
+    }
+
+    // Add remaining text
+    if (lastIndex < tempText.length) {
+        segments.push({
+            type: 'text',
+            content: tempText.slice(lastIndex),
+            start: lastIndex,
+            end: tempText.length
+        });
+    }
+
+    // Process segments and detect timestamps
+    for (const segment of segments) {
+        if (segment.type === 'link') {
+            // Check if this is a YouTube timestamp link
+            const url = segment.url ?? '';
+            const isYouTubeLink = url.includes('youtube.com') || url.includes('youtu.be');
+            const timeMatch = url.match(/[?&]t=(\d+)/);
+
+            if (isYouTubeLink && timeMatch) {
+                const startTimeSeconds = parseInt(timeMatch[1], 10);
+                // Check if this links to the current video
+                const urlVideoId = url.match(/[?&]v=([^&]+)/)?.[1] || url.match(/youtu\.be\/([^?&]+)/)?.[1];
+
+                if (urlVideoId === videoId || !urlVideoId) {
+                    hasTimeline = true;
+                    runs.push({
+                        text: segment.content,
+                        navigationEndpoint: {
+                            watchEndpoint: {
+                                startTimeSeconds
+                            }
+                        }
+                    });
+                    continue;
+                }
+            }
+
+            // Regular link
+            runs.push({
+                text: segment.content,
+                navigationEndpoint: {
+                    commandMetadata: {
+                        webCommandMetadata: {
+                            url: segment.url
+                        }
+                    }
+                }
+            });
+        } else {
+            // Text segment - check for inline timestamps
+            let content = segment.content;
+            // Strip remaining HTML tags
+            content = decodeHtml(content.replace(/<[^>]*>/g, ''));
+
+            // Check for timestamp patterns in text
+            let textLastIndex = 0;
+            let timestampMatch;
+            const timestampRegex = new RegExp(TIMESTAMP_REGEX.source, 'g');
+
+            while ((timestampMatch = timestampRegex.exec(content)) !== null) {
+                // Add text before timestamp
+                if (timestampMatch.index > textLastIndex) {
+                    runs.push({
+                        text: content.slice(textLastIndex, timestampMatch.index)
+                    });
+                }
+
+                // Add timestamp as clickable link
+                const seconds = parseTimestampToSeconds(timestampMatch[0]);
+                if (seconds !== null) {
+                    hasTimeline = true;
+                    runs.push({
+                        text: timestampMatch[0],
+                        navigationEndpoint: {
+                            watchEndpoint: {
+                                startTimeSeconds: seconds
+                            }
+                        }
+                    });
+                } else {
+                    runs.push({
+                        text: timestampMatch[0]
+                    });
+                }
+
+                textLastIndex = timestampMatch.index + timestampMatch[0].length;
+            }
+
+            // Add remaining text
+            if (textLastIndex < content.length) {
+                runs.push({
+                    text: content.slice(textLastIndex)
+                });
+            }
+        }
+    }
+
+    // If no segments were found, just add the plain text
+    if (runs.length === 0) {
+        const plainText = decodeHtml(textDisplay.replace(/<[^>]*>/g, ''));
+        runs.push({ text: plainText });
+    }
+
+    return { runs, hasTimeline };
+}
+
+/**
+ * Format runs to fullText and renderFullText
+ */
+function formatRunsToText(runs: CommentRun[]): { fullText: string; renderFullText: string } {
+    let fullText = '';
+    let renderFullText = '';
+
+    for (const run of runs) {
+        const text = run.text ?? '';
+        fullText += text;
+
+        if (run.navigationEndpoint?.watchEndpoint?.startTimeSeconds !== undefined) {
+            // Timestamp link
+            const seconds = run.navigationEndpoint.watchEndpoint.startTimeSeconds;
+            renderFullText += `<a class="ycs-goto-comment-time" href="#" data-offsetvideo="${seconds}">${text}</a>`;
+        } else if (run.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url) {
+            // External link
+            const url = run.navigationEndpoint.commandMetadata.webCommandMetadata.url;
+            renderFullText += `<a class="ycs-comment-link" href="${url}" target="_blank" rel="noopener">${text}</a>`;
+        } else {
+            renderFullText += text;
+        }
+    }
+
+    return { fullText, renderFullText };
+}
+
+/**
+ * Convert ISO 8601 date to relative time string
+ */
+function formatRelativeTime(isoDate: string): string {
+    const date = new Date(isoDate);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffSeconds = Math.floor(diffMs / 1000);
+    const diffMinutes = Math.floor(diffSeconds / 60);
+    const diffHours = Math.floor(diffMinutes / 60);
+    const diffDays = Math.floor(diffHours / 24);
+    const diffWeeks = Math.floor(diffDays / 7);
+    const diffMonths = Math.floor(diffDays / 30);
+    const diffYears = Math.floor(diffDays / 365);
+
+    if (diffYears > 0) {
+        return `${diffYears} year${diffYears > 1 ? 's' : ''} ago`;
+    } else if (diffMonths > 0) {
+        return `${diffMonths} month${diffMonths > 1 ? 's' : ''} ago`;
+    } else if (diffWeeks > 0) {
+        return `${diffWeeks} week${diffWeeks > 1 ? 's' : ''} ago`;
+    } else if (diffDays > 0) {
+        return `${diffDays} day${diffDays > 1 ? 's' : ''} ago`;
+    } else if (diffHours > 0) {
+        return `${diffHours} hour${diffHours > 1 ? 's' : ''} ago`;
+    } else if (diffMinutes > 0) {
+        return `${diffMinutes} minute${diffMinutes > 1 ? 's' : ''} ago`;
+    } else {
+        return 'just now';
+    }
+}
+
+/**
+ * Transform a YouTube API comment to internal CommentRenderer format
+ */
+function transformApiCommentToRenderer(
+    apiComment: YouTubeApiComment,
+    videoId: string,
+    replyCount?: number
+): CommentRenderer {
+    const { runs, hasTimeline } = parseTextToRuns(apiComment.snippet.textDisplay, videoId);
+    const { fullText, renderFullText } = formatRunsToText(runs);
+
+    const renderer: CommentRenderer = {
+        commentId: apiComment.id,
+        authorText: {
+            simpleText: apiComment.snippet.authorDisplayName
+        },
+        authorThumbnail: {
+            thumbnails: [
+                {
+                    url: apiComment.snippet.authorProfileImageUrl,
+                    width: 48,
+                    height: 48
+                }
+            ]
+        },
+        authorEndpoint: {
+            commandMetadata: {
+                webCommandMetadata: {
+                    url: apiComment.snippet.authorChannelUrl
+                }
+            }
+        },
+        contentText: {
+            runs,
+            fullText,
+            renderFullText
+        },
+        likeCount: apiComment.snippet.likeCount,
+        publishedTimeText: {
+            simpleText: formatRelativeTime(apiComment.snippet.publishedAt)
+        }
+    };
+
+    // Add reply count if provided (for top-level comments)
+    if (replyCount !== undefined && replyCount > 0) {
+        renderer.replyCount = replyCount;
+    }
+
+    // Mark as timeline comment if timestamps were found
+    if (hasTimeline) {
+        renderer.isTimeLine = 'timeline';
+    }
+
+    // Note: The following fields are NOT available from YouTube Data API:
+    // - authorIsChannelOwner (would require additional API call)
+    // - verifiedAuthor (not in API response)
+    // - creatorHeart (not in API response)
+    // - sponsorCommentBadge (not in API response)
+    // - donatedChip (not in API response)
+
+    return renderer;
+}
+
+/**
+ * Transform a YouTube API comment thread to CommentItem array
+ *
+ * @param thread - YouTube API comment thread
+ * @param videoId - Current video ID
+ * @returns Array of CommentItem (parent + replies)
+ */
+export function transformThreadToCommentItems(thread: YouTubeApiCommentThread, videoId: string): CommentItem[] {
+    const items: CommentItem[] = [];
+
+    // Transform top-level comment
+    const parentRenderer = transformApiCommentToRenderer(
+        thread.snippet.topLevelComment,
+        videoId,
+        thread.snippet.totalReplyCount
+    );
+
+    const parentItem: CommentItem = {
+        commentRenderer: parentRenderer,
+        typeComment: 'C'
+    };
+
+    items.push(parentItem);
+
+    // Transform replies if present
+    // Note: replies.comments only contains a subset of replies
+    // Full replies need to be fetched separately using comments.list
+    if (thread.replies?.comments) {
+        for (let i = 0; i < thread.replies.comments.length; i++) {
+            const replyRenderer = transformApiCommentToRenderer(thread.replies.comments[i], videoId);
+
+            const replyItem: CommentItem = {
+                commentRenderer: replyRenderer,
+                originComment: parentItem,
+                typeComment: 'R'
+            };
+
+            items.push(replyItem);
+        }
+    }
+
+    return items;
+}
+
+/**
+ * Transform a YouTube API comment (reply) to CommentItem
+ *
+ * @param apiComment - YouTube API comment
+ * @param videoId - Current video ID
+ * @param parentItem - Parent comment item
+ * @returns CommentItem for the reply
+ */
+export function transformReplyToCommentItem(
+    apiComment: YouTubeApiComment,
+    videoId: string,
+    parentItem: CommentItem
+): CommentItem {
+    const renderer = transformApiCommentToRenderer(apiComment, videoId);
+
+    return {
+        commentRenderer: renderer,
+        originComment: parentItem,
+        typeComment: 'R'
+    };
+}

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -135,6 +135,10 @@ class YouTubeApiMessageError extends Error {
     get isInvalidApiKey(): boolean {
         return this.type === 'invalidApiKey';
     }
+
+    get isUnsupported(): boolean {
+        return this.type === 'unsupported';
+    }
 }
 
 /**
@@ -1143,6 +1147,15 @@ export function initApp(): void {
                                         elStatusCmnts.innerHTML =
                                             '<span class="ycs-warning" title="Stopped - partial results">⏹️</span>';
                                         // Continue to save partial results
+                                    } else if (error.isUnsupported) {
+                                        // Comments disabled or video not found - silently skip with info icon
+                                        console.log(
+                                            '[YCS] YouTube Data API not supported for this video:',
+                                            error.message
+                                        );
+                                        elStatusCmnts.innerHTML =
+                                            '<span class="ycs-info" title="Comments unavailable">ℹ️</span>';
+                                        return;
                                     } else {
                                         elStatusCmnts.innerHTML = '<span class="ycs-error" title="API error">❌</span>';
                                         console.error('[YCS] YouTube Data API error:', error.message);

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -149,6 +149,26 @@ function requestYouTubeApiComments(
     const requestId = crypto.randomUUID();
 
     return new Promise((resolve, reject) => {
+        // Timer ID for abort timeout cleanup
+        let abortTimeoutId: ReturnType<typeof setTimeout> | undefined;
+
+        // Named abort handler for proper cleanup on Promise settle
+        const abortHandler = (): void => {
+            window.postMessage(
+                {
+                    type: 'YCS_YT_API_COMMENTS_ABORT',
+                    body: { requestId }
+                },
+                window.location.origin
+            );
+            // Don't reject immediately - wait for background to send partial results
+            // Safety timeout: if background doesn't respond within 3 seconds, reject
+            abortTimeoutId = setTimeout(() => {
+                window.removeEventListener('message', handleMessage);
+                reject(new DOMException('Aborted', 'AbortError'));
+            }, 3000);
+        };
+
         const handleMessage = (e: MessageEvent): void => {
             if (e.source !== window || e.origin !== window.location.origin) return;
             if (e.data?.body?.requestId !== requestId) return;
@@ -159,6 +179,8 @@ function requestYouTubeApiComments(
                     break;
 
                 case 'YCS_YT_API_COMMENTS_COMPLETE':
+                    if (abortTimeoutId) clearTimeout(abortTimeoutId);
+                    signal?.removeEventListener('abort', abortHandler);
                     window.removeEventListener('message', handleMessage);
                     resolve({
                         comments: e.data.body.comments,
@@ -169,6 +191,8 @@ function requestYouTubeApiComments(
                     break;
 
                 case 'YCS_YT_API_COMMENTS_ERROR': {
+                    if (abortTimeoutId) clearTimeout(abortTimeoutId);
+                    signal?.removeEventListener('abort', abortHandler);
                     window.removeEventListener('message', handleMessage);
                     const error = e.data.body.error;
                     reject(
@@ -181,18 +205,8 @@ function requestYouTubeApiComments(
 
         window.addEventListener('message', handleMessage);
 
-        // Handle external abort signal
-        signal?.addEventListener('abort', () => {
-            window.postMessage(
-                {
-                    type: 'YCS_YT_API_COMMENTS_ABORT',
-                    body: { requestId }
-                },
-                window.location.origin
-            );
-            window.removeEventListener('message', handleMessage);
-            reject(new DOMException('Aborted', 'AbortError'));
-        });
+        // Handle external abort signal (once: true as additional safety)
+        signal?.addEventListener('abort', abortHandler, { once: true });
 
         // Send start request
         window.postMessage(
@@ -1118,6 +1132,17 @@ export function initApp(): void {
                                         alert(
                                             'Invalid YouTube Data API key!\n\nPlease check your API key in extension settings.'
                                         );
+                                    } else if (error.type === 'aborted') {
+                                        // User cancelled via STOP button - silently continue if we have partial comments
+                                        console.log('[YCS] Fetch aborted by user');
+                                        if (!error.partialComments || error.partialComments.length === 0) {
+                                            return;
+                                        }
+                                        // Mark as incomplete so we don't show OK icon or cache as complete
+                                        youtubeApiIncomplete = true;
+                                        elStatusCmnts.innerHTML =
+                                            '<span class="ycs-warning" title="Stopped - partial results">⏹️</span>';
+                                        // Continue to save partial results
                                     } else {
                                         elStatusCmnts.innerHTML = '<span class="ycs-error" title="API error">❌</span>';
                                         console.error('[YCS] YouTube Data API error:', error.message);
@@ -1126,8 +1151,11 @@ export function initApp(): void {
                                         );
                                     }
 
-                                    // If no partial comments, return early
-                                    if (!error.partialComments || error.partialComments.length === 0) {
+                                    // If no partial comments, return early (for non-abort errors)
+                                    if (
+                                        error.type !== 'aborted' &&
+                                        (!error.partialComments || error.partialComments.length === 0)
+                                    ) {
                                         return;
                                     }
                                     // Otherwise continue to save partial results

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -24,12 +24,7 @@ import {
     clearCurrentVideoMemberOnly,
     checkIsLiveStream,
     getLiveBroadcastStartTime,
-    pollLiveChat,
-    // YouTube Data API v3
-    getAllCommentsYouTubeApi,
-    isQuotaExceeded,
-    isInvalidApiKey,
-    YouTubeDataApiError
+    pollLiveChat
 } from '../utils/innertube';
 
 import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
@@ -116,6 +111,99 @@ import { SearchContext, SortOrder } from './search/types';
 import { renderCommentsResult, renderChatResult, renderTranscriptResult } from './ui/render';
 
 const DEBUG = false;
+
+/**
+ * Error class for YouTube API message-based errors
+ */
+class YouTubeApiMessageError extends Error {
+    type: string;
+    code?: number;
+    partialComments?: CommentItem[];
+
+    constructor(type: string, message: string, partialComments?: CommentItem[], code?: number) {
+        super(message);
+        this.name = 'YouTubeApiMessageError';
+        this.type = type;
+        this.code = code;
+        this.partialComments = partialComments;
+    }
+
+    get isQuotaExceeded(): boolean {
+        return this.type === 'quotaExceeded';
+    }
+
+    get isInvalidApiKey(): boolean {
+        return this.type === 'invalidApiKey';
+    }
+}
+
+/**
+ * Request YouTube API comments via background service worker
+ * API key is securely stored in background, never exposed to web page
+ */
+function requestYouTubeApiComments(
+    videoId: string,
+    signal: AbortSignal | undefined,
+    onProgress: (count: number) => void
+): Promise<{ comments: CommentItem[]; quotaUsed: number; incomplete: boolean; replyFetchErrors: number }> {
+    const requestId = crypto.randomUUID();
+
+    return new Promise((resolve, reject) => {
+        const handleMessage = (e: MessageEvent): void => {
+            if (e.source !== window || e.origin !== window.location.origin) return;
+            if (e.data?.body?.requestId !== requestId) return;
+
+            switch (e.data.type) {
+                case 'YCS_YT_API_COMMENTS_PROGRESS':
+                    onProgress(e.data.body.totalCount);
+                    break;
+
+                case 'YCS_YT_API_COMMENTS_COMPLETE':
+                    window.removeEventListener('message', handleMessage);
+                    resolve({
+                        comments: e.data.body.comments,
+                        quotaUsed: e.data.body.quotaUsed,
+                        incomplete: e.data.body.incomplete || false,
+                        replyFetchErrors: e.data.body.replyFetchErrors || 0
+                    });
+                    break;
+
+                case 'YCS_YT_API_COMMENTS_ERROR': {
+                    window.removeEventListener('message', handleMessage);
+                    const error = e.data.body.error;
+                    reject(
+                        new YouTubeApiMessageError(error.type, error.message, e.data.body.partialComments, error.code)
+                    );
+                    break;
+                }
+            }
+        };
+
+        window.addEventListener('message', handleMessage);
+
+        // Handle external abort signal
+        signal?.addEventListener('abort', () => {
+            window.postMessage(
+                {
+                    type: 'YCS_YT_API_COMMENTS_ABORT',
+                    body: { requestId }
+                },
+                window.location.origin
+            );
+            window.removeEventListener('message', handleMessage);
+            reject(new DOMException('Aborted', 'AbortError'));
+        });
+
+        // Send start request
+        window.postMessage(
+            {
+                type: 'YCS_YT_API_COMMENTS_START',
+                body: { videoId, requestId }
+            },
+            window.location.origin
+        );
+    });
+}
 
 const CHAT_UNSUPPORTED_FILTERS = ['heart', 'likes', 'replied', 'random', 'quickTranscript', 'timestampViz'] as const;
 const TRANSCRIPT_UNSUPPORTED_FILTERS = [
@@ -975,26 +1063,44 @@ export function initApp(): void {
                         const controller = getController(state);
 
                         // Check if YouTube Data API key is configured and enabled
-                        const apiKey = GlobalStore.youtubeApiKey;
+                        const hasApiKey = GlobalStore.hasYoutubeApiKey;
                         const apiEnabled = GlobalStore.youtubeApiEnabled !== false; // default true
-                        if (apiKey && apiEnabled && startVideoId) {
-                            // Use YouTube Data API v3
+                        // Track if YouTube API result was incomplete (for status icon)
+                        let youtubeApiIncomplete = false;
+
+                        if (hasApiKey && apiEnabled && startVideoId) {
+                            // Use YouTube Data API v3 via background service worker
                             try {
-                                console.log('[YCS] Using YouTube Data API v3');
-                                const result = await getAllCommentsYouTubeApi(
+                                console.log('[YCS] Using YouTube Data API v3 (via background)');
+                                const result = await requestYouTubeApiComments(
                                     startVideoId,
-                                    apiKey,
-                                    elLoadCmnts,
                                     controller.signal,
-                                    comments
+                                    (count) => showLoadComments(count, elLoadCmnts)
                                 );
+                                comments.push(...result.comments);
                                 console.log(
-                                    `[YCS] YouTube API: ${result.totalCount} comments, ${result.quotaUsed} quota units used`
+                                    `[YCS] YouTube API: ${result.comments.length} comments, ${result.quotaUsed} quota units used`
                                 );
+
+                                // Track incomplete state for status icon
+                                if (result.incomplete) {
+                                    youtubeApiIncomplete = true;
+                                    console.warn(
+                                        `[YCS] Some replies may be missing (${result.replyFetchErrors} fetch errors)`
+                                    );
+                                    elStatusCmnts.innerHTML =
+                                        '<span class="ycs-warning" title="Some replies may be missing">⚠️</span>';
+                                }
                             } catch (error) {
                                 // Handle YouTube Data API specific errors
-                                if (error instanceof YouTubeDataApiError) {
-                                    if (isQuotaExceeded(error)) {
+                                if (error instanceof YouTubeApiMessageError) {
+                                    // If we have partial comments, keep them
+                                    if (error.partialComments && error.partialComments.length > 0) {
+                                        comments.push(...error.partialComments);
+                                        console.log(`[YCS] Keeping ${error.partialComments.length} partial comments`);
+                                    }
+
+                                    if (error.isQuotaExceeded) {
                                         elStatusCmnts.innerHTML =
                                             '<span class="ycs-error" title="Quota exceeded">⚠️</span>';
                                         console.error(
@@ -1003,7 +1109,7 @@ export function initApp(): void {
                                         alert(
                                             'YouTube Data API quota exceeded!\n\nYour daily quota (10,000 units) has been exhausted.\nPlease try again tomorrow or temporarily disable YouTube Data API in extension settings.'
                                         );
-                                    } else if (isInvalidApiKey(error)) {
+                                    } else if (error.isInvalidApiKey) {
                                         elStatusCmnts.innerHTML =
                                             '<span class="ycs-error" title="Invalid API key">❌</span>';
                                         console.error(
@@ -1019,9 +1125,18 @@ export function initApp(): void {
                                             `YouTube Data API error: ${error.message}\n\nYou can temporarily disable YouTube Data API in extension settings to use Innertube instead.`
                                         );
                                     }
+
+                                    // If no partial comments, return early
+                                    if (!error.partialComments || error.partialComments.length === 0) {
+                                        return;
+                                    }
+                                    // Otherwise continue to save partial results
+                                } else if (error instanceof DOMException && error.name === 'AbortError') {
+                                    // User cancelled, don't show error
                                     return;
+                                } else {
+                                    throw error; // Re-throw non-API errors
                                 }
-                                throw error; // Re-throw non-API errors
                             }
                         } else {
                             // Use Innertube API (default or when YouTube Data API is disabled)
@@ -1041,7 +1156,10 @@ export function initApp(): void {
                         }
 
                         if (comments.length > 0) {
-                            elStatusCmnts.innerHTML = iconOk();
+                            // Only show OK icon if result was complete (don't overwrite warning)
+                            if (!youtubeApiIncomplete) {
+                                elStatusCmnts.innerHTML = iconOk();
+                            }
                             saveToCache(
                                 {
                                     videoId: startVideoId,
@@ -2285,9 +2403,9 @@ export function initApp(): void {
                                 );
                                 break;
 
-                            case 'youtubeApiKey':
-                                // Store YouTube Data API key in GlobalStore for use in comment loading
-                                GlobalStore.youtubeApiKey = opts.youtubeApiKey?.trim() || '';
+                            case 'hasYoutubeApiKey':
+                                // Store whether API key is configured (actual key stays in background)
+                                GlobalStore.hasYoutubeApiKey = Boolean(opts.hasYoutubeApiKey);
                                 break;
 
                             case 'youtubeApiEnabled':

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -156,6 +156,16 @@ function requestYouTubeApiComments(
         // Timer ID for abort timeout cleanup
         let abortTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
+        // Chunk accumulation for large payloads
+        const receivedChunks: CommentItem[][] = [];
+
+        // Cleanup helper
+        const cleanup = (): void => {
+            if (abortTimeoutId) clearTimeout(abortTimeoutId);
+            signal?.removeEventListener('abort', abortHandler);
+            window.removeEventListener('message', handleMessage);
+        };
+
         // Named abort handler for proper cleanup on Promise settle
         const abortHandler = (): void => {
             window.postMessage(
@@ -182,10 +192,37 @@ function requestYouTubeApiComments(
                     onProgress(e.data.body.totalCount);
                     break;
 
+                case 'YCS_YT_API_COMMENTS_CHUNK': {
+                    const { comments, chunkIndex, isLastChunk, isError, error } = e.data.body;
+                    receivedChunks[chunkIndex] = comments;
+
+                    if (isLastChunk) {
+                        // All chunks received - flatten and resolve/reject
+                        const allComments: CommentItem[] = [];
+                        for (const chunk of receivedChunks) {
+                            if (chunk) allComments.push(...chunk);
+                        }
+                        cleanup();
+
+                        if (isError && error) {
+                            // Error with partial comments
+                            reject(new YouTubeApiMessageError(error.type, error.message, allComments, error.code));
+                        } else {
+                            // Success
+                            resolve({
+                                comments: allComments,
+                                quotaUsed: e.data.body.quotaUsed || 0,
+                                incomplete: e.data.body.incomplete || false,
+                                replyFetchErrors: e.data.body.replyFetchErrors || 0
+                            });
+                        }
+                    }
+                    break;
+                }
+
+                // Keep for backward compatibility (small payloads may still use this)
                 case 'YCS_YT_API_COMMENTS_COMPLETE':
-                    if (abortTimeoutId) clearTimeout(abortTimeoutId);
-                    signal?.removeEventListener('abort', abortHandler);
-                    window.removeEventListener('message', handleMessage);
+                    cleanup();
                     resolve({
                         comments: e.data.body.comments,
                         quotaUsed: e.data.body.quotaUsed,
@@ -195,9 +232,7 @@ function requestYouTubeApiComments(
                     break;
 
                 case 'YCS_YT_API_COMMENTS_ERROR': {
-                    if (abortTimeoutId) clearTimeout(abortTimeoutId);
-                    signal?.removeEventListener('abort', abortHandler);
-                    window.removeEventListener('message', handleMessage);
+                    cleanup();
                     const error = e.data.body.error;
                     reject(
                         new YouTubeApiMessageError(error.type, error.message, e.data.body.partialComments, error.code)
@@ -2638,6 +2673,16 @@ export function initApp(): void {
 
         // Store interval ID for cleanup on next initApp() call
         observeIntervalId = setInterval(() => {
+            // Abort pending requests when leaving video page
+            // This handles the case: video page -> non-video page (e.g., homepage) -> back to video
+            if (!isVideoPage() && prevUrl) {
+                getController(state).abort();
+                state = resetController(state);
+                prevUrl = '';
+                console.log('[YCS] Left video page, aborted pending requests');
+                return;
+            }
+
             if (isVideoPage() && getPageMetaElement() && prevUrl !== getCleanUrlVideo(window.location.href)) {
                 const currentUrl = getCleanUrlVideo(window.location.href);
 

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1153,6 +1153,7 @@ export function initApp(): void {
                                     }
 
                                     if (error.isQuotaExceeded) {
+                                        youtubeApiIncomplete = true;
                                         elStatusCmnts.innerHTML = iconWarning('Quota exceeded');
                                         console.error(
                                             '[YCS] YouTube Data API quota exceeded. Please try again tomorrow or use a different API key.'
@@ -1161,6 +1162,7 @@ export function initApp(): void {
                                             'YouTube Data API quota exceeded!\n\nYour daily quota (10,000 units) has been exhausted.\nPlease try again tomorrow or temporarily disable YouTube Data API in extension settings.'
                                         );
                                     } else if (error.isInvalidApiKey) {
+                                        youtubeApiIncomplete = true;
                                         elStatusCmnts.innerHTML = iconError('Invalid API key');
                                         console.error(
                                             '[YCS] Invalid YouTube Data API key. Please check your API key in settings.'
@@ -1187,6 +1189,7 @@ export function initApp(): void {
                                         elStatusCmnts.innerHTML = iconInfo('Comments unavailable');
                                         return;
                                     } else {
+                                        youtubeApiIncomplete = true;
                                         elStatusCmnts.innerHTML = iconError('API error');
                                         console.error('[YCS] YouTube Data API error:', error.message);
                                         alert(

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -36,7 +36,7 @@ import type {
     TranscriptTrackInfo
 } from '../utils/interfaces/i_types';
 
-import { iconOk, iconReload } from '../utils/icons';
+import { iconOk, iconReload, iconWarning, iconError, iconStop, iconInfo } from '../utils/icons';
 import { formatRecordingDuration } from '../utils/formatting';
 import { renderLoadComments, renderSearch, loadFilterButtons } from '../utils/renderView';
 import { loadFromCache, saveToCache, updateBadge } from './services/cacheService';
@@ -1106,8 +1106,7 @@ export function initApp(): void {
                                     console.warn(
                                         `[YCS] Some replies may be missing (${result.replyFetchErrors} fetch errors)`
                                     );
-                                    elStatusCmnts.innerHTML =
-                                        '<span class="ycs-warning" title="Some replies may be missing">⚠️</span>';
+                                    elStatusCmnts.innerHTML = iconWarning('Some replies may be missing');
                                 }
                             } catch (error) {
                                 // Handle YouTube Data API specific errors
@@ -1119,8 +1118,7 @@ export function initApp(): void {
                                     }
 
                                     if (error.isQuotaExceeded) {
-                                        elStatusCmnts.innerHTML =
-                                            '<span class="ycs-error" title="Quota exceeded">⚠️</span>';
+                                        elStatusCmnts.innerHTML = iconWarning('Quota exceeded');
                                         console.error(
                                             '[YCS] YouTube Data API quota exceeded. Please try again tomorrow or use a different API key.'
                                         );
@@ -1128,8 +1126,7 @@ export function initApp(): void {
                                             'YouTube Data API quota exceeded!\n\nYour daily quota (10,000 units) has been exhausted.\nPlease try again tomorrow or temporarily disable YouTube Data API in extension settings.'
                                         );
                                     } else if (error.isInvalidApiKey) {
-                                        elStatusCmnts.innerHTML =
-                                            '<span class="ycs-error" title="Invalid API key">❌</span>';
+                                        elStatusCmnts.innerHTML = iconError('Invalid API key');
                                         console.error(
                                             '[YCS] Invalid YouTube Data API key. Please check your API key in settings.'
                                         );
@@ -1144,8 +1141,7 @@ export function initApp(): void {
                                         }
                                         // Mark as incomplete so we don't show OK icon or cache as complete
                                         youtubeApiIncomplete = true;
-                                        elStatusCmnts.innerHTML =
-                                            '<span class="ycs-warning" title="Stopped - partial results">⏹️</span>';
+                                        elStatusCmnts.innerHTML = iconStop('Stopped - partial results');
                                         // Continue to save partial results
                                     } else if (error.isUnsupported) {
                                         // Comments disabled or video not found - silently skip with info icon
@@ -1153,11 +1149,10 @@ export function initApp(): void {
                                             '[YCS] YouTube Data API not supported for this video:',
                                             error.message
                                         );
-                                        elStatusCmnts.innerHTML =
-                                            '<span class="ycs-info" title="Comments unavailable">ℹ️</span>';
+                                        elStatusCmnts.innerHTML = iconInfo('Comments unavailable');
                                         return;
                                     } else {
-                                        elStatusCmnts.innerHTML = '<span class="ycs-error" title="API error">❌</span>';
+                                        elStatusCmnts.innerHTML = iconError('API error');
                                         console.error('[YCS] YouTube Data API error:', error.message);
                                         alert(
                                             `YouTube Data API error: ${error.message}\n\nYou can temporarily disable YouTube Data API in extension settings to use Innertube instead.`

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -24,7 +24,12 @@ import {
     clearCurrentVideoMemberOnly,
     checkIsLiveStream,
     getLiveBroadcastStartTime,
-    pollLiveChat
+    pollLiveChat,
+    // YouTube Data API v3
+    getAllCommentsYouTubeApi,
+    isQuotaExceeded,
+    isInvalidApiKey,
+    YouTubeDataApiError
 } from '../utils/innertube';
 
 import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
@@ -969,7 +974,59 @@ export function initApp(): void {
 
                         const controller = getController(state);
 
-                        await getAllCommentsModeV2(elLoadCmnts, controller.signal, comments);
+                        // Check if YouTube Data API key is configured and enabled
+                        const apiKey = GlobalStore.youtubeApiKey;
+                        const apiEnabled = GlobalStore.youtubeApiEnabled !== false; // default true
+                        if (apiKey && apiEnabled && startVideoId) {
+                            // Use YouTube Data API v3
+                            try {
+                                console.log('[YCS] Using YouTube Data API v3');
+                                const result = await getAllCommentsYouTubeApi(
+                                    startVideoId,
+                                    apiKey,
+                                    elLoadCmnts,
+                                    controller.signal,
+                                    comments
+                                );
+                                console.log(
+                                    `[YCS] YouTube API: ${result.totalCount} comments, ${result.quotaUsed} quota units used`
+                                );
+                            } catch (error) {
+                                // Handle YouTube Data API specific errors
+                                if (error instanceof YouTubeDataApiError) {
+                                    if (isQuotaExceeded(error)) {
+                                        elStatusCmnts.innerHTML =
+                                            '<span class="ycs-error" title="Quota exceeded">⚠️</span>';
+                                        console.error(
+                                            '[YCS] YouTube Data API quota exceeded. Please try again tomorrow or use a different API key.'
+                                        );
+                                        alert(
+                                            'YouTube Data API quota exceeded!\n\nYour daily quota (10,000 units) has been exhausted.\nPlease try again tomorrow or temporarily disable YouTube Data API in extension settings.'
+                                        );
+                                    } else if (isInvalidApiKey(error)) {
+                                        elStatusCmnts.innerHTML =
+                                            '<span class="ycs-error" title="Invalid API key">❌</span>';
+                                        console.error(
+                                            '[YCS] Invalid YouTube Data API key. Please check your API key in settings.'
+                                        );
+                                        alert(
+                                            'Invalid YouTube Data API key!\n\nPlease check your API key in extension settings.'
+                                        );
+                                    } else {
+                                        elStatusCmnts.innerHTML = '<span class="ycs-error" title="API error">❌</span>';
+                                        console.error('[YCS] YouTube Data API error:', error.message);
+                                        alert(
+                                            `YouTube Data API error: ${error.message}\n\nYou can temporarily disable YouTube Data API in extension settings to use Innertube instead.`
+                                        );
+                                    }
+                                    return;
+                                }
+                                throw error; // Re-throw non-API errors
+                            }
+                        } else {
+                            // Use Innertube API (default or when YouTube Data API is disabled)
+                            await getAllCommentsModeV2(elLoadCmnts, controller.signal, comments);
+                        }
 
                         // Verify video hasn't changed before saving cache
                         const currentVideoId = getVideoId(window.location.href);
@@ -2226,6 +2283,16 @@ export function initApp(): void {
                                         ? opts.transcriptLanguage.trim()
                                         : undefined
                                 );
+                                break;
+
+                            case 'youtubeApiKey':
+                                // Store YouTube Data API key in GlobalStore for use in comment loading
+                                GlobalStore.youtubeApiKey = opts.youtubeApiKey?.trim() || '';
+                                break;
+
+                            case 'youtubeApiEnabled':
+                                // Store YouTube Data API enabled state in GlobalStore
+                                GlobalStore.youtubeApiEnabled = opts.youtubeApiEnabled !== false; // default true
                                 break;
 
                             default:

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -219,13 +219,11 @@ function collectRepliesForComment(
 ): ICommentsFuseResult[] {
     if (!commentId) return [];
 
-    const reference = comments.find((entry) => (entry as any)?.commentRenderer?.commentId === commentId);
-    if (!reference) return [];
-
     const replies: ICommentsFuseResult[] = [];
 
     for (const entry of comments) {
-        if ((entry as any)?.originComment === reference) {
+        // Use commentId comparison instead of object reference (fixes JSON serialization issue)
+        if ((entry as any)?.originComment?.commentRenderer?.commentId === commentId) {
             replies.push({
                 item: entry as any,
                 refIndex: Number((entry as any)?._index ?? refId)


### PR DESCRIPTION
## Summary

Add optional YouTube Data API v3 support as an alternative to Innertube for fetching comments. Users can configure their own API key in extension settings, with security improvements that keep API keys protected in the background service worker.

## Main Changes

### YouTube Data API v3 Integration
- New `youtubeDataApi/` module with client, comment fetching, and response transformation
- Options page UI for API key configuration with show/hide toggle
- Runtime switching between Innertube and YouTube Data API based on user settings
- `YouTubeDataApiError` class with detection for quota exceeded, invalid API key, and unsupported video states

### Security Enhancement
- Move all YouTube API execution from web page context to background service worker
- API key stored securely in `chrome.storage`, never exposed to web page
- Web page only receives `hasYoutubeApiKey` boolean flag

### Large Response Handling
- Chunked transfer for large comment sets (20,000 items per chunk) to handle Chrome message size limit
- `sendCommentsInChunks()` unified handler for both success and error responses
- New `YCS_YT_API_COMMENTS_CHUNK` message type for chunked transfer protocol

### Request Lifecycle Management
- `activeYouTubeApiRequests` Map to track in-flight requests by tab
- `safeSendMessage()` helper for graceful tab closure handling
- `chrome.tabs.onRemoved` listener to abort requests when tab closes
- 3-second safety timeout after abort signal for cleanup

### Status Icons
- New SVG icon functions: `iconWarning()`, `iconError()`, `iconStop()`, `iconInfo()`
- Optional `title` parameter for tooltip support
- Replace inline emoji indicators with consistent SVG icons

### Error State Handling
- `isUnsupported` flag for videos with comments disabled or not found
- `youtubeApiIncomplete` flag set on all error conditions to preserve error icon state
- Partial results saved and displayed even when fetch fails midway

---

![CleanShot 2025-12-04 at 01 40 47@2x](https://github.com/user-attachments/assets/0e600869-b9a8-4ee4-bcd9-3fc1e11f1a13)
