### PR TITLE
Fix baction error when clicking ycs toolbar outside of youtube

### DIFF
--- a/app/src/source/browser-action/assets/ts/b_action.ts
+++ b/app/src/source/browser-action/assets/ts/b_action.ts
@@ -30,7 +30,7 @@ window.onload = async (): Promise<void> => {
 
         const checkShorts = (url: string): boolean | void => {
             try {
-                if (typeof url !== 'string') return;
+                if (typeof url !== 'string' || !url) return;
 
                 const u = new URL(url);
                 const uParams = u.pathname.split('/');

--- a/app/src/source/browser-action/assets/ts/b_action.ts
+++ b/app/src/source/browser-action/assets/ts/b_action.ts
@@ -28,7 +28,7 @@ window.onload = async (): Promise<void> => {
             }
         };
 
-        const checkShorts = (url: string): boolean | void => {
+        const checkShorts = (url: string | undefined): boolean | void => {
             try {
                 if (typeof url !== 'string') return;
 
@@ -119,7 +119,7 @@ window.onload = async (): Promise<void> => {
 
             console.log('CURRENT TAB URL: ', url);
 
-            if (url[0].url && checkShorts(url[0].url || '')) {
+            if (checkShorts(url[0]?.url ?? undefined)) {
                 const elBtnsBlock = document.getElementById('ycs_btn_opt_block') as HTMLElement;
 
                 elBtnsBlock.insertAdjacentHTML(

--- a/app/src/source/browser-action/assets/ts/b_action.ts
+++ b/app/src/source/browser-action/assets/ts/b_action.ts
@@ -119,7 +119,7 @@ window.onload = async (): Promise<void> => {
 
             console.log('CURRENT TAB URL: ', url);
 
-            if (checkShorts(url[0]?.url ?? undefined)) {
+            if (checkShorts(url[0].url)) {
                 const elBtnsBlock = document.getElementById('ycs_btn_opt_block') as HTMLElement;
 
                 elBtnsBlock.insertAdjacentHTML(

--- a/app/src/source/browser-action/assets/ts/b_action.ts
+++ b/app/src/source/browser-action/assets/ts/b_action.ts
@@ -30,7 +30,7 @@ window.onload = async (): Promise<void> => {
 
         const checkShorts = (url: string): boolean | void => {
             try {
-                if (typeof url !== 'string' || !url) return;
+                if (typeof url !== 'string') return;
 
                 const u = new URL(url);
                 const uParams = u.pathname.split('/');
@@ -119,7 +119,7 @@ window.onload = async (): Promise<void> => {
 
             console.log('CURRENT TAB URL: ', url);
 
-            if (checkShorts(url[0].url || '')) {
+            if (url[0].url && checkShorts(url[0].url || '')) {
                 const elBtnsBlock = document.getElementById('ycs_btn_opt_block') as HTMLElement;
 
                 elBtnsBlock.insertAdjacentHTML(


### PR DESCRIPTION
<img width="1325" height="547" alt="image" src="https://github.com/user-attachments/assets/891a739f-e19a-4c2f-8f76-a03c7203fa9c" />

While working on YCS, I noticed there was a baction error whenever you clicked the YCS toolbar outside of youtube.com which is caused by the `checkShorts` function checking if the current url is a youtube short.  Since the extension only has access to youtube.com, clicking the browser action outside youtube.com leads to the url being undefined.

Since checkShorts only allows the string type, `if (typeof url !== 'string') return;` is essentially pointless, so I added undefined as  a possible parameter type to make the if statement work properly.