### PR TITLE
Add option to sort timestamps by time

### DIFF
--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -5,6 +5,7 @@ const options = {
     cache: true,
     autoClear: 200,
     hiddenByDefault: false,
+    sortTimestamp: false,
     hiddenByDefaultShorts: false,
     enableShortsSupport: true,
     transcriptLanguage: '',

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -87,6 +87,22 @@ window.onload = async (): Promise<void> => {
             (document.getElementById('y_opts_hidden_by_default') as HTMLInputElement).checked = param;
         };
 
+        const optSetSortTimestamp = async (opt: HTMLInputElement): Promise<void> => {
+            try {
+                await chrome.storage.local.set({
+                    sortTimestamp: opt.checked
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
+        const setRenderSortTimestampOpt = (param: boolean): void => {
+            if (typeof param !== 'boolean') return;
+
+            (document.getElementById('y_opts_sort_timestamp') as HTMLInputElement).checked = param;
+        };
+
         const setRenderHiddenByDefaultShorts = (param: boolean): void => {
             if (typeof param !== 'boolean') return;
 
@@ -676,6 +692,10 @@ window.onload = async (): Promise<void> => {
                         setRenderHiddenByDefault(storageOpts[key]);
                         break;
 
+                    case 'sortTimestamp':
+                        setRenderSortTimestampOpt(storageOpts[key]);
+                        break;
+
                     case 'hiddenByDefaultShorts':
                         setRenderHiddenByDefaultShorts(storageOpts[key]);
                         break;
@@ -744,6 +764,10 @@ window.onload = async (): Promise<void> => {
 
                 case 'y_opts_hidden_by_default':
                     optSetHiddenByDefault(e.target as HTMLInputElement);
+                    break;
+
+                case 'y_opts_sort_timestamp':
+                    optSetSortTimestamp(e.target as HTMLInputElement);
                     break;
 
                 case 'y_opts_hidden_by_default_shorts':

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -52,6 +52,14 @@
           </div>
         </div>
 
+        <div>
+          <label for="y_opts_sort_timestamp">Sort timestamps by time:</label>
+          <input type="checkbox" name="Sort timestamps by time" id="y_opts_sort_timestamp" class="ycs_opts_checkbox" />
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Sort comments with timestamps by timestamp time instead of by comment creation date.</p>
+          </div>
+        </div>
+
         <div class="ycs_group" id="ycs-shorts-group">
           <div>
             <label for="y_opts_enable_shorts_support">Enable YouTube Shorts support:</label>

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -306,6 +306,7 @@ export type ISelectedSearch = 'comments' | 'chat' | 'video' | 'all';
 export interface IYCSOptions {
     autoload?: boolean;
     highlightText?: boolean;
+    sortTimestamp?: boolean;
     highlightExact?: boolean;
     cache?: boolean;
     autoClear?: number;

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1525,6 +1525,14 @@ export function initApp(): void {
                     }
                 };
 
+                const optSortTimestamp = (value: boolean): void => {
+                    try {
+                        GlobalStore.sortTimestamp = value;
+                    } catch (err) {
+                        console.error(err);
+                    }
+                };
+
                 const optHiddenByDefault = (opts: IYCSOptions): void => {
                     try {
                         const app = document.querySelector('.ycs-app') as HTMLElement;
@@ -1573,6 +1581,10 @@ export function initApp(): void {
 
                             case 'cache':
                                 optCached(Boolean(opts.cache));
+                                break;
+
+                            case 'sortTimestamp':
+                                optSortTimestamp(Boolean(opts.sortTimestamp));
                                 break;
 
                             case 'hiddenByDefault':

--- a/app/src/source/web-resources/search/commentsSearch.ts
+++ b/app/src/source/web-resources/search/commentsSearch.ts
@@ -19,6 +19,7 @@ import {
 import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getComments, WebResourcesState } from '../state';
 import { SearchContext } from './types';
+import { GlobalStore } from '../../utils/common';
 
 export interface SearchButtonState {
     order?: 'newest' | 'oldest';
@@ -359,7 +360,24 @@ export function runSearch(
         );
 
         if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
+            if (GlobalStore?.sortTimestamp === true) {
+                resultSearch.sort((a, b) => {
+                    const getFirstTimestamp = (item: any): number => {
+                        const runs = item.commentRenderer?.contentText?.runs;
+                        if (runs && runs.length > 0) {
+                            for (const run of runs) {
+                                if (run.navigationEndpoint?.watchEndpoint?.startTimeSeconds >= 0) {
+                                    return run.navigationEndpoint.watchEndpoint.startTimeSeconds * 1000;
+                                }
+                            }
+                        }
+                        return 0;
+                    };
+                    return getFirstTimestamp(a.item) - getFirstTimestamp(b.item);
+                });
+            } else {
+                resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
+            }
 
             const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_timestamps']);
             if (resolvedOrder === 'oldest') {


### PR DESCRIPTION
Hi again, I think it would be useful to have the option for comment timestamps to be sorted by the time of the timestamp instead of comment creation date:

I suggest to add an option to do this since not everyone would prefer for comments to be sorted this way:
<img width="770" height="122" alt="image" src="https://github.com/user-attachments/assets/b668e09d-c6b8-4258-8f2e-e9e5afd464be" />

Now timestamps search results will sorted by time if the option is selected
<img width="1069" height="882" alt="image" src="https://github.com/user-attachments/assets/014a341b-dd1e-43e8-a189-3f71174556ea" />

Fixes #36 and #46 