### PR TITLE
feat(innertube): add age-restricted video support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,22 +343,41 @@ YouTube's comment system uses an Entity-driven architecture where nested replies
 
 **Documentation**: See `app/docs/innertube-nested-comments.md` for detailed architecture analysis and migration guide.
 
-### Member-Only Video Detection and Authorization Strategy
+### Member-Only and Age-Restricted Video Detection and Authorization Strategy
 
-The extension uses a conservative strategy for sending Authorization headers to minimize request size:
+The extension uses a **tiered strategy** for sending Authorization headers:
 
-- **Detection**: Member-only status is determined by fetching `ytInitialData` via PBJ request (`pbj=1` parameter) and checking for membership badges
-- **Authorization header decision**: 
-  - `isMemberOnly = true` → Send Authorization header (confirmed member-only video)
-  - `isMemberOnly = false` → Do not send Authorization header (confirmed non-member video)
-  - `isMemberOnly = undefined` → Do not send Authorization header (detection failed, conservative fallback)
-- **Design rationale**:
-  - PBJ request failure rate is near zero, so detection failures are extremely rare
-  - Sending Authorization header increases request size by 3-4x, which is costly for the majority of non-member videos
-  - Member-only videos are a small subset, and the combination of member-only + PBJ failure is extremely unlikely
-  - This trade-off prioritizes cost efficiency over handling edge cases
-- **Scope**: This strategy currently applies **only to comments requests**. Chat and transcript requests always send Authorization headers when available, as their request size remains nearly the same regardless of the header presence
-- **Implementation**: See `utils/innertube/memberOnly.ts` for detection logic and `utils/innertube/comments/pipeline.ts` for `ensureMemberOnlyStatus()` function
+**Detection Logic**:
+- **Member-only**: Determined by fetching `ytInitialData` via PBJ request (`pbj=1` parameter) and checking for membership badges
+- **Age-restricted**: Determined by `playabilityStatus.status === 'LOGIN_REQUIRED'`
+  - Note: This broadly treats login-required content as age-restricted to maximize success rate
+
+**Authorization Header Decision** (for comment requests):
+
+| Condition | Action |
+|-----------|--------|
+| `isMemberOnly = true` | Send Authorization header |
+| `isAgeRestricted = true` | Send Authorization header |
+| Both `false` | Do not send Authorization header |
+| Detection failed (`undefined`) | Do not send (conservative fallback) |
+
+**PBJ/HTML Fallback Requests**:
+- **Always send Authorization header** (if available) to ensure age-restricted videos can retrieve initial data
+- This differs from the conservative comment-only strategy but is necessary for restricted content detection
+
+**Design Rationale**:
+- PBJ request failure rate is near zero, so detection failures are extremely rare
+- Sending Authorization header increases request size by 3-4x, which is costly for the majority of non-member videos
+- Age-restricted videos require Auth in initial PBJ request to get valid `ytInitialData`
+- Treating `LOGIN_REQUIRED` broadly as age-restricted prioritizes success rate over precision
+- The trade-off: slightly larger request size for fallback requests, but ensures restricted content works
+
+**Scope**:
+- **Comment requests**: Tiered strategy based on detection results (member-only or age-restricted)
+- **PBJ/HTML Fallback requests**: Always send Auth to support restricted content detection
+- **Chat and transcript requests**: Always send Auth (request size impact is minimal)
+
+**Implementation**: See `utils/innertube/memberOnly.ts` for detection logic and `utils/innertube/comments/pipeline.ts` for `ensureMemberOnlyStatus()` function
 
 ### ytInitialData Format Handling
 

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -22,7 +22,13 @@ export {
     clearCurrentVideoMemberOnly,
     normalizeYtInitialData,
     updateMemberOnlyStatus,
-    shouldDisableAuth
+    shouldDisableAuth,
+    // Age-restricted video support
+    isAgeRestrictedFromYtInitialData,
+    isCurrentVideoAgeRestricted,
+    setCurrentVideoAgeRestricted,
+    clearCurrentVideoAgeRestricted,
+    updateAgeRestrictedStatus
 } from './innertube/memberOnly';
 
 // YouTube Data API v3 (alternative to Innertube)

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -9,7 +9,9 @@ import { buildInnertubeBody, buildInnertubeHeaders } from '../request';
 import { getInnertubeApiKey, getInitYtData, getInitYtDataFromHtml, getPageCfgData } from '../core';
 import {
     clearCurrentVideoMemberOnly,
+    clearCurrentVideoAgeRestricted,
     updateMemberOnlyStatus,
+    updateAgeRestrictedStatus,
     shouldDisableAuth,
     isPostMemberOnlyFromYtInitialData,
     setCurrentVideoMemberOnly
@@ -1563,6 +1565,7 @@ function validateCachedYtData(currentVideoId: string): boolean {
         console.log(`[YCS] VideoId mismatch (stored: ${storedVideoId}, current: ${currentVideoId}), clearing cache`);
         (GlobalStore as any).getInitYtData = undefined;
         clearCurrentVideoMemberOnly();
+        clearCurrentVideoAgeRestricted();
         return false;
     }
 
@@ -1593,6 +1596,7 @@ async function ensureMemberOnlyStatus(
     if (validateCachedYtData(currentVideoId)) {
         const ytData = (GlobalStore as any).getInitYtData;
         updateMemberOnlyStatus(ytData);
+        updateAgeRestrictedStatus(ytData);
         return;
     }
 
@@ -1812,9 +1816,9 @@ async function fetchCommentPage(
             );
 
             const findPtrn = [
-                '**.sortMenu.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.clickTrackingParams',
-                '**.sortMenu.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.command.clickTrackingParams',
-                '**.sortMenu.sortFilterSubMenuRenderer.subMenuItems[?].trackingParams'
+                '**.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.clickTrackingParams',
+                '**.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.command.clickTrackingParams',
+                '**.sortFilterSubMenuRenderer.subMenuItems[?].trackingParams'
             ];
 
             let tokenComments;
@@ -1835,10 +1839,11 @@ async function fetchCommentPage(
 
             // Try to get token from detailsCmntsVIDV2 first
             let continuationToken = wrapTryCatch(() =>
-                objectScan(
-                    ['**.sortMenu.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.token'],
-                    { joined: true, rtn: 'value', abort: true }
-                )(detailsCmntsVIDV2)
+                objectScan(['**.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.token'], {
+                    joined: true,
+                    rtn: 'value',
+                    abort: true
+                })(detailsCmntsVIDV2)
             ) as string | undefined;
 
             if (continuationToken) {
@@ -1862,14 +1867,16 @@ async function fetchCommentPage(
                         ? globalYtData.find((item: any) => item?.response || item?.contents)
                         : globalYtData;
 
-                    const hasSortMenu = wrapTryCatch(() =>
-                        objectScan(['**.sortMenu'], { joined: true, rtn: 'value', abort: true })(ytDataSource)
+                    const hasSortFilterMenu = wrapTryCatch(() =>
+                        objectScan(['**.sortFilterSubMenuRenderer'], { joined: true, rtn: 'value', abort: true })(
+                            ytDataSource
+                        )
                     );
 
-                    if (!hasSortMenu) {
+                    if (!hasSortFilterMenu) {
                         needsFetch = true;
                         console.log(
-                            `[YCS] 📥 GlobalStore.getInitYtData exists but lacks sortMenu data (likely from cache restore), will refetch for video: ${currentVideoId}`
+                            `[YCS] 📥 GlobalStore.getInitYtData exists but lacks sortFilterSubMenuRenderer data (likely from cache restore), will refetch for video: ${currentVideoId}`
                         );
                     }
 
@@ -1917,9 +1924,7 @@ async function fetchCommentPage(
 
                     continuationToken = wrapTryCatch(() =>
                         objectScan(
-                            [
-                                '**.sortMenu.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.token'
-                            ],
+                            ['**.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.token'],
                             { joined: true, rtn: 'value', abort: true }
                         )(ytDataSource)
                     ) as string | undefined;
@@ -1940,8 +1945,49 @@ async function fetchCommentPage(
                     );
                 }
 
+                // Try HTML fallback for age-restricted videos when PBJ API fails
                 if (!continuationToken) {
-                    console.error(`[YCS] ✗ Both token sources failed for video: ${currentVideoId}`);
+                    console.log(`[YCS] 📥 Attempting HTML fallback for video: ${currentVideoId}`);
+
+                    try {
+                        const htmlYtData = await getInitYtDataFromHtml(
+                            windowRef.location.href,
+                            signal as AbortSignal,
+                            windowRef
+                        );
+
+                        if (htmlYtData) {
+                            // Note: getInitYtDataFromHtml already updates age-restricted status via updateAgeRestrictedStatus()
+                            // So we don't need to call isAgeRestrictedFromYtInitialData here again
+
+                            const ytDataSource = (htmlYtData as any).response || htmlYtData;
+
+                            continuationToken = wrapTryCatch(() =>
+                                objectScan(
+                                    [
+                                        '**.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.continuationCommand.token'
+                                    ],
+                                    { joined: true, rtn: 'value', abort: true }
+                                )(ytDataSource)
+                            ) as string | undefined;
+
+                            if (continuationToken) {
+                                console.log(
+                                    `[YCS] ✓ Got continuation token from HTML fallback for video: ${currentVideoId}`
+                                );
+                            } else {
+                                console.warn(
+                                    `[YCS] ⚠️ HTML fallback retrieved ytInitialData but no continuation token for video: ${currentVideoId}`
+                                );
+                            }
+                        }
+                    } catch (error) {
+                        console.error(`[YCS] ✗ HTML fallback failed for video: ${currentVideoId}`, error);
+                    }
+                }
+
+                if (!continuationToken) {
+                    console.error(`[YCS] ✗ All token sources failed for video: ${currentVideoId}`);
                 }
             }
 
@@ -1960,9 +2006,7 @@ async function fetchCommentPage(
 
                     clickTrackingParams = wrapTryCatch(() =>
                         objectScan(
-                            [
-                                '**.sortMenu.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.clickTrackingParams'
-                            ],
+                            ['**.sortFilterSubMenuRenderer.subMenuItems[?].serviceEndpoint.clickTrackingParams'],
                             { joined: true, rtn: 'value', abort: true }
                         )(ytDataSource)
                     );

--- a/app/src/source/utils/innertube/core.ts
+++ b/app/src/source/utils/innertube/core.ts
@@ -1,6 +1,7 @@
 import type { GetParams, InnertubeRequestParams } from '../interfaces/i_assist';
 import { GlobalStore, getCleanUrlVideo, getVideoId, getPostId } from '../common';
-import { updateMemberOnlyStatus } from './memberOnly';
+import { updateMemberOnlyStatus, updateAgeRestrictedStatus } from './memberOnly';
+import { buildSapSidAuthorizationHeader } from './authHeaders';
 import type { YtcfgData } from './request';
 
 export interface PageCfgData extends YtcfgData {
@@ -116,6 +117,12 @@ export async function getParams(globalContext: Window & typeof globalThis, signa
         'x-youtube-variants-checksum': (ytcfgData as any)?.VARIANTS_CHECKSUM
     };
 
+    // Generate authorization header for PBJ and HTML fallback requests
+    const authHeader = buildSapSidAuthorizationHeader({ context: globalContext });
+    if (authHeader) {
+        headers.authorization = authHeader;
+    }
+
     const params: InnertubeRequestParams = {
         credentials: 'include',
         headers,
@@ -186,9 +193,10 @@ export async function getInitYtData(
         const result = (await res.json()) as object;
         (GlobalStore as any).getInitYtData = result;
 
-        // Update members-only status
-        console.log('[YCS] [Core] getInitYtData: Updating members-only status from ytInitialData');
+        // Update members-only and age-restricted status
+        console.log('[YCS] [Core] getInitYtData: Updating members-only and age-restricted status from ytInitialData');
         updateMemberOnlyStatus(result);
+        updateAgeRestrictedStatus(result);
 
         return result;
     } catch (e) {
@@ -289,9 +297,12 @@ export async function getInitYtDataFromHtml(
             const result = JSON.parse(jsonStr) as [object];
             (GlobalStore as any).getInitYtData = result;
 
-            // Update members-only status
-            console.log('[YCS] [Core] getInitYtDataFromHtml: Updating members-only status from ytInitialData');
+            // Update members-only and age-restricted status
+            console.log(
+                '[YCS] [Core] getInitYtDataFromHtml: Updating members-only and age-restricted status from ytInitialData'
+            );
             updateMemberOnlyStatus(result);
+            updateAgeRestrictedStatus(result);
 
             return { response: result };
         } catch (parseError) {

--- a/app/src/source/utils/innertube/memberOnly.ts
+++ b/app/src/source/utils/innertube/memberOnly.ts
@@ -197,6 +197,103 @@ export function clearCurrentVideoMemberOnly(): void {
     }
 }
 
+// ============================================================================
+// Age-Restricted Video Detection
+// ============================================================================
+
+/**
+ * Determines if the current video is age-restricted based on ytInitialData
+ *
+ * Age restriction is detected via:
+ * 1. playerResponse.playabilityStatus.status === 'LOGIN_REQUIRED'
+ * 2. playerResponse.playabilityStatus.reason containing age-related keywords
+ *
+ * @param ytInitialData - The ytInitialData object from YouTube page
+ * @returns true if the video is age-restricted, false otherwise
+ */
+export function isAgeRestrictedFromYtInitialData(ytInitialData: unknown): boolean {
+    try {
+        if (!ytInitialData || typeof ytInitialData !== 'object') {
+            return false;
+        }
+
+        const normalized = normalizeYtInitialData(ytInitialData);
+        if (!normalized) {
+            return false;
+        }
+
+        // Check playerResponse.playabilityStatus.status
+        const playabilityStatus = objectScan(['**.playerResponse.playabilityStatus.status'], {
+            rtn: 'value',
+            abort: true
+        })(normalized);
+
+        if (playabilityStatus === 'LOGIN_REQUIRED') {
+            console.log('[YCS] [AgeRestricted] ✓ AGE-RESTRICTED (LOGIN_REQUIRED status)');
+            return true;
+        }
+
+        // Check for age gate reason
+        const reason = objectScan(['**.playerResponse.playabilityStatus.reason'], {
+            rtn: 'value',
+            abort: true
+        })(normalized) as string | undefined;
+
+        if (reason && typeof reason === 'string') {
+            const lowerReason = reason.toLowerCase();
+            if (lowerReason.includes('age') || lowerReason.includes('confirm your age')) {
+                console.log('[YCS] [AgeRestricted] ✓ AGE-RESTRICTED (age gate reason found)');
+                return true;
+            }
+        }
+
+        return false;
+    } catch (error) {
+        console.error('[YCS] [AgeRestricted] Failed to parse age-restricted status from ytInitialData:', error);
+        return false;
+    }
+}
+
+/**
+ * Sets the current video's age-restricted status in GlobalStore
+ */
+export function setCurrentVideoAgeRestricted(isAgeRestricted: boolean): void {
+    try {
+        (GlobalStore as any).isAgeRestricted = isAgeRestricted;
+        console.log(
+            `[YCS] [AgeRestricted] setCurrentVideoAgeRestricted: ${isAgeRestricted ? 'true (AGE-RESTRICTED)' : 'false (NOT age-restricted)'}`
+        );
+    } catch (error) {
+        console.error('[YCS] [AgeRestricted] Failed to set current video age-restricted status:', error);
+    }
+}
+
+/**
+ * Gets the current video's age-restricted status from GlobalStore
+ *
+ * @returns true if current video is age-restricted, false otherwise
+ */
+export function isCurrentVideoAgeRestricted(): boolean {
+    try {
+        const status = (GlobalStore as any).isAgeRestricted;
+        return status === true;
+    } catch (error) {
+        console.error('[YCS] [AgeRestricted] Failed to get current video age-restricted status:', error);
+        return false;
+    }
+}
+
+/**
+ * Clears the current video's age-restricted status from GlobalStore
+ */
+export function clearCurrentVideoAgeRestricted(): void {
+    try {
+        delete (GlobalStore as any).isAgeRestricted;
+    } catch (error) {
+        console.error('[YCS] [AgeRestricted] Failed to clear current video age-restricted status:', error);
+    }
+}
+
 /**
  * Normalizes ytInitialData to handle both modern PBJ and legacy formats
  *
@@ -251,12 +348,28 @@ export function updateMemberOnlyStatus(ytData: any): boolean {
 }
 
 /**
+ * Updates age-restricted status from ytInitialData
+ * Should be called alongside updateMemberOnlyStatus when fetching ytInitialData
+ *
+ * @param ytData - Raw ytInitialData from API responses
+ * @returns The determined age-restricted status
+ */
+export function updateAgeRestrictedStatus(ytData: any): boolean {
+    const isAgeRestricted = isAgeRestrictedFromYtInitialData(ytData);
+    setCurrentVideoAgeRestricted(isAgeRestricted);
+    return isAgeRestricted;
+}
+
+/**
  * Determines whether to disable Authorization header
- * Conservative strategy: only send auth if CERTAIN it's members-only
+ * Conservative strategy: only send auth if CERTAIN it's members-only or age-restricted
  *
  * @returns true if auth should be disabled, false if auth should be sent
  */
 export function shouldDisableAuth(): boolean {
-    const status = (GlobalStore as any).isMemberOnly;
-    return status !== true;
+    const memberOnly = (GlobalStore as any).isMemberOnly;
+    const ageRestricted = (GlobalStore as any).isAgeRestricted;
+
+    // Send auth for member-only OR age-restricted videos
+    return memberOnly !== true && ageRestricted !== true;
 }

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -18,7 +18,12 @@ import {
     removeNodeList,
     showLoadComments
 } from '../utils/dom';
-import { getAllCommentsModeV2, getChatComments, clearCurrentVideoMemberOnly } from '../utils/innertube';
+import {
+    getAllCommentsModeV2,
+    getChatComments,
+    clearCurrentVideoMemberOnly,
+    clearCurrentVideoAgeRestricted
+} from '../utils/innertube';
 
 import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
 import type { ChatItem, CommentItem } from '../utils/interfaces/i_types';
@@ -250,6 +255,7 @@ export function initApp(): void {
         // Clear GlobalStore to prevent data leakage across videos
         delete GlobalStore.getInitYtData;
         clearCurrentVideoMemberOnly(); // Clear members-only status when switching videos
+        clearCurrentVideoAgeRestricted(); // Clear age-restricted status when switching videos
 
         // Clear search caches whenever we switch videos or reinitialize.
         try {


### PR DESCRIPTION
## Summary

Ref: #123

This PR adds support for age-restricted videos by detecting `LOGIN_REQUIRED` playability status and extending the authorization header strategy to include these videos. The extension now sends Authorization headers for both member-only and age-restricted content, while maintaining the conservative approach for regular videos to minimize request size.

## Main Changes

**Age-Restricted Video Detection**

- Added `isAgeRestrictedFromYtInitialData()` function to detect age-restricted videos via `playabilityStatus.status === 'LOGIN_REQUIRED'` or age-related keywords in the reason field
- Added `GlobalStore` state management functions: `setCurrentVideoAgeRestricted()`, `isCurrentVideoAgeRestricted()`, `clearCurrentVideoAgeRestricted()`
- Added `updateAgeRestrictedStatus()` to update status alongside member-only detection

**Authorization Strategy Update**

- Modified `shouldDisableAuth()` to send Authorization headers for both member-only (`isMemberOnly === true`) AND age-restricted (`isAgeRestricted === true`) videos
- Updated `getParams()` in core module to always include Authorization header for PBJ and HTML fallback requests, ensuring age-restricted content can be properly detected

**Comment Pipeline Improvements**

- Added HTML fallback mechanism in `fetchCommentPage()` when PBJ API fails to retrieve continuation token
- Changed `objectScan` patterns from `**.sortMenu.sortFilterSubMenuRenderer` to `**.sortFilterSubMenuRenderer` for broader compatibility (age-restricted videos use `menu.sortFilterSubMenuRenderer` instead of `sortMenu.sortFilterSubMenuRenderer`, so the scan scope was pushed down one level to match both formats)
- Added `clearCurrentVideoAgeRestricted()` calls in video switching and cache validation logic

