### PR TITLE
refactor(innertube): consolidate access restriction status updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,7 +377,7 @@ The extension uses a **tiered strategy** for sending Authorization headers:
 - **PBJ/HTML Fallback requests**: Always send Auth to support restricted content detection
 - **Chat and transcript requests**: Always send Auth (request size impact is minimal)
 
-**Implementation**: See `utils/innertube/memberOnly.ts` for detection logic and `utils/innertube/comments/pipeline.ts` for `ensureMemberOnlyStatus()` function
+**Implementation**: See `utils/innertube/memberOnly.ts` for detection logic (`updateAccessRestrictionStatus()` for unified status updates) and `utils/innertube/comments/pipeline.ts` for `ensureMemberOnlyStatus()` function
 
 ### ytInitialData Format Handling
 

--- a/app/docs/adaptive-authorization-headers.md
+++ b/app/docs/adaptive-authorization-headers.md
@@ -46,7 +46,7 @@ export function isMemberOnlyFromYtInitialData(ytInitialData: unknown): boolean
 
 Member-only status is stored in `GlobalStore.isMemberOnly` for the current video session.
 
-**Implementation**: `utils/innertube/memberOnly.ts:121-161`
+**Implementation**: `utils/innertube/memberOnly.ts`
 
 ```typescript
 // Set status
@@ -62,19 +62,19 @@ export function clearCurrentVideoMemberOnly(): void
 **State Initialization** (Three Mechanisms):
 
 1. **Automatic Update** (Primary):
-   - When `getInitYtData()` fetches `ytInitialData` via PBJ request (`utils/innertube/core.ts:181`)
-   - When `getInitYtDataFromHtml()` parses `ytInitialData` from HTML (`utils/innertube/core.ts:284`)
-   - Status is automatically updated via `updateMemberOnlyStatus()` after data retrieval
+   - When `getInitYtData()` fetches `ytInitialData` via PBJ request (`utils/innertube/core.ts`)
+   - When `getInitYtDataFromHtml()` parses `ytInitialData` from HTML (`utils/innertube/core.ts`)
+   - Status is automatically updated via `updateAccessRestrictionStatus()` after data retrieval, which atomically updates both `isMemberOnly` and `isAgeRestricted`
 
 2. **Lazy Initialization** (On-Demand):
-   - `ensureMemberOnlyStatus()` function ensures status is set before comment requests (`utils/innertube/comments/pipeline.ts:1226-1254`)
+   - `ensureMemberOnlyStatus()` function ensures status is set before comment requests (`utils/innertube/comments/pipeline.ts`)
    - First checks if status is already set (early return if `isMemberOnly !== undefined`)
    - Tries cached `ytData` first via `validateCachedYtData()`
    - Only fetches new data if cache is invalid or missing
 
 3. **Fallback Check** (Request-Time):
-   - `getParamsForComments()` checks and updates status if undefined (`utils/innertube/comments/pipeline.ts:1354-1366`)
-   - `fetchCommentPage()` ensures status before building request params (`utils/innertube/comments/pipeline.ts:1630-1635`)
+   - `getParamsForComments()` checks and updates status if undefined (`utils/innertube/comments/pipeline.ts`)
+   - `fetchCommentPage()` ensures status before building request params (`utils/innertube/comments/pipeline.ts`)
    - Uses conservative strategy (no auth header) if `ytInitialData` is unavailable
 
 **State Lifecycle**:
@@ -88,9 +88,9 @@ export function clearCurrentVideoMemberOnly(): void
   - Before building request headers for comment API calls via `shouldDisableAuth()`
   - Decision logic: `status !== true` → disable auth header (conservative strategy)
   
-- **Cleared**: 
-  - **Primary**: When user navigates to a different video (`web-resources/appController.ts:283`)
-  - **Secondary**: When `validateCachedYtData()` detects videoId mismatch (`utils/innertube/comments/pipeline.ts:1211`)
+- **Cleared**:
+  - **Primary**: When user navigates to a different video (`web-resources/appController.ts`)
+  - **Secondary**: When `validateCachedYtData()` detects videoId mismatch (`utils/innertube/comments/pipeline.ts`)
 
 **State Validation**:
 
@@ -111,27 +111,30 @@ The system prevents state pollution across videos through `validateCachedYtData(
 
 ### 3. Authorization Decision
 
-The decision logic uses a **conservative strategy**: only send authorization when certain the video is member-only.
+The decision logic uses a **conservative strategy**: only send authorization when certain the video is member-only or age-restricted.
 
-**Implementation**: `utils/innertube/memberOnly.ts:222-225`
+**Implementation**: `utils/innertube/memberOnly.ts`
 
 ```typescript
 export function shouldDisableAuth(): boolean {
-    const status = (GlobalStore as any).isMemberOnly;
-    return status !== true; // Disable unless explicitly true
+    const memberOnly = (GlobalStore as any).isMemberOnly;
+    const ageRestricted = (GlobalStore as any).isAgeRestricted;
+
+    // Send auth for member-only OR age-restricted videos
+    return memberOnly !== true && ageRestricted !== true;
 }
 ```
 
 **Decision Logic**:
-- `isMemberOnly === true` → Send authorization (member-only confirmed)
-- `isMemberOnly === false` → Skip authorization (public video)
-- `isMemberOnly === undefined` → Skip authorization (status unknown, use conservative approach)
+- `isMemberOnly === true` OR `isAgeRestricted === true` → Send authorization (restricted content confirmed)
+- Both `false` → Skip authorization (public video)
+- Both `undefined` → Skip authorization (status unknown, use conservative approach)
 
 ### 4. Header Construction
 
 The `buildInnertubeHeaders()` function accepts a `disableAuth` option to control authorization header inclusion.
 
-**Implementation**: `utils/innertube/request.ts:43-76`
+**Implementation**: `utils/innertube/request.ts`
 
 ```typescript
 export function buildInnertubeHeaders(
@@ -142,7 +145,7 @@ export function buildInnertubeHeaders(
 ): Record<string, string>
 ```
 
-**Authorization Logic** (line 60-66):
+**Authorization Logic**:
 ```typescript
 // Generate authorization header if globalContext is provided and disableAuth is not true
 if (globalContext && options?.disableAuth !== true) {
@@ -159,18 +162,18 @@ if (globalContext && options?.disableAuth !== true) {
 
 All comment-related API calls use adaptive authorization:
 
-- `getDetailsVideoIDV2()` (line 1268)
-- `getDetailsCommentsVideoIDV2()` (line 1308)
-- `getParamsForComments()` (line 1368)
-- `getParamsForReplies()` (line 1400)
+- `getDetailsVideoIDV2()`
+- `getDetailsCommentsVideoIDV2()`
+- `getParamsForComments()`
+- `getParamsForReplies()`
 
 **Example** (from `getParamsForComments`):
 ```typescript
-// Update member-only status if not set yet
+// Update access restriction status if not set yet
 if ((GlobalStore as any).isMemberOnly === undefined) {
     const ytData: any = (GlobalStore as any).getInitYtData;
     if (ytData) {
-        updateMemberOnlyStatus(ytData);
+        updateAccessRestrictionStatus(ytData);
     } else {
         console.log(
             "[YCS] [Comments] No ytInitialData available, will use conservative strategy (don't send Authorization to reduce request size)"
@@ -193,11 +196,11 @@ Adaptive authorization is **currently applied only to comment requests**, not to
 - Reply list API
 
 **Chat Requests** (always send auth):
-- Live chat API (`utils/innertube/chat.ts:41`)
-- Chat replay API (`utils/innertube/chat.ts:71`)
+- Live chat API (`utils/innertube/chat.ts`)
+- Chat replay API (`utils/innertube/chat.ts`)
 
 **Transcript Requests** (always send auth):
-- Transcript API (`utils/innertube/transcript.ts:45`)
+- Transcript API (`utils/innertube/transcript.ts`)
 
 ### Rationale
 
@@ -232,7 +235,7 @@ Adaptive authorization could potentially be extended to chat and transcript requ
 
 The system handles multiple `ytInitialData` formats through normalization.
 
-**Implementation**: `utils/innertube/memberOnly.ts:172-192`
+**Implementation**: `utils/innertube/memberOnly.ts`
 
 ```typescript
 export function normalizeYtInitialData(ytData: any): any
@@ -247,7 +250,7 @@ export function normalizeYtInitialData(ytData: any): any
 
 To prevent stale member-only status across video navigation, the system validates cached `ytInitialData` against the current video ID.
 
-**Implementation**: `utils/innertube/comments/pipeline.ts:1195-1216`
+**Implementation**: `utils/innertube/comments/pipeline.ts`
 
 ```typescript
 function validateCachedYtData(currentVideoId: string): boolean

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -10,8 +10,7 @@ import { getInnertubeApiKey, getInitYtData, getInitYtDataFromHtml, getPageCfgDat
 import {
     clearCurrentVideoMemberOnly,
     clearCurrentVideoAgeRestricted,
-    updateMemberOnlyStatus,
-    updateAgeRestrictedStatus,
+    updateAccessRestrictionStatus,
     shouldDisableAuth,
     isPostMemberOnlyFromYtInitialData,
     setCurrentVideoMemberOnly
@@ -1595,17 +1594,13 @@ async function ensureMemberOnlyStatus(
     // Try cached data first
     if (validateCachedYtData(currentVideoId)) {
         const ytData = (GlobalStore as any).getInitYtData;
-        updateMemberOnlyStatus(ytData);
-        updateAgeRestrictedStatus(ytData);
+        updateAccessRestrictionStatus(ytData);
         return;
     }
 
-    // Fetch if needed
+    // Fetch if needed - getInitYtData already calls updateAccessRestrictionStatus internally
     try {
-        const ytData = await getInitYtData(windowRef.location.href, signal as AbortSignal, windowRef);
-        if (ytData) {
-            updateMemberOnlyStatus(ytData);
-        }
+        await getInitYtData(windowRef.location.href, signal as AbortSignal, windowRef);
     } catch (error) {
         console.error('[YCS] Failed to fetch ytInitialData:', error);
     }
@@ -1708,14 +1703,14 @@ async function getParamsForComments(
             clickTrackingParams: clickTrackingParams ?? undefined
         });
 
-        // Update member-only status if not set yet
+        // Update access restriction status if not set yet
         if ((GlobalStore as any).isMemberOnly === undefined) {
             const ytData: any = (GlobalStore as any).getInitYtData;
             if (ytData) {
                 console.log(
-                    '[YCS] [Comments] getParamsForComments: Using GlobalStore.getInitYtData for members-only check'
+                    '[YCS] [Comments] getParamsForComments: Using GlobalStore.getInitYtData for access restriction check'
                 );
-                updateMemberOnlyStatus(ytData);
+                updateAccessRestrictionStatus(ytData);
             } else {
                 console.log(
                     "[YCS] [Comments] getParamsForComments: No ytInitialData available, will use conservative strategy (don't send Authorization to reduce request size)"
@@ -1902,8 +1897,7 @@ async function fetchCommentPage(
                             console.log(
                                 `[YCS] ✓ Successfully fetched and populated GlobalStore.getInitYtData for video: ${currentVideoId}`
                             );
-                            // Status is already updated by getInitYtData
-                            updateMemberOnlyStatus(globalYtData);
+                            // Note: getInitYtData already calls updateAccessRestrictionStatus internally
                         }
                     } catch (error) {
                         console.error(
@@ -1912,8 +1906,8 @@ async function fetchCommentPage(
                         );
                     }
                 } else if (globalYtData) {
-                    // If we're using cached data, ensure members-only status is updated
-                    updateMemberOnlyStatus(globalYtData);
+                    // If we're using cached data, ensure access restriction status is updated
+                    updateAccessRestrictionStatus(globalYtData);
                 }
 
                 if (globalYtData) {
@@ -1957,8 +1951,8 @@ async function fetchCommentPage(
                         );
 
                         if (htmlYtData) {
-                            // Note: getInitYtDataFromHtml already updates age-restricted status via updateAgeRestrictedStatus()
-                            // So we don't need to call isAgeRestrictedFromYtInitialData here again
+                            // Note: getInitYtDataFromHtml already calls updateAccessRestrictionStatus() internally
+                            // So we don't need to update access restriction status here again
 
                             const ytDataSource = (htmlYtData as any).response || htmlYtData;
 
@@ -2024,11 +2018,11 @@ async function fetchCommentPage(
                 console.warn(`[YCS] ⚠️  No clickTrackingParams found for video: ${currentVideoId}`);
             }
 
-            // Ensure members-only status is updated before calling getParamsForComments
+            // Ensure access restriction status is updated before calling getParamsForComments
             if ((GlobalStore as any).isMemberOnly === undefined) {
                 const finalYtData: any = (GlobalStore as any).getInitYtData;
                 if (finalYtData) {
-                    updateMemberOnlyStatus(finalYtData);
+                    updateAccessRestrictionStatus(finalYtData);
                 }
             }
 

--- a/app/src/source/utils/innertube/core.ts
+++ b/app/src/source/utils/innertube/core.ts
@@ -1,6 +1,6 @@
 import type { GetParams, InnertubeRequestParams } from '../interfaces/i_assist';
 import { GlobalStore, getCleanUrlVideo, getVideoId, getPostId } from '../common';
-import { updateMemberOnlyStatus, updateAgeRestrictedStatus } from './memberOnly';
+import { updateAccessRestrictionStatus } from './memberOnly';
 import { buildSapSidAuthorizationHeader } from './authHeaders';
 import type { YtcfgData } from './request';
 
@@ -194,9 +194,8 @@ export async function getInitYtData(
         (GlobalStore as any).getInitYtData = result;
 
         // Update members-only and age-restricted status
-        console.log('[YCS] [Core] getInitYtData: Updating members-only and age-restricted status from ytInitialData');
-        updateMemberOnlyStatus(result);
-        updateAgeRestrictedStatus(result);
+        console.log('[YCS] [Core] getInitYtData: Updating access restriction status from ytInitialData');
+        updateAccessRestrictionStatus(result);
 
         return result;
     } catch (e) {
@@ -298,11 +297,8 @@ export async function getInitYtDataFromHtml(
             (GlobalStore as any).getInitYtData = result;
 
             // Update members-only and age-restricted status
-            console.log(
-                '[YCS] [Core] getInitYtDataFromHtml: Updating members-only and age-restricted status from ytInitialData'
-            );
-            updateMemberOnlyStatus(result);
-            updateAgeRestrictedStatus(result);
+            console.log('[YCS] [Core] getInitYtDataFromHtml: Updating access restriction status from ytInitialData');
+            updateAccessRestrictionStatus(result);
 
             return { response: result };
         } catch (parseError) {

--- a/app/src/source/utils/innertube/memberOnly.ts
+++ b/app/src/source/utils/innertube/memberOnly.ts
@@ -328,6 +328,7 @@ export function normalizeYtInitialData(ytData: any): any {
 /**
  * Updates member-only status from ytInitialData
  * Handles both modern PBJ and legacy formats automatically
+ * Note: Prefer using updateAccessRestrictionStatus() which updates both statuses together
  *
  * @param ytData - Raw ytInitialData from API responses (supports):
  *   - Modern PBJ format (object): `{response: {...}, playerResponse: {...}, ...}` (primary)
@@ -349,7 +350,7 @@ export function updateMemberOnlyStatus(ytData: any): boolean {
 
 /**
  * Updates age-restricted status from ytInitialData
- * Should be called alongside updateMemberOnlyStatus when fetching ytInitialData
+ * Note: Prefer using updateAccessRestrictionStatus() which updates both statuses together
  *
  * @param ytData - Raw ytInitialData from API responses
  * @returns The determined age-restricted status
@@ -358,6 +359,29 @@ export function updateAgeRestrictedStatus(ytData: any): boolean {
     const isAgeRestricted = isAgeRestrictedFromYtInitialData(ytData);
     setCurrentVideoAgeRestricted(isAgeRestricted);
     return isAgeRestricted;
+}
+
+/**
+ * Combined access restriction status result
+ */
+export interface AccessRestrictionStatus {
+    isMemberOnly: boolean;
+    isAgeRestricted: boolean;
+}
+
+/**
+ * Updates both member-only and age-restricted status from ytInitialData
+ * This is the preferred way to update access restriction status as it ensures
+ * both statuses are always updated together.
+ *
+ * @param ytData - Raw ytInitialData from API responses (supports PBJ, legacy array, and object formats)
+ * @returns Object containing both isMemberOnly and isAgeRestricted status
+ */
+export function updateAccessRestrictionStatus(ytData: any): AccessRestrictionStatus {
+    return {
+        isMemberOnly: updateMemberOnlyStatus(ytData),
+        isAgeRestricted: updateAgeRestrictedStatus(ytData)
+    };
 }
 
 /**

--- a/app/tests/fixtures/ytInitialData-age-reason-only.json
+++ b/app/tests/fixtures/ytInitialData-age-reason-only.json
@@ -1,0 +1,17 @@
+{
+  "currentVideoEndpoint": {
+    "watchEndpoint": {
+      "videoId": "age-reason-video-id"
+    }
+  },
+  "playerResponse": {
+    "playabilityStatus": {
+      "status": "UNPLAYABLE",
+      "reason": "This video may be inappropriate for some users. Confirm your age to continue."
+    },
+    "videoDetails": {
+      "videoId": "age-reason-video-id",
+      "title": "Age Restricted by Reason Only"
+    }
+  }
+}

--- a/app/tests/fixtures/ytInitialData-age-restricted-pbj.json
+++ b/app/tests/fixtures/ytInitialData-age-restricted-pbj.json
@@ -1,0 +1,47 @@
+{
+  "response": {
+    "currentVideoEndpoint": {
+      "watchEndpoint": {
+        "videoId": "age-restricted-pbj-video-id"
+      }
+    },
+    "contents": {
+      "twoColumnWatchNextResults": {
+        "results": {
+          "results": {
+            "contents": [
+              {
+                "videoPrimaryInfoRenderer": {
+                  "title": {
+                    "runs": [
+                      {
+                        "text": "Age Restricted Video (PBJ)"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "playerResponse": {
+    "playabilityStatus": {
+      "status": "LOGIN_REQUIRED",
+      "reason": "Sign in to confirm your age",
+      "errorScreen": {
+        "playerErrorMessageRenderer": {
+          "reason": {
+            "simpleText": "Sign in to confirm your age"
+          }
+        }
+      }
+    },
+    "videoDetails": {
+      "videoId": "age-restricted-pbj-video-id",
+      "title": "Age Restricted Video (PBJ)"
+    }
+  }
+}

--- a/app/tests/fixtures/ytInitialData-age-restricted.json
+++ b/app/tests/fixtures/ytInitialData-age-restricted.json
@@ -1,0 +1,24 @@
+{
+  "currentVideoEndpoint": {
+    "watchEndpoint": {
+      "videoId": "age-restricted-video-id"
+    }
+  },
+  "playerResponse": {
+    "playabilityStatus": {
+      "status": "LOGIN_REQUIRED",
+      "reason": "Sign in to confirm your age",
+      "errorScreen": {
+        "playerErrorMessageRenderer": {
+          "reason": {
+            "simpleText": "Sign in to confirm your age"
+          }
+        }
+      }
+    },
+    "videoDetails": {
+      "videoId": "age-restricted-video-id",
+      "title": "Age Restricted Video"
+    }
+  }
+}

--- a/app/tests/fixtures/ytInitialData-non-restricted.json
+++ b/app/tests/fixtures/ytInitialData-non-restricted.json
@@ -1,0 +1,17 @@
+{
+  "currentVideoEndpoint": {
+    "watchEndpoint": {
+      "videoId": "normal-video-id"
+    }
+  },
+  "playerResponse": {
+    "playabilityStatus": {
+      "status": "OK",
+      "playableInEmbed": true
+    },
+    "videoDetails": {
+      "videoId": "normal-video-id",
+      "title": "Normal Video"
+    }
+  }
+}

--- a/app/tests/memberOnly.test.ts
+++ b/app/tests/memberOnly.test.ts
@@ -9,6 +9,7 @@ import {
     normalizeYtInitialData,
     updateMemberOnlyStatus,
     updateAgeRestrictedStatus,
+    updateAccessRestrictionStatus,
     setCurrentVideoMemberOnly,
     setCurrentVideoAgeRestricted,
     clearCurrentVideoMemberOnly,
@@ -339,6 +340,134 @@ describe('setCurrentVideoAgeRestricted / clearCurrentVideoAgeRestricted', () => 
         setCurrentVideoAgeRestricted(true);
         clearCurrentVideoAgeRestricted();
         assert.equal((GlobalStore as any).isAgeRestricted, undefined);
+    });
+});
+
+// ============================================================================
+// Group 4: Unified Access Restriction Status
+// ============================================================================
+
+describe('updateAccessRestrictionStatus', () => {
+    beforeEach(() => {
+        resetGlobalStore();
+    });
+
+    test('updateAccessRestrictionStatus - member-only video sets both statuses', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-member-only-1.json');
+        const result = updateAccessRestrictionStatus(fixture);
+
+        assert.equal(result.isMemberOnly, true, 'Should return isMemberOnly: true');
+        assert.equal(result.isAgeRestricted, false, 'Should return isAgeRestricted: false');
+        assert.equal((GlobalStore as any).isMemberOnly, true, 'Should set GlobalStore.isMemberOnly to true');
+        assert.equal((GlobalStore as any).isAgeRestricted, false, 'Should set GlobalStore.isAgeRestricted to false');
+    });
+
+    test('updateAccessRestrictionStatus - age-restricted video sets both statuses', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-age-restricted.json');
+        const result = updateAccessRestrictionStatus(fixture);
+
+        assert.equal(result.isMemberOnly, false, 'Should return isMemberOnly: false');
+        assert.equal(result.isAgeRestricted, true, 'Should return isAgeRestricted: true');
+        assert.equal((GlobalStore as any).isMemberOnly, false, 'Should set GlobalStore.isMemberOnly to false');
+        assert.equal((GlobalStore as any).isAgeRestricted, true, 'Should set GlobalStore.isAgeRestricted to true');
+    });
+
+    test('updateAccessRestrictionStatus - non-restricted video sets both statuses to false', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-non-member.json');
+        const result = updateAccessRestrictionStatus(fixture);
+
+        assert.equal(result.isMemberOnly, false, 'Should return isMemberOnly: false');
+        assert.equal(result.isAgeRestricted, false, 'Should return isAgeRestricted: false');
+        assert.equal((GlobalStore as any).isMemberOnly, false, 'Should set GlobalStore.isMemberOnly to false');
+        assert.equal((GlobalStore as any).isAgeRestricted, false, 'Should set GlobalStore.isAgeRestricted to false');
+    });
+
+    test('updateAccessRestrictionStatus - PBJ format member-only video', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-pbj-member-only.json');
+        const result = updateAccessRestrictionStatus(fixture);
+
+        assert.equal(result.isMemberOnly, true, 'Should return isMemberOnly: true');
+        assert.equal(result.isAgeRestricted, false, 'Should return isAgeRestricted: false');
+        assert.equal((GlobalStore as any).isMemberOnly, true, 'Should set GlobalStore.isMemberOnly to true');
+    });
+
+    test('updateAccessRestrictionStatus - PBJ format age-restricted video', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-age-restricted-pbj.json');
+        const result = updateAccessRestrictionStatus(fixture);
+
+        assert.equal(result.isMemberOnly, false, 'Should return isMemberOnly: false');
+        assert.equal(result.isAgeRestricted, true, 'Should return isAgeRestricted: true');
+        assert.equal((GlobalStore as any).isAgeRestricted, true, 'Should set GlobalStore.isAgeRestricted to true');
+    });
+
+    test('updateAccessRestrictionStatus - null input sets both to false', () => {
+        resetGlobalStore();
+        const result = updateAccessRestrictionStatus(null);
+
+        assert.equal(result.isMemberOnly, false, 'Should return isMemberOnly: false for null input');
+        assert.equal(result.isAgeRestricted, false, 'Should return isAgeRestricted: false for null input');
+        assert.equal((GlobalStore as any).isMemberOnly, false, 'Should set GlobalStore.isMemberOnly to false');
+        assert.equal((GlobalStore as any).isAgeRestricted, false, 'Should set GlobalStore.isAgeRestricted to false');
+    });
+
+    test('updateAccessRestrictionStatus - undefined input sets both to false', () => {
+        resetGlobalStore();
+        const result = updateAccessRestrictionStatus(undefined);
+
+        assert.equal(result.isMemberOnly, false, 'Should return isMemberOnly: false for undefined input');
+        assert.equal(result.isAgeRestricted, false, 'Should return isAgeRestricted: false for undefined input');
+        assert.equal((GlobalStore as any).isMemberOnly, false, 'Should set GlobalStore.isMemberOnly to false');
+        assert.equal((GlobalStore as any).isAgeRestricted, false, 'Should set GlobalStore.isAgeRestricted to false');
+    });
+
+    test('updateAccessRestrictionStatus - legacy array format member-only video', () => {
+        resetGlobalStore();
+        // Legacy array format: [{response: {...}}, {playerResponse: {...}}]
+        const legacyArrayInput = [
+            {
+                response: {
+                    currentVideoEndpoint: { watchEndpoint: { videoId: 'legacy-test-id' } },
+                    contents: {
+                        twoColumnWatchNextResults: {
+                            results: {
+                                results: {
+                                    contents: [
+                                        {
+                                            videoPrimaryInfoRenderer: {
+                                                badges: [
+                                                    {
+                                                        metadataBadgeRenderer: {
+                                                            style: 'BADGE_STYLE_TYPE_MEMBERS_ONLY'
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                playerResponse: {
+                    playabilityStatus: { status: 'OK' }
+                }
+            }
+        ];
+
+        const result = updateAccessRestrictionStatus(legacyArrayInput);
+
+        assert.equal(result.isMemberOnly, true, 'Should detect member-only from legacy array format');
+        assert.equal(result.isAgeRestricted, false, 'Should not be age-restricted');
+        assert.equal((GlobalStore as any).isMemberOnly, true, 'Should set GlobalStore.isMemberOnly to true');
+        assert.equal((GlobalStore as any).isAgeRestricted, false, 'Should set GlobalStore.isAgeRestricted to false');
     });
 });
 

--- a/app/tests/memberOnly.test.ts
+++ b/app/tests/memberOnly.test.ts
@@ -1,9 +1,21 @@
 import { strict as assert } from 'node:assert';
-import test from 'node:test';
+import test, { beforeEach, describe } from 'node:test';
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isMemberOnlyFromYtInitialData } from '../src/source/utils/innertube/memberOnly';
+import {
+    isMemberOnlyFromYtInitialData,
+    isAgeRestrictedFromYtInitialData,
+    normalizeYtInitialData,
+    updateMemberOnlyStatus,
+    updateAgeRestrictedStatus,
+    setCurrentVideoMemberOnly,
+    setCurrentVideoAgeRestricted,
+    clearCurrentVideoMemberOnly,
+    clearCurrentVideoAgeRestricted,
+    shouldDisableAuth
+} from '../src/source/utils/innertube/memberOnly';
+import { GlobalStore } from '../src/source/utils/common';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -55,5 +67,278 @@ test('isMemberOnlyFromYtInitialData - PBJ format non-member video', () => {
     const fixture = loadFixture('ytInitialData-pbj-non-member.json');
     const result = isMemberOnlyFromYtInitialData(fixture);
     assert.equal(result, false, 'Should return false for non-member video in PBJ format');
+});
+
+// ============================================================================
+// Group 1: Pure Functions - isAgeRestrictedFromYtInitialData
+// ============================================================================
+
+test('isAgeRestrictedFromYtInitialData - LOGIN_REQUIRED status', () => {
+    const fixture = loadFixture('ytInitialData-age-restricted.json');
+    const result = isAgeRestrictedFromYtInitialData(fixture);
+    assert.equal(result, true, 'Should detect age-restricted video with LOGIN_REQUIRED status');
+});
+
+test('isAgeRestrictedFromYtInitialData - PBJ format LOGIN_REQUIRED', () => {
+    const fixture = loadFixture('ytInitialData-age-restricted-pbj.json');
+    const result = isAgeRestrictedFromYtInitialData(fixture);
+    assert.equal(result, true, 'Should detect age-restricted video in PBJ format');
+});
+
+test('isAgeRestrictedFromYtInitialData - age gate reason only', () => {
+    const fixture = loadFixture('ytInitialData-age-reason-only.json');
+    const result = isAgeRestrictedFromYtInitialData(fixture);
+    assert.equal(result, true, 'Should detect age-restricted video by reason containing "age"');
+});
+
+test('isAgeRestrictedFromYtInitialData - non-restricted video', () => {
+    const fixture = loadFixture('ytInitialData-non-restricted.json');
+    const result = isAgeRestrictedFromYtInitialData(fixture);
+    assert.equal(result, false, 'Should return false for non-restricted video');
+});
+
+test('isAgeRestrictedFromYtInitialData - non-member video (not age-restricted)', () => {
+    const fixture = loadFixture('ytInitialData-non-member.json');
+    const result = isAgeRestrictedFromYtInitialData(fixture);
+    assert.equal(result, false, 'Should return false for non-member video (not age-restricted)');
+});
+
+test('isAgeRestrictedFromYtInitialData - invalid input', () => {
+    assert.equal(isAgeRestrictedFromYtInitialData(null), false, 'Should return false for null');
+    assert.equal(isAgeRestrictedFromYtInitialData(undefined), false, 'Should return false for undefined');
+    assert.equal(isAgeRestrictedFromYtInitialData('invalid'), false, 'Should return false for string');
+    assert.equal(isAgeRestrictedFromYtInitialData({}), false, 'Should return false for empty object');
+});
+
+test('isAgeRestrictedFromYtInitialData - status exists but not LOGIN_REQUIRED and no age reason', () => {
+    // Gemini suggestion: ensure no false positives
+    const fixture = {
+        playerResponse: {
+            playabilityStatus: {
+                status: 'UNPLAYABLE',
+                reason: 'Video unavailable'
+            }
+        }
+    };
+    const result = isAgeRestrictedFromYtInitialData(fixture);
+    assert.equal(result, false, 'Should return false when status is not LOGIN_REQUIRED and reason has no age keywords');
+});
+
+// ============================================================================
+// Group 1: Pure Functions - normalizeYtInitialData
+// ============================================================================
+
+test('normalizeYtInitialData - PBJ format (object with response and playerResponse)', () => {
+    const input = {
+        response: { contents: { test: 'data' } },
+        playerResponse: { playabilityStatus: { status: 'OK' } }
+    };
+    const result = normalizeYtInitialData(input);
+    assert.ok(result, 'Should return a result');
+    assert.ok(result.response || result.contents, 'Should preserve structure');
+});
+
+test('normalizeYtInitialData - legacy array format', () => {
+    const input = [{ response: { test: 1 } }, { playerResponse: { test: 2 } }];
+    const result = normalizeYtInitialData(input);
+    assert.ok(result, 'Should return a result');
+    // Array format should be merged
+    assert.ok(result.response || result.playerResponse, 'Should merge array elements');
+});
+
+test('normalizeYtInitialData - already normalized object', () => {
+    const input = { contents: { test: 'data' }, currentVideoEndpoint: {} };
+    const result = normalizeYtInitialData(input);
+    assert.deepEqual(result, input, 'Should return same object if already normalized');
+});
+
+test('normalizeYtInitialData - invalid input', () => {
+    assert.equal(normalizeYtInitialData(null), null, 'Should return null for null input');
+    assert.equal(normalizeYtInitialData(undefined), null, 'Should return null for undefined input (falsy check)');
+    assert.equal(normalizeYtInitialData('string'), 'string', 'Should return string as-is');
+});
+
+// ============================================================================
+// Helper function to reset GlobalStore
+// ============================================================================
+
+function resetGlobalStore(): void {
+    delete (GlobalStore as any).isMemberOnly;
+    delete (GlobalStore as any).isAgeRestricted;
+}
+
+// ============================================================================
+// Group 2: GlobalStore Integration - updateMemberOnlyStatus
+// ============================================================================
+
+describe('updateMemberOnlyStatus', () => {
+    beforeEach(() => {
+        resetGlobalStore();
+    });
+
+    test('updateMemberOnlyStatus - sets GlobalStore.isMemberOnly to true for member-only video', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-member-only-1.json');
+        const result = updateMemberOnlyStatus(fixture);
+
+        assert.equal(result, true, 'Should return true');
+        assert.equal((GlobalStore as any).isMemberOnly, true, 'Should set GlobalStore.isMemberOnly to true');
+    });
+
+    test('updateMemberOnlyStatus - sets GlobalStore.isMemberOnly to false for non-member video', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-non-member.json');
+        const result = updateMemberOnlyStatus(fixture);
+
+        assert.equal(result, false, 'Should return false');
+        assert.equal((GlobalStore as any).isMemberOnly, false, 'Should set GlobalStore.isMemberOnly to false');
+    });
+});
+
+// ============================================================================
+// Group 2: GlobalStore Integration - updateAgeRestrictedStatus
+// ============================================================================
+
+describe('updateAgeRestrictedStatus', () => {
+    beforeEach(() => {
+        resetGlobalStore();
+    });
+
+    test('updateAgeRestrictedStatus - sets GlobalStore.isAgeRestricted to true for age-restricted video', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-age-restricted.json');
+        const result = updateAgeRestrictedStatus(fixture);
+
+        assert.equal(result, true, 'Should return true');
+        assert.equal((GlobalStore as any).isAgeRestricted, true, 'Should set GlobalStore.isAgeRestricted to true');
+    });
+
+    test('updateAgeRestrictedStatus - sets GlobalStore.isAgeRestricted to false for non-restricted video', () => {
+        resetGlobalStore();
+        const fixture = loadFixture('ytInitialData-non-restricted.json');
+        const result = updateAgeRestrictedStatus(fixture);
+
+        assert.equal(result, false, 'Should return false');
+        assert.equal((GlobalStore as any).isAgeRestricted, false, 'Should set GlobalStore.isAgeRestricted to false');
+    });
+});
+
+// ============================================================================
+// Group 2: GlobalStore Integration - shouldDisableAuth (Truth Table)
+// ============================================================================
+
+describe('shouldDisableAuth', () => {
+    beforeEach(() => {
+        resetGlobalStore();
+    });
+
+    test('shouldDisableAuth - returns false when both member-only and age-restricted', () => {
+        resetGlobalStore();
+        (GlobalStore as any).isMemberOnly = true;
+        (GlobalStore as any).isAgeRestricted = true;
+
+        assert.equal(shouldDisableAuth(), false, 'Should NOT disable auth (send auth for restricted)');
+    });
+
+    test('shouldDisableAuth - returns false when member-only only', () => {
+        resetGlobalStore();
+        (GlobalStore as any).isMemberOnly = true;
+        (GlobalStore as any).isAgeRestricted = false;
+
+        assert.equal(shouldDisableAuth(), false, 'Should NOT disable auth (send auth for member-only)');
+    });
+
+    test('shouldDisableAuth - returns false when age-restricted only', () => {
+        resetGlobalStore();
+        (GlobalStore as any).isMemberOnly = false;
+        (GlobalStore as any).isAgeRestricted = true;
+
+        assert.equal(shouldDisableAuth(), false, 'Should NOT disable auth (send auth for age-restricted)');
+    });
+
+    test('shouldDisableAuth - returns true when neither restricted', () => {
+        resetGlobalStore();
+        (GlobalStore as any).isMemberOnly = false;
+        (GlobalStore as any).isAgeRestricted = false;
+
+        assert.equal(shouldDisableAuth(), true, 'Should disable auth (no restriction)');
+    });
+
+    test('shouldDisableAuth - returns true when both undefined (not detected)', () => {
+        resetGlobalStore();
+        // Both are undefined after reset
+
+        assert.equal(shouldDisableAuth(), true, 'Should disable auth (conservative fallback)');
+    });
+
+    test('shouldDisableAuth - returns false when member-only true and age-restricted undefined', () => {
+        resetGlobalStore();
+        (GlobalStore as any).isMemberOnly = true;
+        // isAgeRestricted is undefined
+
+        assert.equal(shouldDisableAuth(), false, 'Should NOT disable auth (member-only confirmed)');
+    });
+
+    test('shouldDisableAuth - returns false when member-only undefined and age-restricted true', () => {
+        resetGlobalStore();
+        // isMemberOnly is undefined
+        (GlobalStore as any).isAgeRestricted = true;
+
+        assert.equal(shouldDisableAuth(), false, 'Should NOT disable auth (age-restricted confirmed)');
+    });
+});
+
+// ============================================================================
+// Group 3: Set/Clear Functions
+// ============================================================================
+
+describe('setCurrentVideoMemberOnly / clearCurrentVideoMemberOnly', () => {
+    beforeEach(() => {
+        resetGlobalStore();
+    });
+
+    test('setCurrentVideoMemberOnly - sets to true', () => {
+        resetGlobalStore();
+        setCurrentVideoMemberOnly(true);
+        assert.equal((GlobalStore as any).isMemberOnly, true);
+    });
+
+    test('setCurrentVideoMemberOnly - sets to false', () => {
+        resetGlobalStore();
+        setCurrentVideoMemberOnly(false);
+        assert.equal((GlobalStore as any).isMemberOnly, false);
+    });
+
+    test('clearCurrentVideoMemberOnly - clears the value', () => {
+        resetGlobalStore();
+        setCurrentVideoMemberOnly(true);
+        clearCurrentVideoMemberOnly();
+        assert.equal((GlobalStore as any).isMemberOnly, undefined);
+    });
+});
+
+describe('setCurrentVideoAgeRestricted / clearCurrentVideoAgeRestricted', () => {
+    beforeEach(() => {
+        resetGlobalStore();
+    });
+
+    test('setCurrentVideoAgeRestricted - sets to true', () => {
+        resetGlobalStore();
+        setCurrentVideoAgeRestricted(true);
+        assert.equal((GlobalStore as any).isAgeRestricted, true);
+    });
+
+    test('setCurrentVideoAgeRestricted - sets to false', () => {
+        resetGlobalStore();
+        setCurrentVideoAgeRestricted(false);
+        assert.equal((GlobalStore as any).isAgeRestricted, false);
+    });
+
+    test('clearCurrentVideoAgeRestricted - clears the value', () => {
+        resetGlobalStore();
+        setCurrentVideoAgeRestricted(true);
+        clearCurrentVideoAgeRestricted();
+        assert.equal((GlobalStore as any).isAgeRestricted, undefined);
+    });
 });
 


### PR DESCRIPTION
## Summary

Ref: #125 

Consolidates member-only and age-restricted status updates into a unified `updateAccessRestrictionStatus()` function. This refactoring ensures both access restriction statuses are always updated atomically, improving code maintainability and reducing the risk of inconsistent state.

## Main Changes

- **New unified function**: Added `updateAccessRestrictionStatus()` in `memberOnly.ts` that atomically updates both `isMemberOnly` and `isAgeRestricted` status in `GlobalStore`
- **Interface addition**: Added `AccessRestrictionStatus` interface to represent the combined status result
- **Codebase-wide adoption**: Replaced all separate `updateMemberOnlyStatus()` + `updateAgeRestrictedStatus()` call pairs with the new unified function across:
  - `core.ts`: `getInitYtData()` and `getInitYtDataFromHtml()`
  - `pipeline.ts`: `ensureMemberOnlyStatus()`, `getParamsForComments()`, and `fetchCommentPage()`
- **Test coverage**: Added comprehensive tests for age-restricted video detection including:
  - `isAgeRestrictedFromYtInitialData()` with various input formats
  - `normalizeYtInitialData()` format handling
  - `updateAgeRestrictedStatus()` GlobalStore integration
  - `shouldDisableAuth()` truth table validation
- **Documentation updates**: Updated authorization strategy documentation to reflect the unified approach and removed hardcoded line numbers
