### PR TITLE
fix(dropdown): prevent interference with YouTube native dropdowns

### DIFF
--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1147,7 +1147,10 @@ export function initApp(): void {
 
             trigger.addEventListener('click', (event) => {
                 try {
-                    event.stopPropagation();
+                    const target = event.target as HTMLElement | null;
+                    if (target?.closest('.ycs_dropdown_trigger')) {
+                        event.stopPropagation();
+                    }
                     closeAllDropdowns(menu);
                     const shouldShow = !menu.classList.contains('show');
                     setMenuVisibility(menu, shouldShow);
@@ -1268,6 +1271,8 @@ export function initApp(): void {
         handleDocumentClick = (event) => {
             try {
                 const target = event.target as HTMLElement | null;
+                // Skip YouTube's native dropdown/popup elements to prevent interference
+                if (target?.closest('tp-yt-iron-dropdown') || target?.closest('ytd-popup-container')) return;
                 if (target?.closest('.ycs_dropdown_wrap')) return;
 
                 closeAllDropdowns();


### PR DESCRIPTION
## Summary

Defensive fix attempting to address dropdown interaction conflicts between YCS extension and YouTube's native UI elements. This change aims to prevent YCS event handlers from interfering with YouTube's native dropdown/popup behavior.

Note: This is a speculative fix based on code analysis. The root cause of the reported issue (YouTube popups getting stuck on Shorts) has not been definitively identified, and this change may or may not resolve it.

Ref #116

## Changes

- Add `closest()` check in dropdown trigger click handler to only call `stopPropagation()` for YCS dropdown elements (`.ycs_dropdown_trigger`)
- Skip YouTube's native dropdown/popup elements (`tp-yt-iron-dropdown`, `ytd-popup-container`) in document click handler to prevent premature closure of YouTube UI
