### PR TITLE
Search clear button visible without input

### DIFF
--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1030,7 +1030,7 @@ export function initApp(): void {
 
         const setClearTextButtonVisibility = (): void => {
             const btnVisible =
-                (eInputSearch as HTMLInputElement).value.trim().length > 0 ||
+                ((eInputSearch as HTMLInputElement)?.value?.trim()?.length ?? 0) > 0 ||
                 document.getElementById('ycs-search-result')?.hasChildNodes();
             if (btnSearchClearText) {
                 (btnSearchClearText as HTMLButtonElement).style.visibility = btnVisible ? 'visible' : 'hidden';

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1028,6 +1028,15 @@ export function initApp(): void {
         const eInputSearch = document.getElementById('ycs-input-search');
         const btnSearchClearText = document.getElementById('ycs_btn_search_clear_text');
 
+        const setClearTextButtonVisibility = (): void => {
+            const btnVisible =
+                (eInputSearch as HTMLInputElement).value.trim().length > 0 ||
+                document.getElementById('ycs-search-result')?.hasChildNodes();
+            if (btnSearchClearText) {
+                (btnSearchClearText as HTMLButtonElement).style.visibility = btnVisible ? 'visible' : 'hidden';
+            }
+        };
+
         if (eInputSearch) {
             eInputSearch.onkeyup = (e): void => {
                 if (e.key === 'Enter' || e.code === 'Enter') {
@@ -1036,17 +1045,13 @@ export function initApp(): void {
             };
             // toggle clear-text button visibility
             eInputSearch.addEventListener('input', () => {
-                const hasText = (eInputSearch as HTMLInputElement).value.trim().length > 0;
-                if (btnSearchClearText) {
-                    (btnSearchClearText as HTMLButtonElement).style.visibility = hasText ? 'visible' : 'hidden';
-                }
+                setClearTextButtonVisibility();
             });
         }
 
         // initialize clear-text button visibility
         if (btnSearchClearText) {
-            (btnSearchClearText as HTMLButtonElement).style.visibility =
-                (eInputSearch as HTMLInputElement)?.value?.trim()?.length > 0 ? 'visible' : 'hidden';
+            setClearTextButtonVisibility();
             btnSearchClearText.addEventListener('click', () => {
                 try {
                     if (eInputSearch) {


### PR DESCRIPTION
This is a slight pet peeve of mine and I think this would be useful to add: whenever you manually clear the text in the search bar the clear search results button gets hidden so you to have to enter something in the search bar to get the button to be visible.

Before:
<img width="1251" height="409" alt="image" src="https://github.com/user-attachments/assets/e3b474b6-9f60-46a3-9f38-f4342c3f59ef" />
After:
<img width="1238" height="413" alt="image" src="https://github.com/user-attachments/assets/56cdec3d-d556-4058-b70c-c2a847774176" />

I added an additional condition to make the button visible if ycs-search-result has any children.
