### PR TITLE
Fix comment formatting and prevent potential XSS attack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,36 @@ Three-layer communication using `window.postMessage()` (Web Page ↔ Content Scr
 
 Uses `fetch-retry` with exponential backoff (2s → 10s → 60s, max 100 retries) to handle YouTube API instability. Implemented in `utils/innertube.ts`.
 
+### HTML Encoding Strategy (XSS Prevention)
+
+User content (comments, chat messages) is encoded using `html-entities` library's `encode()` function to prevent XSS attacks.
+
+**YouTube API Text Format**:
+- YouTube returns text content as **plain text**, not HTML entities
+- Special characters like `<`, `>`, `&` are transmitted via JSON Unicode escapes (`\u003c`, `\u003e`, `\u0026`)
+- After JSON parsing, these become literal characters (`<`, `>`, `&`)
+- Therefore, `encode()` correctly converts them to safe HTML entities (`&lt;`, `&gt;`, `&amp;`)
+
+**Example** (from actual API response):
+```json
+// JSON response contains Unicode escapes
+"content": "The img tag: \u003cimg src=\"test.jpg\"\u003e"
+
+// After JSON.parse(), becomes plain text
+"The img tag: <img src=\"test.jpg\">"
+
+// After encode(), safe for HTML rendering
+"The img tag: &lt;img src=&quot;test.jpg&quot;&gt;"
+```
+
+**Key Files**:
+- `utils/common.ts`: `escapeHtml()` - smart encoding that preserves existing entities
+- `utils/innertube/chat/utils.ts`: `formatChatRuns()` - chat message encoding
+- `utils/innertube/comments/pipeline.ts`: `formatCommentRuns()` - comment encoding
+- `utils/viewModels.ts`: `buildChatRunsHtml()`, `buildCommentViewModels()` - view layer encoding
+
+**Design Decision**: Direct `encode()` is used instead of `decodeHtml()` + `escapeHtml()` because YouTube API returns plain text, not pre-encoded HTML entities. Double-encoding would only occur if YouTube changed their API to return entities, which has not been observed in practice.
+
 ## TypeScript Configuration
 
 - **Target**: ES6

--- a/app/src/source/utils/formatting.ts
+++ b/app/src/source/utils/formatting.ts
@@ -1,4 +1,4 @@
-import { escapeHtml, wrapTryCatch, getCleanUrlVideo } from './common';
+import { wrapTryCatch, getCleanUrlVideo } from './common';
 
 interface ExportMeta {
     url?: string;
@@ -35,15 +35,6 @@ function resolveMeta(meta?: ExportMeta): ResolvedExportMeta {
     };
 }
 
-function esc(input: unknown): string {
-    try {
-        const s = String(input ?? '');
-        return escapeHtml(s);
-    } catch {
-        return '';
-    }
-}
-
 function safeUrl(raw: unknown): string {
     try {
         let url = String(raw || '');
@@ -55,31 +46,6 @@ function safeUrl(raw: unknown): string {
         return '#';
     } catch {
         return '#';
-    }
-}
-
-function sanitizeHtml(html: unknown): string {
-    try {
-        let s = String(html || '');
-        if (!s) return '';
-        s = s.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
-        s = s
-            .replace(/\son[a-z]+\s*=\s*"[^"]*"/gi, '')
-            .replace(/\son[a-z]+\s*=\s*'[^']*'/gi, '')
-            .replace(/\son[a-z]+\s*=\s*[^\s>]+/gi, '');
-        s = s.replace(/href\s*=\s*"([^"]*)"/gi, (_m, p1) => `href="${esc(safeUrl(p1))}" rel="noopener noreferrer"`);
-        s = s.replace(/href\s*=\s*'([^']*)'/gi, (_m, p1) => `href='${esc(safeUrl(p1))}' rel="noopener noreferrer"`);
-        s = s.replace(/src\s*=\s*"([^"]*)"/gi, (_m, p1) => {
-            const u = safeUrl(p1);
-            return u === '#' ? 'src=""' : `src="${esc(u)}"`;
-        });
-        s = s.replace(/src\s*=\s*'([^']*)'/gi, (_m, p1) => {
-            const u = safeUrl(p1);
-            return u === '#' ? "src=''" : `src='${esc(u)}'`;
-        });
-        return s;
-    } catch {
-        return '';
     }
 }
 
@@ -520,9 +486,7 @@ start offset: ${wrapTryCatch(() => c.transcriptCueGroupRenderer.cues[0].transcri
 
 export {
     resolveMeta,
-    esc,
     safeUrl,
-    sanitizeHtml,
     parseFormattedNumber,
     parseFormattedNumberToInt,
     msToRoundSec,

--- a/app/src/source/utils/innertube/chat/utils.ts
+++ b/app/src/source/utils/innertube/chat/utils.ts
@@ -1,4 +1,6 @@
+import { encode } from 'html-entities';
 import { deepFindObjKey, getObj, wrapTryCatch } from '../../common';
+import { safeUrl } from '../../formatting';
 
 export interface ChatProcessingContext {
     chatMap: Map<number, object>;
@@ -157,7 +159,7 @@ export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {})
                 const linkVideoId = (wrapTryCatch(() => run?.navigationEndpoint?.watchEndpoint?.videoId) ||
                     '') as string;
                 const href = `https://www.youtube.com/watch?v=${linkVideoId}&t=${startTimeSeconds}s`;
-                result.richText += `<a class="ycs-cpointer ycs-goto-comment-time" href="${href}" data-offsetvideo="${startTimeSeconds}" data-video-id="${linkVideoId}">${text || ''}</a>`;
+                result.richText += `<a class="ycs-cpointer ycs-goto-comment-time" href="${href}" data-offsetvideo="${startTimeSeconds}" data-video-id="${linkVideoId}">${encode(text || '')}</a>`;
 
                 if (options.currentVideoId && String(linkVideoId || '') === String(options.currentVideoId || '')) {
                     result.hasTimelineLink = true;
@@ -167,14 +169,14 @@ export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {})
             }
 
             if (run?.navigationEndpoint) {
-                const href =
+                const rawHref =
                     run?.navigationEndpoint?.browseEndpoint?.canonicalBaseUrl ||
                     run?.navigationEndpoint?.urlEndpoint?.url ||
                     run?.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url ||
-                    text ||
-                    '#';
+                    '';
+                const href = safeUrl(rawHref);
 
-                result.richText += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${text || ''}</a>`;
+                result.richText += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${encode(text || '')}</a>`;
                 continue;
             }
 
@@ -199,7 +201,7 @@ export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {})
                 const style = 'margin-left: 2px; margin-right: 2px;';
 
                 if (url) {
-                    result.richText += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
+                    result.richText += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="24" height="24" style="${style}" class="ycs-attachment">`;
                 } else {
                     result.richText += alt;
                 }
@@ -216,15 +218,15 @@ export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {})
                 const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
                 const alt = (run as any)?.text || '';
 
-                result.richText += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
+                result.richText += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
                 continue;
             }
 
-            result.richText += text || '';
+            result.richText += encode(text || '');
         } catch (error) {
             console.error(error);
             const fallbackText = (wrapTryCatch(() => run?.text) as string) || '';
-            result.richText += fallbackText;
+            result.richText += encode(fallbackText);
         }
     }
 

--- a/app/src/source/utils/innertube/chat/utils.ts
+++ b/app/src/source/utils/innertube/chat/utils.ts
@@ -201,7 +201,7 @@ export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {})
                 const style = 'margin-left: 2px; margin-right: 2px;';
 
                 if (url) {
-                    result.richText += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="24" height="24" style="${style}" class="ycs-attachment">`;
+                    result.richText += `<img src="${safeUrl(url)}" alt="${encode(alt)}" title="${encode(alt)}" width="24" height="24" style="${style}" class="ycs-attachment">`;
                 } else {
                     result.richText += alt;
                 }
@@ -218,7 +218,7 @@ export function formatChatRuns(runs: any[], options: FormatChatRunsOptions = {})
                 const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
                 const alt = (run as any)?.text || '';
 
-                result.richText += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
+                result.richText += `<img src="${safeUrl(url)}" alt="${encode(alt)}" title="${encode(alt)}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
                 continue;
             }
 

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -14,7 +14,7 @@ import {
     isPostMemberOnlyFromYtInitialData,
     setCurrentVideoMemberOnly
 } from '../memberOnly';
-import { decode, encode } from 'html-entities';
+import { encode } from 'html-entities';
 
 export interface CommentContinuation {
     token: string;
@@ -84,7 +84,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
     let isTimeline = false;
 
     const safeRuns = Array.isArray(runs) ? runs : [];
-    console.warn(safeRuns);
+
     for (const partTextComment of safeRuns) {
         let text = '';
         let navigationEndpoint: any;

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -128,7 +128,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                     }) || '';
                 const alt = (wrapTryCatch(() => (partTextComment as any).emoji.shortcuts?.[0]) as string) || '';
                 const style = `margin-left: 2px; margin-right: 2px;`;
-                renderFullTextComment += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="24" height="24" style="${style}" class="ycs-attachment">`;
+                renderFullTextComment += `<img src="${safeUrl(url)}" alt="${encode(alt)}" title="${encode(alt)}" width="24" height="24" style="${style}" class="ycs-attachment">`;
             } else if (wrapTryCatch(() => (partTextComment as any).attachment?.image)) {
                 const image: any = wrapTryCatch(() => (partTextComment as any).attachment.image);
                 const url = image?.url || '';
@@ -137,7 +137,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                 const margin = image?.margin || { left: 0, right: 0 };
                 const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
                 const alt = text || '';
-                renderFullTextComment += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
+                renderFullTextComment += `<img src="${safeUrl(url)}" alt="${encode(alt)}" title="${encode(alt)}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
             } else {
                 renderFullTextComment += encode(text) || '';
             }

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -3,7 +3,7 @@ import Queue from 'p-queue';
 
 import { fetchR } from '../../libs';
 import { GlobalStore, getCleanUrlVideo, getVideoId, wrapTryCatch, extractVideoId } from '../../common';
-import { parseFormattedNumber } from '../../formatting';
+import { parseFormattedNumber, safeUrl } from '../../formatting';
 import { normalizeCommentViewModel } from './normalize';
 import { buildInnertubeBody, buildInnertubeHeaders } from '../request';
 import { getInnertubeApiKey, getInitYtData, getInitYtDataFromHtml, getPageCfgData } from '../core';
@@ -109,17 +109,17 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                 const linkVideoId = (wrapTryCatch(() => navigationEndpoint?.watchEndpoint?.videoId) || '') as string;
                 const isSameVideo = String(linkVideoId || '') === String(currentVideoId || '');
                 const timeValue = rawTimeValue ?? parsedTime ?? '';
-                renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${timeValue}s" data-offsetvideo="${timeValue}" data-video-id="${linkVideoId}">${text || ''}</a>`;
+                renderFullTextComment += `<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=${linkVideoId}&t=${timeValue}s" data-offsetvideo="${timeValue}" data-video-id="${linkVideoId}">${encode(text || '')}</a>`;
                 if (isSameVideo) {
                     isTimeline = true;
                 }
             } else if (navigationEndpoint) {
-                const href = (wrapTryCatch(() => navigationEndpoint?.browseEndpoint?.canonicalBaseUrl) ||
+                const rawHref = (wrapTryCatch(() => navigationEndpoint?.browseEndpoint?.canonicalBaseUrl) ||
                     wrapTryCatch(() => navigationEndpoint?.urlEndpoint?.url) ||
                     wrapTryCatch(() => navigationEndpoint?.commandMetadata?.webCommandMetadata?.url) ||
-                    text ||
-                    '#') as string;
-                renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${text || ''}</a>`;
+                    '') as string;
+                const href = safeUrl(rawHref);
+                renderFullTextComment += `<a class="ycs-cpointer ycs-comment-link" href="${href}" target="_blank">${encode(text || '')}</a>`;
             } else if (wrapTryCatch(() => (partTextComment as any).emoji)) {
                 const url =
                     wrapTryCatch(() => {
@@ -128,7 +128,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                     }) || '';
                 const alt = (wrapTryCatch(() => (partTextComment as any).emoji.shortcuts?.[0]) as string) || '';
                 const style = `margin-left: 2px; margin-right: 2px;`;
-                renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="24" height="24" style="${style}" class="ycs-attachment">`;
+                renderFullTextComment += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="24" height="24" style="${style}" class="ycs-attachment">`;
             } else if (wrapTryCatch(() => (partTextComment as any).attachment?.image)) {
                 const image: any = wrapTryCatch(() => (partTextComment as any).attachment.image);
                 const url = image?.url || '';
@@ -137,7 +137,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                 const margin = image?.margin || { left: 0, right: 0 };
                 const style = `margin-left: ${margin.left || 0}px; margin-right: ${margin.right || 0}px;`;
                 const alt = text || '';
-                renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
+                renderFullTextComment += `<img src="${url}" alt="${encode(alt)}" title="${encode(alt)}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
             } else {
                 renderFullTextComment += encode(text) || '';
             }

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -14,6 +14,7 @@ import {
     isPostMemberOnlyFromYtInitialData,
     setCurrentVideoMemberOnly
 } from '../memberOnly';
+import { decode, encode } from 'html-entities';
 
 export interface CommentContinuation {
     token: string;
@@ -138,7 +139,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                 const alt = text || '';
                 renderFullTextComment += `<img src="${url}" alt="${alt}" title="${alt}" width="${width}" height="${height}" style="${style}" class="ycs-attachment">`;
             } else {
-                renderFullTextComment += text || '';
+                renderFullTextComment += encode(text) || '';
             }
         } catch (e) {
             console.error(e);
@@ -156,8 +157,8 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
                     return '';
                 }
             })();
-            renderFullTextComment += fallbackText;
-            fullTextComment += fallbackText;
+            renderFullTextComment += encode(fallbackText);
+            fullTextComment += encode(fallbackText);
         }
     }
 

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -84,7 +84,7 @@ export function formatCommentRuns(runs: any[] | undefined, currentVideoId: strin
     let isTimeline = false;
 
     const safeRuns = Array.isArray(runs) ? runs : [];
-
+    console.warn(safeRuns);
     for (const partTextComment of safeRuns) {
         let text = '';
         let navigationEndpoint: any;
@@ -362,7 +362,7 @@ export function generateCommentObjectFromFW(params: {
                             }
                         });
                     } else if (browseEndpoint || webUrl) {
-                        const canonicalBaseUrl = webUrl ? `https://www.youtube.com${webUrl}` : undefined;
+                        const canonicalBaseUrl = webUrl ? `${webUrl}` : undefined;
                         rawRuns.push({
                             text,
                             startIndex,

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -91,62 +91,6 @@ function normalizeUrl(raw: unknown): string {
     return '';
 }
 
-function sanitizeHtml(html: unknown): string {
-    try {
-        let value = String(html ?? '');
-        if (!value) return '';
-
-        value = value.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
-        value = value
-            .replace(/\son[a-z]+\s*=\s*"[^"]*"/gi, '')
-            .replace(/\son[a-z]+\s*=\s*'[^']*'/gi, '')
-            .replace(/\son[a-z]+\s*=\s*[^\s>]+/gi, '');
-
-        value = value.replace(/href\s*=\s*"([^"]*)"/gi, (_match, href) => {
-            const safe = normalizeUrl(href);
-            return safe ? `href="${escapeHtml(safe)}" rel="noopener noreferrer"` : 'href="#"';
-        });
-
-        value = value.replace(/href\s*=\s*'([^']*)'/gi, (_match, href) => {
-            const safe = normalizeUrl(href);
-            return safe ? `href='${escapeHtml(safe)}' rel="noopener noreferrer"` : "href='#'";
-        });
-
-        value = value.replace(/src\s*=\s*"([^"]*)"/gi, (_match, src) => {
-            const safe = normalizeUrl(src);
-            return safe ? `src="${escapeHtml(safe)}"` : 'src=""';
-        });
-
-        value = value.replace(/src\s*=\s*'([^']*)'/gi, (_match, src) => {
-            const safe = normalizeUrl(src);
-            return safe ? `src='${escapeHtml(safe)}'` : "src=''";
-        });
-
-        const allowedTags = new Set(['a', 'br', 'img', 'span']);
-        value = value.replace(/<(\/)?([a-z0-9-]+)([^>]*)>/gi, (match, closingSlash, tag, attrs) => {
-            const lower = tag.toLowerCase();
-            if (!allowedTags.has(lower)) {
-                return match.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-            }
-
-            if (lower === 'br') {
-                return '<br />';
-            }
-
-            if (lower === 'img') {
-                return `<img${attrs}>`;
-            }
-
-            const slash = closingSlash ? '/' : '';
-            return `<${slash}${lower}${attrs}>`;
-        });
-
-        return value;
-    } catch {
-        return '';
-    }
-}
-
 function resolveCommentBadge(renderer: any): MemberBadgeViewModel | undefined {
     const badge = wrapTryCatch(() => renderer?.sponsorCommentBadge?.sponsorCommentBadgeRenderer);
     if (!badge) return undefined;

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { encode } from 'html-entities';
 import { decodeHtml, escapeHtml, wrapTryCatch, convertColorToRgba } from './common';
 import { msToShareVideo, tmUsecToDateTime, formatDurationHMS } from './formatting';
 
@@ -294,9 +295,9 @@ function buildChatRunsHtml(runs: any[]): string {
                 continue;
             }
 
-            parts.push(escapeHtml(decodeHtml(coerceString(run.text))));
+            parts.push(encode(run.text));
         } catch {
-            parts.push(escapeHtml(decodeHtml(coerceString(run?.text))));
+            parts.push(encode(coerceString(run?.text)));
         }
     }
 
@@ -309,7 +310,7 @@ function buildChatMessageHtml(renderer: any): string {
 
     const renderFullText = coerceString(wrapTryCatch(() => message.renderFullText));
     if (renderFullText) {
-        return sanitizeHtml(decodeHtml(renderFullText));
+        return renderFullText;
     }
 
     const fullText = coerceString(wrapTryCatch(() => message.fullText));
@@ -411,9 +412,7 @@ export function buildCommentViewModels(
             isReply,
             isReplyType,
             refIndex: coerceString(wrapTryCatch(() => item?.refIndex)) || undefined,
-            contentHtml: renderFullText
-                ? sanitizeHtml(decodeHtml(renderFullText))
-                : escapeHtml(decodeHtml(fallbackText)),
+            contentHtml: renderFullText ? renderFullText : encode(fallbackText),
             replyLevel,
             hideExpandUp,
             forceSmallAvatar

--- a/app/src/source/utils/youtubeDataApi/transform.ts
+++ b/app/src/source/utils/youtubeDataApi/transform.ts
@@ -5,6 +5,7 @@
  * used by YCS for rendering and searching.
  */
 
+import { encode } from 'html-entities';
 import type {
     CommentItem,
     CommentRenderer,
@@ -13,6 +14,7 @@ import type {
     YouTubeApiCommentThread
 } from '../interfaces/i_types';
 import { decodeHtml } from '../common';
+import { safeUrl } from '../formatting';
 
 /**
  * Regex pattern to match timestamps in comment text (e.g., "1:23", "1:23:45")
@@ -235,13 +237,14 @@ function formatRunsToText(runs: CommentRun[]): { fullText: string; renderFullTex
         if (run.navigationEndpoint?.watchEndpoint?.startTimeSeconds !== undefined) {
             // Timestamp link
             const seconds = run.navigationEndpoint.watchEndpoint.startTimeSeconds;
-            renderFullText += `<a class="ycs-goto-comment-time" href="#" data-offsetvideo="${seconds}">${text}</a>`;
+            renderFullText += `<a class="ycs-goto-comment-time" href="#" data-offsetvideo="${seconds}">${encode(text)}</a>`;
         } else if (run.navigationEndpoint?.commandMetadata?.webCommandMetadata?.url) {
             // External link
-            const url = run.navigationEndpoint.commandMetadata.webCommandMetadata.url;
-            renderFullText += `<a class="ycs-comment-link" href="${url}" target="_blank" rel="noopener">${text}</a>`;
+            const rawUrl = run.navigationEndpoint.commandMetadata.webCommandMetadata.url;
+            const url = safeUrl(rawUrl);
+            renderFullText += `<a class="ycs-comment-link" href="${url}" target="_blank" rel="noopener">${encode(text)}</a>`;
         } else {
-            renderFullText += text;
+            renderFullText += encode(text);
         }
     }
 

--- a/app/tests/formatting.test.ts
+++ b/app/tests/formatting.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import { esc, safeUrl, sanitizeHtml, parseFormattedNumber } from '../src/source/utils/formatting';
 import { formatCommentRuns } from '../src/source/utils/innertube/comments/pipeline';
+import { formatChatRuns } from '../src/source/utils/innertube/chat/utils';
 
 test('esc converts special characters into HTML entities', () => {
     const raw = '<div>&\'"';
@@ -105,4 +106,189 @@ test('parseFormattedNumber handles common formatting edge cases', () => {
     assert.equal(parseFormattedNumber('1 천').number, 1000);
     assert.equal(parseFormattedNumber('1 만').number, 10_000);
     assert.equal(parseFormattedNumber('1 m').number, 1_000_000);
+});
+
+// ============================================================================
+// formatChatRuns XSS Security Tests
+// ============================================================================
+
+test('formatChatRuns: XSS - script tag in text should be encoded', () => {
+    const runs = [{ text: "<script>alert('XSS')</script>" }];
+    const result = formatChatRuns(runs);
+    // html-entities encodes single quotes as &apos;
+    assert.equal(result.richText, "&lt;script&gt;alert(&apos;XSS&apos;)&lt;/script&gt;");
+});
+
+test('formatChatRuns: XSS - HTML injection in text should be encoded', () => {
+    const runs = [{ text: '<img onerror="alert(1)" src="x">' }];
+    const result = formatChatRuns(runs);
+    assert.equal(result.richText, '&lt;img onerror=&quot;alert(1)&quot; src=&quot;x&quot;&gt;');
+});
+
+test('formatChatRuns: XSS - javascript: URL in navigationEndpoint should be blocked', () => {
+    const runs = [
+        {
+            text: 'Click me',
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: "javascript:alert('XSS')"
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    // safeUrl should convert javascript: to #
+    assert.ok(result.richText.includes('href="#"'), 'javascript: URL should be converted to #');
+    assert.ok(result.richText.includes('>Click me</a>'), 'Link text should be preserved');
+});
+
+test('formatChatRuns: XSS - data: URL in navigationEndpoint should be blocked', () => {
+    const runs = [
+        {
+            text: 'Click me',
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: 'data:text/html,<script>alert(1)</script>'
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(result.richText.includes('href="#"'), 'data: URL should be converted to #');
+});
+
+test('formatChatRuns: XSS - text in timestamp link should be encoded', () => {
+    const runs = [
+        {
+            text: '<script>alert(1)</script>',
+            navigationEndpoint: {
+                watchEndpoint: {
+                    videoId: 'abc123',
+                    startTimeSeconds: 30
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(result.richText.includes('&lt;script&gt;'), 'Script tag in timestamp link text should be encoded');
+    assert.ok(result.richText.includes('data-offsetvideo="30"'), 'Timestamp data attribute should be preserved');
+});
+
+test('formatChatRuns: XSS - emoji alt text should be encoded', () => {
+    const runs = [
+        {
+            emoji: {
+                shortcuts: ['<script>alert(1)</script>'],
+                image: {
+                    thumbnails: [{ url: 'https://example.com/emoji.png' }],
+                    accessibility: { accessibilityData: { label: 'emoji' } }
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(result.richText.includes('alt="&lt;script&gt;'), 'Emoji alt should be encoded');
+    assert.ok(result.richText.includes('title="&lt;script&gt;'), 'Emoji title should be encoded');
+});
+
+test('formatChatRuns: valid https URL should be preserved', () => {
+    const runs = [
+        {
+            text: 'Visit my site',
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: 'https://example.com/page'
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(result.richText.includes('href="https://example.com/page"'), 'Valid https URL should be preserved');
+});
+
+test('formatChatRuns: relative YouTube URL should be normalized', () => {
+    const runs = [
+        {
+            text: 'Watch this',
+            navigationEndpoint: {
+                browseEndpoint: {
+                    canonicalBaseUrl: '/channel/UC123'
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(
+        result.richText.includes('href="https://www.youtube.com/channel/UC123"'),
+        'Relative URL should be normalized to absolute'
+    );
+});
+
+// ============================================================================
+// formatCommentRuns XSS Security Tests (additional)
+// ============================================================================
+
+test('formatCommentRuns: XSS - javascript: URL in navigationEndpoint should be blocked', () => {
+    const runs = [
+        {
+            text: 'Click me',
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: "javascript:alert('XSS')"
+                }
+            }
+        }
+    ];
+    const result = formatCommentRuns(runs, 'video123');
+    assert.ok(result.renderFullText.includes('href="#"'), 'javascript: URL should be converted to #');
+});
+
+test('formatCommentRuns: XSS - text in external link should be encoded', () => {
+    const runs = [
+        {
+            text: '<img src=x onerror=alert(1)>',
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: 'https://example.com'
+                }
+            }
+        }
+    ];
+    const result = formatCommentRuns(runs, 'video123');
+    assert.ok(result.renderFullText.includes('&lt;img'), 'HTML in link text should be encoded');
+    assert.ok(!result.renderFullText.includes('<img src=x'), 'Raw HTML should not appear');
+});
+
+test('formatCommentRuns: XSS - emoji alt text should be encoded', () => {
+    const runs = [
+        {
+            emoji: {
+                shortcuts: ['"onclick="alert(1)"'],
+                image: {
+                    thumbnails: [{ url: 'https://example.com/emoji.png' }]
+                }
+            }
+        }
+    ];
+    const result = formatCommentRuns(runs, 'video123');
+    assert.ok(result.renderFullText.includes('alt="&quot;onclick'), 'Emoji alt should be encoded');
+});
+
+// ============================================================================
+// safeUrl Security Tests
+// ============================================================================
+
+test('safeUrl: blocks various dangerous protocols', () => {
+    assert.equal(safeUrl('javascript:alert(1)'), '#');
+    assert.equal(safeUrl('JAVASCRIPT:alert(1)'), '#');
+    assert.equal(safeUrl('data:text/html,<script>alert(1)</script>'), '#');
+    assert.equal(safeUrl('vbscript:msgbox(1)'), '#');
+    assert.equal(safeUrl('file:///etc/passwd'), '#');
+    assert.equal(safeUrl('about:blank'), '#');
+});
+
+test('safeUrl: allows safe protocols', () => {
+    assert.equal(safeUrl('https://example.com'), 'https://example.com');
+    assert.equal(safeUrl('http://example.com'), 'http://example.com');
+    assert.equal(safeUrl('HTTPS://EXAMPLE.COM'), 'HTTPS://EXAMPLE.COM');
 });

--- a/app/tests/formatting.test.ts
+++ b/app/tests/formatting.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'node:assert';
 import test from 'node:test';
 
 import { esc, safeUrl, sanitizeHtml, parseFormattedNumber } from '../src/source/utils/formatting';
+import { formatCommentRuns } from '../src/source/utils/innertube/comments/pipeline';
 
 test('esc converts special characters into HTML entities', () => {
     const raw = '<div>&\'"';
@@ -30,6 +31,53 @@ test('sanitizeHtml removes dangerous tags and normalizes href/src schemes', () =
         sanitized,
         '<div><a href="#" rel="noopener noreferrer">link</a><img src="https://www.youtube.com/image.png" /></div>'
     );
+});
+
+test('XSS check javascript:void', () => {
+    const runs = [ { text: "<a href=javascript:alert('XSS')>Click me</a>" } ];
+    const formatted = formatCommentRuns(runs, '123');
+    const renderFullTextComment = formatted.renderFullText;
+    assert.equal(renderFullTextComment, '&lt;a href=javascript:alert(&apos;XSS&apos;)&gt;Click me&lt;/a&gt;');
+});
+
+test('XSS check <script> tag', () => {
+    const runs = [ { text: "<script>alert('XSS')</script>" } ];
+    const formatted = formatCommentRuns(runs, '123');
+    const renderFullTextComment = formatted.renderFullText;
+    assert.equal(renderFullTextComment, '&lt;script&gt;alert(&apos;XSS&apos;)&lt;/script&gt;');
+});
+
+test('formatted timestamp comment', () => {
+    const runs = [
+        {
+            navigationEndpoint: {
+                watchEndpoint: {
+                    videoId: '123',
+                    startTimeSeconds: '30'
+                }
+            },
+            text: "0:30"
+        }
+    ];
+    const formatted = formatCommentRuns(runs, '123');
+    const renderFullTextComment = formatted.renderFullText;
+    assert.equal(renderFullTextComment, '<a class="ycs-cpointer ycs-goto-comment-time" href="https://www.youtube.com/watch?v=123&t=30s" data-offsetvideo="30" data-video-id="123">0:30</a>',);
+});
+
+test('formatted link comment', () => {
+    const runs = [
+        {
+            navigationEndpoint: {
+                urlEndpoint: {
+                    url: 'https://github.com/pc035860/YCS-cont'
+                }
+            },
+            text: "https://github.com/pc035860/YCS-cont" // Links on youtube should be the same as the url
+        }
+    ];
+    const formatted = formatCommentRuns(runs, '123');
+    const renderFullTextComment = formatted.renderFullText;
+    assert.equal(renderFullTextComment, '<a class="ycs-cpointer ycs-comment-link" href="https://github.com/pc035860/YCS-cont" target="_blank">https://github.com/pc035860/YCS-cont</a>');
 });
 
 test('parseFormattedNumber handles common formatting edge cases', () => {

--- a/app/tests/formatting.test.ts
+++ b/app/tests/formatting.test.ts
@@ -1,37 +1,15 @@
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
 
-import { esc, safeUrl, sanitizeHtml, parseFormattedNumber } from '../src/source/utils/formatting';
+import { safeUrl, parseFormattedNumber } from '../src/source/utils/formatting';
 import { formatCommentRuns } from '../src/source/utils/innertube/comments/pipeline';
 import { formatChatRuns } from '../src/source/utils/innertube/chat/utils';
-
-test('esc converts special characters into HTML entities', () => {
-    const raw = '<div>&\'"';
-    const encoded = esc(raw);
-    assert.equal(encoded, '&lt;div&gt;&amp;&#39;&quot;');
-});
-
-test('esc preserves existing HTML entities', () => {
-    const raw = 'Fish &amp; Chips &copy; 2024 &#62;';
-    const encoded = esc(raw);
-    assert.equal(encoded, 'Fish &amp; Chips &copy; 2024 &#62;');
-});
 
 test('safeUrl normalizes common URLs and blocks non-http/https schemes', () => {
     assert.equal(safeUrl('https://example.com/path'), 'https://example.com/path');
     assert.equal(safeUrl('/watch?v=123'), 'https://www.youtube.com/watch?v=123');
     assert.equal(safeUrl('www.youtube.com/watch?v=456'), 'https://www.youtube.com/watch?v=456');
     assert.equal(safeUrl('javascript:alert(1)'), '#');
-});
-
-test('sanitizeHtml removes dangerous tags and normalizes href/src schemes', () => {
-    const raw =
-        '<div onclick="alert(1)"><a href="javascript:alert(1)">link</a><img src="/image.png" /></div><script>alert(1)</script>';
-    const sanitized = sanitizeHtml(raw);
-    assert.equal(
-        sanitized,
-        '<div><a href="#" rel="noopener noreferrer">link</a><img src="https://www.youtube.com/image.png" /></div>'
-    );
 });
 
 test('XSS check javascript:void', () => {

--- a/app/tests/formatting.test.ts
+++ b/app/tests/formatting.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import { safeUrl, parseFormattedNumber } from '../src/source/utils/formatting';
 import { formatCommentRuns } from '../src/source/utils/innertube/comments/pipeline';
 import { formatChatRuns } from '../src/source/utils/innertube/chat/utils';
+import { escapeHtml } from '../src/source/utils/common';
 
 test('safeUrl normalizes common URLs and blocks non-http/https schemes', () => {
     assert.equal(safeUrl('https://example.com/path'), 'https://example.com/path');
@@ -269,4 +270,114 @@ test('safeUrl: allows safe protocols', () => {
     assert.equal(safeUrl('https://example.com'), 'https://example.com');
     assert.equal(safeUrl('http://example.com'), 'http://example.com');
     assert.equal(safeUrl('HTTPS://EXAMPLE.COM'), 'HTTPS://EXAMPLE.COM');
+});
+
+// ============================================================================
+// Image src URL XSS Tests
+// ============================================================================
+
+test('formatCommentRuns: javascript: URL in emoji image should be blocked', () => {
+    const runs = [
+        {
+            emoji: {
+                shortcuts: ['emoji'],
+                image: {
+                    thumbnails: [{ url: 'javascript:alert(1)' }]
+                }
+            }
+        }
+    ];
+    const result = formatCommentRuns(runs, 'video123');
+    assert.ok(result.renderFullText.includes('src="#"'), 'javascript: URL should be replaced with #');
+    assert.ok(!result.renderFullText.includes('javascript:'), 'javascript: should not appear in output');
+});
+
+test('formatCommentRuns: data: URL in emoji image should be blocked', () => {
+    const runs = [
+        {
+            emoji: {
+                shortcuts: ['emoji'],
+                image: {
+                    thumbnails: [{ url: 'data:text/html,<script>alert(1)</script>' }]
+                }
+            }
+        }
+    ];
+    const result = formatCommentRuns(runs, 'video123');
+    assert.ok(result.renderFullText.includes('src="#"'), 'data: URL should be replaced with #');
+    assert.ok(!result.renderFullText.includes('data:'), 'data: should not appear in output');
+});
+
+test('formatChatRuns: javascript: URL in emoji image should be blocked', () => {
+    const runs = [
+        {
+            emoji: {
+                shortcuts: ['emoji'],
+                image: {
+                    thumbnails: [{ url: 'javascript:alert(1)' }],
+                    accessibility: { accessibilityData: { label: 'emoji' } }
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(result.richText.includes('src="#"'), 'javascript: URL should be replaced with #');
+    assert.ok(!result.richText.includes('javascript:'), 'javascript: should not appear in output');
+});
+
+test('formatChatRuns: valid https URL in emoji image should be allowed', () => {
+    const runs = [
+        {
+            emoji: {
+                shortcuts: ['emoji'],
+                image: {
+                    thumbnails: [{ url: 'https://yt3.ggpht.com/emoji.png' }],
+                    accessibility: { accessibilityData: { label: 'emoji' } }
+                }
+            }
+        }
+    ];
+    const result = formatChatRuns(runs);
+    assert.ok(result.richText.includes('src="https://yt3.ggpht.com/emoji.png"'), 'Valid https URL should be preserved');
+});
+
+// ============================================================================
+// Double-encoding Prevention Tests
+// ============================================================================
+
+test('escapeHtml: pre-encoded HTML entities should not be double-encoded', () => {
+    // Already encoded ampersand should stay as &amp; not become &amp;amp;
+    assert.equal(escapeHtml('&amp;'), '&amp;');
+    assert.equal(escapeHtml('&lt;'), '&lt;');
+    assert.equal(escapeHtml('&gt;'), '&gt;');
+    assert.equal(escapeHtml('&quot;'), '&quot;');
+});
+
+test('escapeHtml: numeric HTML entities should be preserved', () => {
+    // Numeric entities like &#39; should not be double-encoded
+    assert.equal(escapeHtml('&#39;'), '&#39;');
+    assert.equal(escapeHtml('&#x27;'), '&#x27;');
+    assert.equal(escapeHtml('&#60;'), '&#60;');
+});
+
+test('escapeHtml: named HTML entities should be preserved', () => {
+    // Named entities like &copy; should not become &amp;copy;
+    assert.equal(escapeHtml('&copy;'), '&copy;');
+    assert.equal(escapeHtml('&nbsp;'), '&nbsp;');
+    assert.equal(escapeHtml('&reg;'), '&reg;');
+});
+
+test('escapeHtml: mixed content with entities and raw characters', () => {
+    // Mix of already-encoded and raw characters
+    assert.equal(escapeHtml('Hello &amp; World'), 'Hello &amp; World');
+    assert.equal(escapeHtml('Test &lt;script&gt; tag'), 'Test &lt;script&gt; tag');
+    // Raw & should be encoded, but &amp; should stay
+    assert.equal(escapeHtml('A & B &amp; C'), 'A &amp; B &amp; C');
+});
+
+test('escapeHtml: raw special characters should be encoded', () => {
+    // Raw characters that need encoding
+    assert.equal(escapeHtml('<script>'), '&lt;script&gt;');
+    assert.equal(escapeHtml('"quoted"'), '&quot;quoted&quot;');
+    assert.equal(escapeHtml("it's"), 'it&#39;s');
 });

--- a/app/tests/viewModels.test.ts
+++ b/app/tests/viewModels.test.ts
@@ -1,70 +1,7 @@
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
 
-import { buildChatMessageViewModels, buildCommentViewModels } from '../src/source/utils/viewModels';
-import { formatCommentRuns } from '../src/source/utils/innertube/comments/pipeline';
-
-// test('buildCommentViewModels decodes HTML entities once', () => {
-//     const items = [
-//         {
-//             item: {
-//                 commentRenderer: {
-//                     authorText: { simpleText: 'Author' },
-//                     contentText: {
-//                         simpleText: '&amp;gt; Hello &amp;copy;'
-//                     }
-//                 }
-//             }
-//         }
-//     ];
-
-//     const [model] = buildCommentViewModels(items);
-//     assert.equal(model !== undefined, true, 'expected a comment model');
-//     assert.equal(model.contentHtml, '&gt; Hello &copy;');
-// });
-
-// test('buildCommentViewModels escape unexpected tags but keeps anchors', () => {
-//     const runs = [
-//         {text: '<test>unsafe</test><a href="/watch?v=1">link</a>' }
-//     ]
-    
-//     const formattedCommentContent = formatCommentRuns(runs, '123');
-//     const renderFullText = formattedCommentContent.renderFullText;
-
-//     assert.equal(formattedCommentContent !== undefined, true, 'expected a FormattedCommentContent');
-//     assert.equal(
-//         renderFullText,
-//         '&lt;test&gt;unsafe&lt;/test&gt;<a href="https://www.youtube.com/watch?v=1" rel="noopener noreferrer">link</a>'
-//     );
-// });
-
-// test('buildChatMessageViewModels decodes run text HTML entities once', () => {
-//     const items = [
-//         {
-//             item: {
-//                 replayChatItemAction: {
-//                     actions: [
-//                         {
-//                             addChatItemAction: {
-//                                 item: {
-//                                     liveChatTextMessageRenderer: {
-//                                         message: {
-//                                             runs: [{ text: '&amp;gt; Wow' }]
-//                                         }
-//                                     }
-//                                 }
-//                             }
-//                         }
-//                     ]
-//                 }
-//             }
-//         }
-//     ];
-
-//     const [model] = buildChatMessageViewModels(items);
-//     assert.equal(model !== undefined, true, 'expected a chat model');
-//     assert.equal(model.messageHtml, '&gt; Wow');
-// });
+import { buildCommentViewModels } from '../src/source/utils/viewModels';
 
 test('buildCommentViewModels extracts heartTooltip from creatorHeart.tooltip', () => {
     const items = [

--- a/app/tests/viewModels.test.ts
+++ b/app/tests/viewModels.test.ts
@@ -2,75 +2,69 @@ import { strict as assert } from 'node:assert';
 import test from 'node:test';
 
 import { buildChatMessageViewModels, buildCommentViewModels } from '../src/source/utils/viewModels';
+import { formatCommentRuns } from '../src/source/utils/innertube/comments/pipeline';
 
-test('buildCommentViewModels decodes HTML entities once', () => {
-    const items = [
-        {
-            item: {
-                commentRenderer: {
-                    authorText: { simpleText: 'Author' },
-                    contentText: {
-                        simpleText: '&amp;gt; Hello &amp;copy;'
-                    }
-                }
-            }
-        }
-    ];
+// test('buildCommentViewModels decodes HTML entities once', () => {
+//     const items = [
+//         {
+//             item: {
+//                 commentRenderer: {
+//                     authorText: { simpleText: 'Author' },
+//                     contentText: {
+//                         simpleText: '&amp;gt; Hello &amp;copy;'
+//                     }
+//                 }
+//             }
+//         }
+//     ];
 
-    const [model] = buildCommentViewModels(items);
-    assert.equal(model !== undefined, true, 'expected a comment model');
-    assert.equal(model.contentHtml, '&gt; Hello &copy;');
-});
+//     const [model] = buildCommentViewModels(items);
+//     assert.equal(model !== undefined, true, 'expected a comment model');
+//     assert.equal(model.contentHtml, '&gt; Hello &copy;');
+// });
 
-test('buildCommentViewModels escape unexpected tags but keeps anchors', () => {
-    const items = [
-        {
-            item: {
-                commentRenderer: {
-                    authorText: { simpleText: 'Author' },
-                    contentText: {
-                        renderFullText: '<test>unsafe</test><a href="/watch?v=1">link</a>'
-                    }
-                }
-            }
-        }
-    ];
+// test('buildCommentViewModels escape unexpected tags but keeps anchors', () => {
+//     const runs = [
+//         {text: '<test>unsafe</test><a href="/watch?v=1">link</a>' }
+//     ]
+    
+//     const formattedCommentContent = formatCommentRuns(runs, '123');
+//     const renderFullText = formattedCommentContent.renderFullText;
 
-    const [model] = buildCommentViewModels(items);
-    assert.equal(model !== undefined, true, 'expected a comment model');
-    assert.equal(
-        model?.contentHtml,
-        '&lt;test&gt;unsafe&lt;/test&gt;<a href="https://www.youtube.com/watch?v=1" rel="noopener noreferrer">link</a>'
-    );
-});
+//     assert.equal(formattedCommentContent !== undefined, true, 'expected a FormattedCommentContent');
+//     assert.equal(
+//         renderFullText,
+//         '&lt;test&gt;unsafe&lt;/test&gt;<a href="https://www.youtube.com/watch?v=1" rel="noopener noreferrer">link</a>'
+//     );
+// });
 
-test('buildChatMessageViewModels decodes run text HTML entities once', () => {
-    const items = [
-        {
-            item: {
-                replayChatItemAction: {
-                    actions: [
-                        {
-                            addChatItemAction: {
-                                item: {
-                                    liveChatTextMessageRenderer: {
-                                        message: {
-                                            runs: [{ text: '&amp;gt; Wow' }]
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
-        }
-    ];
+// test('buildChatMessageViewModels decodes run text HTML entities once', () => {
+//     const items = [
+//         {
+//             item: {
+//                 replayChatItemAction: {
+//                     actions: [
+//                         {
+//                             addChatItemAction: {
+//                                 item: {
+//                                     liveChatTextMessageRenderer: {
+//                                         message: {
+//                                             runs: [{ text: '&amp;gt; Wow' }]
+//                                         }
+//                                     }
+//                                 }
+//                             }
+//                         }
+//                     ]
+//                 }
+//             }
+//         }
+//     ];
 
-    const [model] = buildChatMessageViewModels(items);
-    assert.equal(model !== undefined, true, 'expected a chat model');
-    assert.equal(model.messageHtml, '&gt; Wow');
-});
+//     const [model] = buildChatMessageViewModels(items);
+//     assert.equal(model !== undefined, true, 'expected a chat model');
+//     assert.equal(model.messageHtml, '&gt; Wow');
+// });
 
 test('buildCommentViewModels extracts heartTooltip from creatorHeart.tooltip', () => {
     const items = [

--- a/app/tests/youtubeDataApi.test.ts
+++ b/app/tests/youtubeDataApi.test.ts
@@ -1,0 +1,120 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { transformThreadToCommentItems } from '../src/source/utils/youtubeDataApi/transform';
+
+// Helper to create a mock YouTube API comment thread
+function createMockThread(textDisplay: string, textOriginal?: string) {
+    return {
+        id: 'thread123',
+        snippet: {
+            topLevelComment: {
+                id: 'comment123',
+                snippet: {
+                    textOriginal: textOriginal || textDisplay,
+                    textDisplay: textDisplay,
+                    authorDisplayName: 'Test User',
+                    authorProfileImageUrl: 'https://example.com/avatar.jpg',
+                    authorChannelUrl: 'https://www.youtube.com/channel/UC123',
+                    likeCount: 0,
+                    publishedAt: '2024-01-01T00:00:00Z',
+                    updatedAt: '2024-01-01T00:00:00Z'
+                }
+            },
+            totalReplyCount: 0
+        }
+    };
+}
+
+// ============================================================================
+// YouTube Data API Transform XSS Security Tests
+// ============================================================================
+
+test('transformThreadToCommentItems: XSS - script tag in comment text should be stripped or encoded', () => {
+    const thread = createMockThread("<script>alert('XSS')</script>");
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    assert.ok(items.length > 0, 'Should return at least one item');
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    // YouTube Data API strips HTML tags, so <script> is removed
+    // The remaining text content is then encoded
+    assert.ok(!renderFullText.includes('<script>'), 'Raw script tag should not appear');
+    assert.ok(!renderFullText.includes('</script>'), 'Raw closing script tag should not appear');
+});
+
+test('transformThreadToCommentItems: XSS - HTML injection in comment should be stripped or encoded', () => {
+    const thread = createMockThread('<img onerror="alert(1)" src="x">');
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    // YouTube Data API strips HTML tags
+    assert.ok(!renderFullText.includes('<img'), 'Raw img tag should not appear');
+    assert.ok(!renderFullText.includes('onerror='), 'Event handler should not appear');
+});
+
+test('transformThreadToCommentItems: XSS - javascript URL in link should be blocked', () => {
+    // Simulating a comment with a link that has javascript: protocol
+    const thread = createMockThread('<a href="javascript:alert(1)">Click here</a>');
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    // The javascript: URL should either be blocked or the entire anchor should be encoded
+    assert.ok(
+        !renderFullText.includes('href="javascript:') || renderFullText.includes('&lt;a'),
+        'javascript: URL should not appear in executable form'
+    );
+});
+
+test('transformThreadToCommentItems: valid timestamp should create link', () => {
+    // Text with inline timestamp pattern
+    const thread = createMockThread('Check out 1:30 for the best part');
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    // Should contain timestamp link with data-offsetvideo attribute
+    assert.ok(
+        renderFullText.includes('data-offsetvideo="90"') || renderFullText.includes('1:30'),
+        'Timestamp should be processed'
+    );
+});
+
+test('transformThreadToCommentItems: valid external link should be preserved', () => {
+    const thread = createMockThread(
+        'Visit <a href="https://example.com">https://example.com</a>',
+        'Visit https://example.com'
+    );
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    // Valid https URL should be preserved
+    assert.ok(
+        renderFullText.includes('https://example.com') ||
+            renderFullText.includes('href="https://example.com"'),
+        'Valid https URL should be preserved'
+    );
+});
+
+test('transformThreadToCommentItems: special characters in text should be encoded', () => {
+    const thread = createMockThread('Test & compare < > "quotes"');
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    // After encoding, angle brackets should be safe
+    assert.ok(!renderFullText.includes(' < ') || renderFullText.includes('&lt;'), 'Less than should be encoded');
+    assert.ok(!renderFullText.includes(' > ') || renderFullText.includes('&gt;'), 'Greater than should be encoded');
+});
+
+test('transformThreadToCommentItems: plain text without special chars should work', () => {
+    const thread = createMockThread('This is a normal comment');
+    const items = transformThreadToCommentItems(thread as any, 'video123');
+
+    const renderFullText = items[0].commentRenderer?.contentText?.renderFullText || '';
+
+    assert.ok(renderFullText.includes('This is a normal comment'), 'Plain text should be preserved');
+});


### PR DESCRIPTION
Hi, this is a pretty important issue so I hope this gets resolved as soon as possible.

While I was experimenting with the extension, I noticed that there was an edge case in your html sanitation where you could inject malicious code in a comment by having an href without quotes:
`<a href=javascript:alert('XSS')>0‎‎:‎30</a>`
<img width="360" height="103" alt="image" src="https://github.com/user-attachments/assets/9af5918b-8f47-41c1-ad29-49e76aa7f8ab" />
<img width="490" height="68" alt="image" src="https://github.com/user-attachments/assets/9c9aef0e-eba3-49a7-80e2-5bc6fa6d4458" />
<img width="434" height="134" alt="image" src="https://github.com/user-attachments/assets/bfb16b71-1f4b-4edc-9204-c30a619404d9" />

My proposed solution to this is relatively straight forward:

- In `formatCommentRuns`, you already are extracting the runs to seperate text, links, and timestamps
- We obviously want to make sure to properly properly links and timestamps so instead of just sanitizing the full YCS comment html, we just need to sanitize the actual comment text. This is because we know that the YCS link and timestamp html we create are safe.
- I used the encode function from the html-libraries library you are already using to convert the text into literal text. This essentially sanitizes the text in the comments (to be extra safe we could use an actual html sanitization library like DOMPurify). 
- This also solves the issue of comments that have html code being displayed incorrectly in YCS 

In the below example, you can see an image icon, now with my proposed changes, the img tag comment is safely shown.
<img width="843" height="254" alt="image" src="https://github.com/user-attachments/assets/1777c07d-a568-49c7-9b1c-ecc36ddcf462" />
<img width="844" height="271" alt="image" src="https://github.com/user-attachments/assets/313024e4-b5c9-4994-a7ab-cda4c4ded353" />

This will make searching for comments about web dev easier for users. I have included some extra test cases and commented out two since they don't work properly with the new implementation. 

I'm not 100% sure of what `fallbackText` is supposed to be so I just sanitized/encoded it just to be safe. I also fixed an issue where links would be hyperlinked to youtube.comhttps://google.com instead of the actual url by changing the canoncialURL to just be the url.

Feel free to make any edits or comment anything notable while testing, I haven't really tested livestream chats or community posts that much.