### PR TITLE
fix(innertube): fix chat replay loading for logged-out users via HTML fallback

### DIFF
--- a/app/src/source/utils/innertube/chat.ts
+++ b/app/src/source/utils/innertube/chat.ts
@@ -288,6 +288,11 @@ export async function getChatComments(
                     { ...params, signal, cache: 'no-store' }
                 );
 
+                if (!res.ok) {
+                    console.warn(`[YCS] chat replay HTTP error (legacy): ${res.status} ${res.statusText}`);
+                    break;
+                }
+
                 const response = await res.json();
                 const cmnts = response?.continuationContents?.liveChatContinuation?.actions;
 
@@ -336,6 +341,12 @@ export async function getChatComments(
                     cache: 'no-store'
                 }
             );
+
+            if (!res.ok) {
+                // Stage 1 failure → terminate entire flow (Stage 2 requires token from here)
+                console.warn(`[YCS] chat replay HTTP error (initial): ${res.status} ${res.statusText}`);
+                return chatCmnts;
+            }
 
             const response = await res.json();
             const continuations = response?.continuationContents?.liveChatContinuation?.continuations;
@@ -404,6 +415,11 @@ export async function getChatComments(
                     }
                 );
 
+                if (!res.ok) {
+                    console.warn(`[YCS] chat replay HTTP error (playerSeek): ${res.status} ${res.statusText}`);
+                    break;
+                }
+
                 const response = await res.json();
                 const cmnts = response?.continuationContents?.liveChatContinuation?.actions;
 
@@ -461,6 +477,11 @@ export async function getChatComments(
                         cache: 'no-store'
                     }
                 );
+
+                if (!res.ok) {
+                    console.warn(`[YCS] chat replay HTTP error (fallback): ${res.status} ${res.statusText}`);
+                    break;
+                }
 
                 const response = await res.json();
                 const cmnts = response?.continuationContents?.liveChatContinuation?.actions;

--- a/app/src/source/utils/innertube/core.ts
+++ b/app/src/source/utils/innertube/core.ts
@@ -226,11 +226,84 @@ export async function getInitYtData(
     }
 }
 
+/**
+ * Extract a JSON object from HTML content using brace-counting algorithm.
+ * Handles string escaping and nested structures safely.
+ *
+ * @param html - The HTML content to search
+ * @param tag - The variable declaration tag (e.g., 'var ytInitialData = ')
+ * @returns The parsed JSON object, or undefined if not found/invalid
+ */
+export function extractJsonObjectFromHtml(html: string, tag: string): object | undefined {
+    const start = html.indexOf(tag);
+    if (start === -1) {
+        return undefined;
+    }
+
+    const searchStart = start + tag.length;
+    let braceCount = 0;
+    let endIndex = -1;
+    let foundStart = false;
+    let inString = false;
+    let stringChar = '';
+    let escapeNext = false;
+
+    // Loop is bounded by html.length, no additional iteration limit needed
+    for (let i = searchStart; i < html.length; i++) {
+        const ch = html[i];
+
+        if (escapeNext) {
+            escapeNext = false;
+            continue;
+        }
+
+        if (ch === '\\') {
+            escapeNext = true;
+            continue;
+        }
+
+        if (ch === '"' || ch === "'" || ch === '`') {
+            if (!inString) {
+                inString = true;
+                stringChar = ch;
+            } else if (ch === stringChar) {
+                inString = false;
+                stringChar = '';
+            }
+            continue;
+        }
+
+        if (!inString) {
+            if (ch === '{') {
+                braceCount++;
+                foundStart = true;
+            } else if (ch === '}') {
+                braceCount--;
+                if (foundStart && braceCount === 0) {
+                    endIndex = i + 1;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (endIndex === -1) {
+        return undefined;
+    }
+
+    const jsonStr = html.substring(searchStart, endIndex);
+    try {
+        return JSON.parse(jsonStr) as object;
+    } catch {
+        return undefined;
+    }
+}
+
 export async function getInitYtDataFromHtml(
     url: string,
     signal: AbortSignal | undefined,
     globalContext: Window & typeof globalThis = window
-): Promise<{ response: [object] } | undefined> {
+): Promise<{ response: object; playerResponse?: object } | undefined> {
     try {
         if (!url) return undefined;
 
@@ -251,82 +324,29 @@ export async function getInitYtDataFromHtml(
         const res = await fetch(targetUrl, { ...requestInit, signal, cache: 'no-store' });
         const html = await res.text();
 
-        // Use a safer method to locate ytInitialData
-        const tag = 'var ytInitialData = ';
-        const start = html.indexOf(tag);
-        if (start === -1) {
-            console.error('Failed to find ytInitialData start pattern in HTML');
+        // Extract ytInitialData (required)
+        const ytInitialData = extractJsonObjectFromHtml(html, 'var ytInitialData = ');
+        if (!ytInitialData) {
+            console.error('[YCS] [Core] getInitYtDataFromHtml: Failed to extract ytInitialData from HTML');
             return undefined;
         }
 
-        const searchStart = start + tag.length;
-        const MAX_ITERATIONS = 1000000; // Prevent extreme cases
-        let braceCount = 0;
-        let endIndex = -1;
-        let foundStart = false;
-        let inString = false;
-        let stringChar = '';
-        let escapeNext = false;
-        let iterations = 0;
+        // Extract ytInitialPlayerResponse (optional, for live broadcast details)
+        const ytInitialPlayerResponse = extractJsonObjectFromHtml(html, 'var ytInitialPlayerResponse = ');
 
-        for (let i = searchStart; i < html.length && iterations < MAX_ITERATIONS; i++) {
-            iterations++;
-            const ch = html[i];
+        // Build result matching PBJ format structure
+        const result: { response: object; playerResponse?: object } = {
+            response: ytInitialData,
+            ...(ytInitialPlayerResponse && { playerResponse: ytInitialPlayerResponse })
+        };
 
-            if (escapeNext) {
-                escapeNext = false;
-                continue;
-            }
+        (GlobalStore as any).getInitYtData = result;
 
-            if (ch === '\\') {
-                escapeNext = true;
-                continue;
-            }
+        // Update members-only and age-restricted status
+        console.log('[YCS] [Core] getInitYtDataFromHtml: Updating access restriction status from ytInitialData');
+        updateAccessRestrictionStatus(result);
 
-            if (ch === '"' || ch === "'" || ch === '`') {
-                if (!inString) {
-                    inString = true;
-                    stringChar = ch;
-                } else if (ch === stringChar) {
-                    inString = false;
-                    stringChar = '';
-                }
-                continue;
-            }
-
-            if (!inString) {
-                if (ch === '{') {
-                    braceCount++;
-                    foundStart = true;
-                } else if (ch === '}') {
-                    braceCount--;
-                    if (foundStart && braceCount === 0) {
-                        endIndex = i + 1;
-                        break;
-                    }
-                }
-            }
-        }
-
-        if (iterations >= MAX_ITERATIONS || endIndex === -1) {
-            console.error('Failed to locate ytInitialData JSON object boundaries');
-            return undefined;
-        }
-
-        const jsonStr = html.substring(searchStart, endIndex);
-        try {
-            const result = JSON.parse(jsonStr) as [object];
-            (GlobalStore as any).getInitYtData = result;
-
-            // Update members-only and age-restricted status
-            console.log('[YCS] [Core] getInitYtDataFromHtml: Updating access restriction status from ytInitialData');
-            updateAccessRestrictionStatus(result);
-
-            return { response: result };
-        } catch (parseError) {
-            console.error('Failed to parse ytInitialData JSON:', parseError);
-            return undefined;
-        }
+        return result;
     } catch (e) {
         console.error(e);
         return undefined;

--- a/app/src/source/utils/innertube/core.ts
+++ b/app/src/source/utils/innertube/core.ts
@@ -190,7 +190,29 @@ export async function getInitYtData(
         const targetUrl = `${getCleanUrlVideo(url) ?? url}&pbj=1`;
         const res = await fetch(targetUrl, { ...requestInit, signal, cache: 'no-store' });
 
-        const result = (await res.json()) as object;
+        if (!res.ok) {
+            console.warn(`[YCS] [Core] getInitYtData HTTP error: ${res.status} ${res.statusText}`);
+            return undefined;
+        }
+
+        // Handle YouTube's anti-JSON hijacking prefix: )]}'
+        // This prefix is added by Google to prevent JSON hijacking attacks
+        // and is commonly returned for unauthenticated users
+        let text = await res.text();
+        const JSON_SECURITY_PREFIX = ")]}'\n";
+        if (text.startsWith(JSON_SECURITY_PREFIX)) {
+            text = text.slice(JSON_SECURITY_PREFIX.length);
+        }
+
+        const result = JSON.parse(text) as object;
+
+        // Valid PBJ response should have 'response' property
+        // If missing, fallback to HTML parsing method (e.g., unauthenticated users get different response)
+        if (!('response' in result)) {
+            console.log('[YCS] [Core] getInitYtData: PBJ response missing required data, falling back to HTML parsing');
+            return getInitYtDataFromHtml(url, signal, globalContext);
+        }
+
         (GlobalStore as any).getInitYtData = result;
 
         // Update members-only and age-restricted status

--- a/app/src/source/utils/innertube/core.ts
+++ b/app/src/source/utils/innertube/core.ts
@@ -206,9 +206,9 @@ export async function getInitYtData(
 
         const result = JSON.parse(text) as object;
 
-        // Valid PBJ response should have 'response' property
-        // If missing, fallback to HTML parsing method (e.g., unauthenticated users get different response)
-        if (!('response' in result)) {
+        // Modern PBJ is an object with top-level 'response' (and usually 'playerResponse').
+        // Legacy array PBJ is rare and normalized elsewhere; non-PBJ falls back to HTML.
+        if (!isValidPbjResponse(result)) {
             console.log('[YCS] [Core] getInitYtData: PBJ response missing required data, falling back to HTML parsing');
             return getInitYtDataFromHtml(url, signal, globalContext);
         }
@@ -224,6 +224,10 @@ export async function getInitYtData(
         console.error(e);
         return undefined;
     }
+}
+
+export function isValidPbjResponse(result: unknown): result is { response: object } {
+    return !!result && typeof result === 'object' && 'response' in result;
 }
 
 /**

--- a/app/tests/innertube-chat.test.ts
+++ b/app/tests/innertube-chat.test.ts
@@ -46,28 +46,31 @@ test('getChatComments should trigger expected pbj=1 requests', async () => {
             pbj1CallCount++;
 
             // Return mock response for pbj=1 request
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({
-                    response: {
-                        contents: {
-                            twoColumnWatchNextResults: {
-                                conversationBar: {
-                                    liveChatRenderer: {
-                                        continuations: [
-                                            {
-                                                reloadContinuationData: {
-                                                    continuation: 'mock-continuation-token'
-                                                }
+            // Note: getInitYtData uses text() + JSON.parse() to handle anti-JSON hijacking prefix
+            const mockData = {
+                response: {
+                    contents: {
+                        twoColumnWatchNextResults: {
+                            conversationBar: {
+                                liveChatRenderer: {
+                                    continuations: [
+                                        {
+                                            reloadContinuationData: {
+                                                continuation: 'mock-continuation-token'
                                             }
-                                        ]
-                                    }
+                                        }
+                                    ]
                                 }
                             }
                         }
                     }
-                })
+                }
+            };
+            return {
+                ok: true,
+                status: 200,
+                text: async () => JSON.stringify(mockData),
+                json: async () => mockData
             } as Response;
         }
 
@@ -178,28 +181,31 @@ test('getChatComments should pass continuation data to getLiveChat', async () =>
             // Record the call with timestamp to verify no duplicates
             pbj1Calls.push(`pbj=1 at ${Date.now()}`);
 
-            return {
-                ok: true,
-                status: 200,
-                json: async () => ({
-                    response: {
-                        contents: {
-                            twoColumnWatchNextResults: {
-                                conversationBar: {
-                                    liveChatRenderer: {
-                                        continuations: [
-                                            {
-                                                reloadContinuationData: {
-                                                    continuation: 'test-continuation'
-                                                }
+            // Note: getInitYtData uses text() + JSON.parse() to handle anti-JSON hijacking prefix
+            const mockData = {
+                response: {
+                    contents: {
+                        twoColumnWatchNextResults: {
+                            conversationBar: {
+                                liveChatRenderer: {
+                                    continuations: [
+                                        {
+                                            reloadContinuationData: {
+                                                continuation: 'test-continuation'
                                             }
-                                        ]
-                                    }
+                                        }
+                                    ]
                                 }
                             }
                         }
                     }
-                })
+                }
+            };
+            return {
+                ok: true,
+                status: 200,
+                text: async () => JSON.stringify(mockData),
+                json: async () => mockData
             } as Response;
         }
 

--- a/app/tests/innertube.test.ts
+++ b/app/tests/innertube.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import test from 'node:test';
 
 import { applyFrameworkUpdatesToComment, generateCommentObjectFromFW } from '../src/source/utils/innertube';
-import { extractJsonObjectFromHtml } from '../src/source/utils/innertube/core';
+import { extractJsonObjectFromHtml, isValidPbjResponse } from '../src/source/utils/innertube/core';
 
 /**
  * Helper: Create minimal frameworkUpdate payload for testing
@@ -467,6 +467,23 @@ test('generateCommentObjectFromFW does not create creatorHeart when not hearted'
         undefined,
         'Expected creatorHeart to not be created when not hearted'
     );
+});
+
+// ============================================================================
+// isValidPbjResponse Tests
+// ============================================================================
+
+test('isValidPbjResponse accepts modern PBJ object format', () => {
+    const input = {
+        response: { contents: { test: 'data' } },
+        playerResponse: { playabilityStatus: { status: 'OK' } }
+    };
+    assert.equal(isValidPbjResponse(input), true, 'Should accept object with response property');
+});
+
+test('isValidPbjResponse rejects legacy array format', () => {
+    const input = [{ response: { test: 1 } }, { playerResponse: { test: 2 } }];
+    assert.equal(isValidPbjResponse(input), false, 'Should reject array format (handled elsewhere)');
 });
 
 // ============================================================================

--- a/app/tests/innertube.test.ts
+++ b/app/tests/innertube.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import test from 'node:test';
 
 import { applyFrameworkUpdatesToComment, generateCommentObjectFromFW } from '../src/source/utils/innertube';
+import { extractJsonObjectFromHtml } from '../src/source/utils/innertube/core';
 
 /**
  * Helper: Create minimal frameworkUpdate payload for testing
@@ -466,4 +467,110 @@ test('generateCommentObjectFromFW does not create creatorHeart when not hearted'
         undefined,
         'Expected creatorHeart to not be created when not hearted'
     );
+});
+
+// ============================================================================
+// extractJsonObjectFromHtml Tests
+// ============================================================================
+
+test('extractJsonObjectFromHtml extracts simple object', () => {
+    const html = 'var ytInitialData = {"foo": "bar"};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ');
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.deepEqual(result, { foo: 'bar' }, 'Expected extracted object to match');
+});
+
+test('extractJsonObjectFromHtml handles nested objects', () => {
+    const html = 'var ytInitialData = {"a": {"b": {"c": 1}}};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ');
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.deepEqual(result, { a: { b: { c: 1 } } }, 'Expected nested object to be extracted correctly');
+});
+
+test('extractJsonObjectFromHtml handles strings containing braces', () => {
+    const html = 'var ytInitialData = {"text": "Hello {world}"};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ') as { text: string };
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.equal(result.text, 'Hello {world}', 'Expected string with braces to be preserved');
+});
+
+test('extractJsonObjectFromHtml handles escaped quotes', () => {
+    const html = 'var ytInitialData = {"text": "He said \\"hello\\""};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ') as { text: string };
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.equal(result.text, 'He said "hello"', 'Expected escaped quotes to be handled correctly');
+});
+
+test('extractJsonObjectFromHtml returns undefined when tag not found', () => {
+    const html = '<html><body>No data here</body></html>';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ');
+
+    assert.equal(result, undefined, 'Expected undefined when tag not found');
+});
+
+test('extractJsonObjectFromHtml extracts ytInitialPlayerResponse tag', () => {
+    const html = 'var ytInitialPlayerResponse = {"videoDetails": {"videoId": "abc123"}};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialPlayerResponse = ') as {
+        videoDetails: { videoId: string };
+    };
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.equal(result.videoDetails.videoId, 'abc123', 'Expected videoId to match');
+});
+
+test('extractJsonObjectFromHtml handles arrays in object', () => {
+    const html = 'var ytInitialData = {"items": [1, 2, 3], "names": ["a", "b"]};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ') as { items: number[]; names: string[] };
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.deepEqual(result.items, [1, 2, 3], 'Expected array to be extracted correctly');
+    assert.deepEqual(result.names, ['a', 'b'], 'Expected string array to be extracted correctly');
+});
+
+test('extractJsonObjectFromHtml handles complex real-world structure', () => {
+    const html = `
+        <script>var ytInitialPlayerResponse = {
+            "microformat": {
+                "playerMicroformatRenderer": {
+                    "liveBroadcastDetails": {
+                        "isLiveNow": true,
+                        "startTimestamp": "2026-01-03T14:00:20+00:00"
+                    }
+                }
+            }
+        };</script>
+    `;
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialPlayerResponse = ') as {
+        microformat: {
+            playerMicroformatRenderer: {
+                liveBroadcastDetails: {
+                    isLiveNow: boolean;
+                    startTimestamp: string;
+                };
+            };
+        };
+    };
+
+    assert.ok(result, 'Expected result to be defined');
+    assert.equal(
+        result.microformat.playerMicroformatRenderer.liveBroadcastDetails.startTimestamp,
+        '2026-01-03T14:00:20+00:00',
+        'Expected startTimestamp to match'
+    );
+    assert.equal(
+        result.microformat.playerMicroformatRenderer.liveBroadcastDetails.isLiveNow,
+        true,
+        'Expected isLiveNow to be true'
+    );
+});
+
+test('extractJsonObjectFromHtml returns undefined for malformed JSON', () => {
+    const html = 'var ytInitialData = {invalid json here};';
+    const result = extractJsonObjectFromHtml(html, 'var ytInitialData = ');
+
+    assert.equal(result, undefined, 'Expected undefined for malformed JSON');
 });


### PR DESCRIPTION
## Summary

Ref: #128 

Fix chat replay loading for logged-out users by implementing automatic HTML fallback when PBJ responses lack required data (logged-out users receive incomplete PBJ responses without the `response` property).

## Key Changes

- **Automatic HTML fallback**: When PBJ response lacks required `response` property, automatically fall back to HTML parsing via `getInitYtDataFromHtml()`
- **`extractJsonObjectFromHtml()` extraction**: Refactored JSON extraction logic from `getInitYtDataFromHtml()` into a reusable function supporting both `ytInitialData` and `ytInitialPlayerResponse` tags
- **`getInitYtDataFromHtml()` refactor**: Simplified implementation using extracted function, now returns normalized `{ response, playerResponse? }` structure matching PBJ format
- **Anti-JSON hijacking support**: Handle Google's `)]}'` security prefix in PBJ responses using `Response.text()` + `JSON.parse()`
- **`getInitYtData()` enhancement**: Added HTTP error handling to gracefully handle request failures
- **Chat replay HTTP error handling**: Added `Response.ok` checks in `getChatComments()` for legacy, initial, playerSeek, and fallback stages
- **Test updates**: Updated mocks to use `Response.text()` method for PBJ responses, added comprehensive test coverage for `extractJsonObjectFromHtml()`
