### PR TITLE
Improve YCS filtering

### DIFF
--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -300,14 +300,20 @@ async function fetchAllCommentsBackground(
 
 const STORE_CACHE_YCS = 'STORE_CACHE_YCS';
 
-chrome.runtime.onInstalled.addListener(async () => {
+chrome.runtime.onInstalled.addListener(async (details) => {
     const optsStorage = await chrome.storage.local.get();
 
-    await chrome.storage.local.set({
-        ...options,
-        ...optsStorage
-    });
-
+    if (details.reason === 'update') {
+        await chrome.storage.local.set({
+            ...optsStorage,
+            filterButtons: options.filterButtons
+        });
+    } else {
+        await chrome.storage.local.set({
+            ...options,
+            ...optsStorage
+        });
+    }
     chrome.tabs.query({ url: '*://*.youtube.com/*' }, (tabs) => {
         for (const tab of tabs) {
             if (tab.id) {

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -5,13 +5,15 @@ const options = {
     cache: true,
     autoClear: 200,
     hiddenByDefault: false,
-    sortTimestamp: false,
     hiddenByDefaultShorts: false,
     enableShortsSupport: true,
     transcriptLanguage: '',
     youtubeApiKey: '', // Empty = use Innertube (default); Filled = use YouTube Data API
     youtubeApiEnabled: true, // Enable YouTube Data API (requires API key to take effect)
     filterButtons: [
+        { id: 'ycs_btn_comments', enabled: true },
+        { id: 'ycs_btn_quick_chat', enabled: true },
+        { id: 'ycs_btn_quick_transcript', enabled: true },
         { id: 'ycs_btn_timestamps', enabled: true },
         { id: 'ycs_btn_timestamp_viz', enabled: true },
         { id: 'ycs_btn_author', enabled: true },
@@ -22,10 +24,8 @@ const options = {
         { id: 'ycs_btn_replied_comments', enabled: true },
         { id: 'ycs_btn_members', enabled: true },
         { id: 'ycs_btn_donated', enabled: true },
-        { id: 'ycs_btn_sort_first', enabled: true },
         { id: 'ycs_btn_random', enabled: true },
-        { id: 'ycs_btn_quick_chat', enabled: false },
-        { id: 'ycs_btn_quick_transcript', enabled: false }
+        { id: 'ycs_btn_origin', enabled: true }
     ]
 };
 

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -10,6 +10,7 @@ const options = {
     transcriptLanguage: '',
     youtubeApiKey: '', // Empty = use Innertube (default); Filled = use YouTube Data API
     youtubeApiEnabled: true, // Enable YouTube Data API (requires API key to take effect)
+    defaultSort: 'relevance',
     filterButtons: [
         { id: 'ycs_btn_comments', enabled: true },
         { id: 'ycs_btn_quick_chat', enabled: true },

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -25,7 +25,8 @@ const options = {
         { id: 'ycs_btn_members', enabled: true },
         { id: 'ycs_btn_donated', enabled: true },
         { id: 'ycs_btn_random', enabled: true },
-        { id: 'ycs_btn_origin', enabled: true }
+        { id: 'ycs_btn_origin', enabled: true },
+        { id: 'ycs_btn_emoji', enabled: true }
     ]
 };
 

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -87,22 +87,6 @@ window.onload = async (): Promise<void> => {
             (document.getElementById('y_opts_hidden_by_default') as HTMLInputElement).checked = param;
         };
 
-        const optSetSortTimestamp = async (opt: HTMLInputElement): Promise<void> => {
-            try {
-                await chrome.storage.local.set({
-                    sortTimestamp: opt.checked
-                });
-            } catch (err) {
-                console.error(err);
-            }
-        };
-
-        const setRenderSortTimestampOpt = (param: boolean): void => {
-            if (typeof param !== 'boolean') return;
-
-            (document.getElementById('y_opts_sort_timestamp') as HTMLInputElement).checked = param;
-        };
-
         const setRenderHiddenByDefaultShorts = (param: boolean): void => {
             if (typeof param !== 'boolean') return;
 
@@ -301,9 +285,10 @@ window.onload = async (): Promise<void> => {
                 ycs_btn_members: 'Members',
                 ycs_btn_donated: 'Donated',
                 ycs_btn_random: 'Random',
-                ycs_btn_sort_first: 'All',
+                ycs_btn_comments: 'Comments',
                 ycs_btn_quick_chat: 'Chat (Quick chat search)',
-                ycs_btn_quick_transcript: 'Transcript (Quick transcript search)'
+                ycs_btn_quick_transcript: 'Transcript (Quick transcript search)',
+                ycs_btn_origin: 'Origin'
             };
             return nameMap[buttonId] || buttonId;
         };
@@ -692,10 +677,6 @@ window.onload = async (): Promise<void> => {
                         setRenderHiddenByDefault(storageOpts[key]);
                         break;
 
-                    case 'sortTimestamp':
-                        setRenderSortTimestampOpt(storageOpts[key]);
-                        break;
-
                     case 'hiddenByDefaultShorts':
                         setRenderHiddenByDefaultShorts(storageOpts[key]);
                         break;
@@ -764,10 +745,6 @@ window.onload = async (): Promise<void> => {
 
                 case 'y_opts_hidden_by_default':
                     optSetHiddenByDefault(e.target as HTMLInputElement);
-                    break;
-
-                case 'y_opts_sort_timestamp':
-                    optSetSortTimestamp(e.target as HTMLInputElement);
                     break;
 
                 case 'y_opts_hidden_by_default_shorts':

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -3,7 +3,7 @@ import { formatBytes } from '../../../utils/formatting';
 import { isNumeric } from '../../../utils/common';
 import { idb } from '../../../utils/libs';
 
-import { IStorageEstimate } from '../../../utils/interfaces/i_types';
+import { ISelectedSort, IStorageEstimate } from '../../../utils/interfaces/i_types';
 
 const STORE_CACHE_YCS = 'STORE_CACHE_YCS';
 
@@ -142,6 +142,32 @@ window.onload = async (): Promise<void> => {
             try {
                 await chrome.storage.local.set({
                     transcriptLanguage: value
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
+        const optSetRenderDefaultSort = (param?: ISelectedSort): void => {
+            const select = document.getElementById('y_opts_default_sort_select') as HTMLSelectElement | null;
+
+            if (!select) return;
+
+            const value = param ?? 'relevance';
+
+            const matchingOption = Array.from(select.options).find((option) => option.value === value);
+
+            if (matchingOption) {
+                select.value = value;
+            } else {
+                select.value = 'relevance';
+            }
+        };
+
+        const optSetDefaultSort = async (value: ISelectedSort): Promise<void> => {
+            try {
+                await chrome.storage.local.set({
+                    defaultSort: value
                 });
             } catch (err) {
                 console.error(err);
@@ -690,6 +716,10 @@ window.onload = async (): Promise<void> => {
                         setRenderTranscriptLanguage(storageOpts[key]);
                         break;
 
+                    case 'defaultSort':
+                        optSetRenderDefaultSort(storageOpts[key]);
+                        break;
+
                     case 'filterButtons':
                         setRenderFilterButtons(storageOpts[key]);
                         break;
@@ -804,6 +834,15 @@ window.onload = async (): Promise<void> => {
         transcriptLanguageSelect?.addEventListener('change', handleTranscriptLanguageSelectChange);
         transcriptLanguageInput?.addEventListener('input', handleTranscriptLanguageInputChange);
         transcriptLanguageInput?.addEventListener('change', handleTranscriptLanguageInputChange);
+
+        const defaultSortSelect = document.getElementById('y_opts_default_sort_select') as HTMLSelectElement | null;
+        const handleDefaultSortSelectChange = (event: Event): void => {
+            const target = event.target as HTMLSelectElement | null;
+            if (!target) return;
+            const nextValue = target.value as ISelectedSort;
+            optSetDefaultSort(nextValue);
+        };
+        defaultSortSelect?.addEventListener('change', handleDefaultSortSelectChange);
 
         const elPageCache = document.getElementById('ycs_opts_btn_export_page') as HTMLElement;
         elPageCache.onclick = () => {

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -288,7 +288,8 @@ window.onload = async (): Promise<void> => {
                 ycs_btn_comments: 'Comments',
                 ycs_btn_quick_chat: 'Chat (Quick chat search)',
                 ycs_btn_quick_transcript: 'Transcript (Quick transcript search)',
-                ycs_btn_origin: 'Origin'
+                ycs_btn_origin: 'Origin',
+                ycs_btn_emoji: '😊 (Emoji)'
             };
             return nameMap[buttonId] || buttonId;
         };

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -213,6 +213,18 @@
               <input type="checkbox" id="filter_opt_quick_transcript" />
               <label for="filter_opt_quick_transcript">Transcript (Quick transcript search)</label>
             </div>
+
+            <div class="ycs_filter_button_item" draggable="true" data-button-id="ycs_btn_origin">
+              <span class="ycs_drag_handle">⋮⋮</span>
+              <input type="checkbox" id="filter_opt_origin" />
+              <label for="filter_opt_origin">Origin</label>
+            </div>
+
+            <div class="ycs_filter_button_item" draggable="true" data-button-id="ycs_btn_emoji">
+              <span class="ycs_drag_handle">⋮⋮</span>
+              <input type="checkbox" id="filter_opt_emoji" />
+              <label for="filter_opt_emoji">😊 (Emoji)</label>
+            </div>
           </div>
 
           <button class="ycs_opts_btn" type="button" id="ycs_opts_btn_reset_filters">Reset to Default</button>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -84,6 +84,27 @@
         </div>
 
         <div>
+          <label for="y_opts_default_sort_select">Default sort:</label>
+          <select id="y_opts_default_sort_select" class="ycs_opts_select">
+            <option value="relevance">Relevance</option>
+            <option value="newest">Newest</option>
+            <option value="oldest">Oldest</option>
+            <option value="most_likes">Most Likes</option>
+            <option value="least_likes">Least Likes</option>
+            <option value="most_replies">Most Replies</option>
+            <option value="least_replies">Least Replies</option>
+            <option value="author_az">Author(a-z)</option>
+            <option value="author_za">Author(z-a)</option>
+            <option value="longest">Longest</option>
+            <option value="shortest">Shortest</option>
+          </select>
+
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Select the default sort order for search results.</p>
+          </div>
+        </div>
+
+        <div>
           <label for="y_opts_transcript_language_select">Default transcript language:</label>
           <select id="y_opts_transcript_language_select" class="ycs_opts_select">
             <option value="">YouTube default</option>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -52,14 +52,6 @@
           </div>
         </div>
 
-        <div>
-          <label for="y_opts_sort_timestamp">Sort timestamps by time:</label>
-          <input type="checkbox" name="Sort timestamps by time" id="y_opts_sort_timestamp" class="ycs_opts_checkbox" />
-          <div class="ycs_description_option ycs_api_desc">
-            <p>Sort comments with timestamps by timestamp time instead of by comment creation date.</p>
-          </div>
-        </div>
-
         <div class="ycs_group" id="ycs-shorts-group">
           <div>
             <label for="y_opts_enable_shorts_support">Enable YouTube Shorts support:</label>
@@ -198,10 +190,10 @@
               <label for="filter_opt_donated">Donated</label>
             </div>
 
-            <div class="ycs_filter_button_item" draggable="true" data-button-id="ycs_btn_sort_first">
+            <div class="ycs_filter_button_item" draggable="true" data-button-id="ycs_btn_comments">
               <span class="ycs_drag_handle">⋮⋮</span>
-              <input type="checkbox" id="filter_opt_sort_first" checked />
-              <label for="filter_opt_sort_first">All</label>
+              <input type="checkbox" id="filter_opt_comments" checked />
+              <label for="filter_opt_comments">Comments</label>
             </div>
 
             <div class="ycs_filter_button_item" draggable="true" data-button-id="ycs_btn_random">

--- a/app/src/source/utils/filters/chatAgg.ts
+++ b/app/src/source/utils/filters/chatAgg.ts
@@ -11,6 +11,7 @@ export interface DerivedChatMessage {
     isDonated: boolean;
     isVerified: boolean;
     hasLinks: boolean;
+    hasEmoji: boolean;
 }
 
 export interface ChatFilterConfig<T = any> {
@@ -53,6 +54,7 @@ function deriveChatMessage(item: ChatItem): DerivedChatMessage {
 
     const messageText = renderer?.message?.fullText || renderer?.message?.simpleText || '';
     const hasLinks = urlRegex().test(String(messageText));
+    const hasEmoji = renderer?.message?.runs?.some((run: any) => run?.emoji) ?? false;
 
     return {
         origin: item,
@@ -61,7 +63,8 @@ function deriveChatMessage(item: ChatItem): DerivedChatMessage {
         isMember,
         isDonated,
         isVerified,
-        hasLinks
+        hasLinks,
+        hasEmoji
     };
 }
 
@@ -122,4 +125,8 @@ export function createChatVerifiedFilter(): ChatFilterConfig<boolean> {
 
 export function createChatLinksFilter(): ChatFilterConfig<boolean> {
     return createChatFilter('chatLinks', (item, flag) => (!flag ? true : item.hasLinks), true);
+}
+
+export function createChatEmojiFilter(): ChatFilterConfig<boolean> {
+    return createChatFilter('chatEmoji', (item, flag) => (!flag ? true : item.hasEmoji), true);
 }

--- a/app/src/source/utils/filters/commentsAgg.ts
+++ b/app/src/source/utils/filters/commentsAgg.ts
@@ -86,3 +86,7 @@ export function createOriginalCommentsFilter(only = true): FilterConfig<boolean>
         only
     );
 }
+
+export function createEmojiCommentsFilter(only = true): FilterConfig<boolean> {
+    return createFilter('emoji', 'Emoji Comments Filter', (item, flag) => (!flag ? true : item.hasEmoji), only);
+}

--- a/app/src/source/utils/filters/commentsAgg.ts
+++ b/app/src/source/utils/filters/commentsAgg.ts
@@ -77,3 +77,12 @@ export function createTimelineFilter(only = true): FilterConfig<boolean> {
 export function createDonatedFilter(only = true): FilterConfig<boolean> {
     return createFilter('donated', 'Donated Filter', (item, flag) => (!flag ? true : item.isDonated), only);
 }
+
+export function createOriginalCommentsFilter(only = true): FilterConfig<boolean> {
+    return createFilter(
+        'origin',
+        'Original Comments Filter',
+        (item, flag) => (!flag ? true : item.origin.typeComment === 'C'),
+        only
+    );
+}

--- a/app/src/source/utils/filters/engine.ts
+++ b/app/src/source/utils/filters/engine.ts
@@ -38,6 +38,7 @@ export function deriveComment(item: CommentItemLike): DerivedComment {
     const isTimeline = commentRenderer?.isTimeLine === 'timeline';
     const publishedTimeText = commentRenderer?.publishedTimeText?.runs?.[0]?.text || '';
     const isChannelOwner = Boolean(commentRenderer?.authorIsChannelOwner);
+    const hasEmoji = commentRenderer?.contentText?.renderFullText?.includes('class="ycs-attachment">');
 
     return {
         origin: item as Record<string, any>,
@@ -52,7 +53,8 @@ export function deriveComment(item: CommentItemLike): DerivedComment {
         hasLinks,
         isTimeline,
         isChannelOwner,
-        publishedTimeText
+        publishedTimeText,
+        hasEmoji
     };
 }
 

--- a/app/src/source/utils/filters/types.ts
+++ b/app/src/source/utils/filters/types.ts
@@ -15,6 +15,7 @@ export interface DerivedComment {
     isTimeline: boolean;
     isChannelOwner: boolean;
     publishedTimeText: string;
+    hasEmoji: boolean;
 }
 
 export interface FilterConfig<T = any> {

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -297,6 +297,7 @@ export interface IParamSearch {
     quickTranscript?: boolean;
     quickComments?: boolean;
     origin?: boolean;
+    emoji?: boolean;
     sortOrder?: ISelectedSort;
 }
 export type ISelectedSort =

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -285,9 +285,7 @@ export type ICommentItem = CommentItem;
 
 export interface IParamSearch {
     links?: boolean;
-    likes?: boolean;
     members?: boolean;
-    replied?: boolean;
     author?: boolean;
     heart?: boolean;
     verified?: boolean;
@@ -295,13 +293,24 @@ export interface IParamSearch {
     random?: boolean;
     timestamp?: boolean;
     timestampViz?: boolean;
-    sortFirst?: boolean;
     quickChat?: boolean;
     quickTranscript?: boolean;
-    sortOrder?: 'newest' | 'oldest';
+    quickComments?: boolean;
+    origin?: boolean;
+    sortOrder?: ISelectedSort;
 }
-
-export type ISelectedSearch = 'comments' | 'chat' | 'video' | 'all';
+export type ISelectedSort =
+    | 'newest'
+    | 'oldest'
+    | 'most_likes'
+    | 'least_likes'
+    | 'most_replies'
+    | 'least_replies'
+    | 'author_az'
+    | 'author_za'
+    | 'relevance'
+    | 'longest'
+    | 'shortest';
 
 /**
  * Comment sort order for YouTube API token extraction
@@ -324,7 +333,6 @@ export interface CommentSortOption {
 export interface IYCSOptions {
     autoload?: boolean;
     highlightText?: boolean;
-    sortTimestamp?: boolean;
     highlightExact?: boolean;
     cache?: boolean;
     autoClear?: number;

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -342,6 +342,7 @@ export interface IYCSOptions {
     enableShortsSupport?: boolean;
     filterButtons?: Array<{ id: string; enabled: boolean }>;
     transcriptLanguage?: string;
+    defaultSort?: ISelectedSort;
     youtubeApiKey?: string; // Empty = use Innertube; Filled = use YouTube Data API (storage only)
     hasYoutubeApiKey?: boolean; // Flag exposed to web page (API key never exposed)
     youtubeApiEnabled?: boolean; // Enable YouTube Data API (default: true, requires API key)

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -16,6 +16,7 @@ import {
 } from './viewModels';
 import { iconCollapse, iconExpandShowMore, iconReload, iconCurve } from './icons';
 import { EXPORT_FORMAT } from './constants';
+import { ISelectedSort } from './interfaces/i_types';
 
 /**
  * Options for rendering comments
@@ -1184,7 +1185,7 @@ function renderSearch(node: HTMLElement): void {
                 </div>
                 <select title="Select a search category" name="ycs_sort_select"
                     id="ycs_sort_select" class="ycs-btn-search ycs-title ycs_sort_select ycs_noselect">
-                    <option selected value="relevance">Relevance</option>
+                    <option value="relevance">Relevance</option>
                     <option value="newest">Newest</option>
                     <option value="oldest">Oldest</option>
                     <option value="most_likes">Most Likes</option>
@@ -1241,6 +1242,18 @@ function renderSearch(node: HTMLElement): void {
     `;
 }
 
+function selectSortOption(sortOrder: ISelectedSort): void {
+    const sortSelect = document.getElementById('ycs_sort_select') as HTMLSelectElement | null;
+    if (!sortSelect) return;
+
+    const validOptions = Array.from(sortSelect.options).map((option) => option.value);
+    if (validOptions.includes(sortOrder)) {
+        sortSelect.value = sortOrder;
+    } else {
+        sortSelect.value = 'relevance'; // Default fallback
+    }
+}
+
 // Dynamically load filter buttons
 function loadFilterButtons(filterButtons?: Array<{ id: string; enabled: boolean }>): void {
     try {
@@ -1295,4 +1308,12 @@ function loadFilterButtons(filterButtons?: Array<{ id: string; enabled: boolean 
     }
 }
 
-export { renderComment, renderLoadComments, renderSearch, renderCommentTrVideo, renderCommentChat, loadFilterButtons };
+export {
+    renderComment,
+    renderLoadComments,
+    renderSearch,
+    renderCommentTrVideo,
+    renderCommentChat,
+    loadFilterButtons,
+    selectSortOption
+};

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1175,7 +1175,7 @@ function renderSearch(node: HTMLElement): void {
                     <input title="Write the search query, press Enter or click the button Search."
                         class="ycs-search__input ycs_noselect" type="text" id="ycs-input-search" placeholder="Search">
                 </div>
-                <select title="Sort by." name="ycs_sort_select"
+                <select title="Select a search category" name="ycs_sort_select"
                     id="ycs_sort_select" class="ycs-btn-search ycs-title ycs_sort_select ycs_noselect">
                     <option selected value="relevance">Relevance</option>
                     <option value="newest">Newest</option>

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1115,6 +1115,11 @@ function generateFilterButtonHTML(buttonId: string): string {
         ycs_btn_origin: {
             name: 'origin',
             title: 'Show non-reply comments only'
+        },
+        ycs_btn_emoji: {
+            name: 'emoji',
+            title: 'Show comments, replies, chat with emojis',
+            icon: '<span class="ycs-emoji-icon">😊</span>'
         }
     };
 
@@ -1160,7 +1165,9 @@ function generateFilterButtonHTML(buttonId: string): string {
                                               ? 'Transcript'
                                               : config.name === 'origin'
                                                 ? 'Origin'
-                                                : config.name
+                                                : config.name === 'emoji'
+                                                  ? ''
+                                                  : config.name
             }
         </button>`;
 }

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1060,15 +1060,10 @@ function renderLoadComments(
 
 // Generate HTML for a single button
 function generateFilterButtonHTML(buttonId: string): string {
-    const buttonConfigs: Record<
-        string,
-        { name: string; title: string; dataSort?: string; dataSortChat?: string; dataSortTrp?: string; icon?: string }
-    > = {
+    const buttonConfigs: Record<string, { name: string; title: string; icon?: string }> = {
         ycs_btn_timestamps: {
             name: 'timestamps',
-            title: 'Show comments, replies, chat with time stamps (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest'
+            title: 'Show comments, replies, chat with time stamps'
         },
         ycs_btn_timestamp_viz: {
             name: 'timestampViz',
@@ -1077,56 +1072,29 @@ function generateFilterButtonHTML(buttonId: string): string {
         },
         ycs_btn_author: {
             name: 'author',
-            title: 'Show comments, replies, chat from the author (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest'
+            title: 'Show comments, replies, chat from the author'
         },
         ycs_btn_heart: {
             name: 'heart',
-            title: 'Show comments and replies that the author likes (Newest)',
-            dataSort: 'newest',
+            title: 'Show comments and replies that the author likes',
             icon: '<span class="ycs-creator-heart_icon">❤</span>'
         },
         ycs_btn_verified: {
             name: 'verified',
-            title: 'Show comments, replies and chat from a verified authors (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest',
+            title: 'Show comments, replies and chat from a verified authors',
             icon: '<span class="ycs-creator-verified_icon">✔</span>'
         },
         ycs_btn_links: {
             name: 'links',
-            title: 'Shows links in comments, replies, chat, video transcript (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest',
-            dataSortTrp: 'newest'
-        },
-        ycs_btn_likes: {
-            name: 'likes',
-            title: 'Show comments, replies by number of likes (sort largest to smallest)'
-        },
-        ycs_btn_replied_comments: {
-            name: 'replied',
-            title: 'Show comments by number of replies (sort largest to smallest)'
+            title: 'Shows links in comments, replies, chat, video transcript'
         },
         ycs_btn_members: {
             name: 'members',
-            title: 'Show comments, replies, chat from channel members (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest'
+            title: 'Show comments, replies, chat from channel members'
         },
         ycs_btn_donated: {
             name: 'donated',
-            title: 'Show chat comments from users who have donated (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest'
-        },
-        ycs_btn_sort_first: {
-            name: 'sortFirst',
-            title: 'Show all comments, chat, video transcript sorted by date (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest',
-            dataSortTrp: 'newest'
+            title: 'Show chat comments from users who have donated'
         },
         ycs_btn_random: {
             name: 'random',
@@ -1134,32 +1102,29 @@ function generateFilterButtonHTML(buttonId: string): string {
         },
         ycs_btn_quick_chat: {
             name: 'quickChat',
-            title: 'Show chat replay (Newest)',
-            dataSort: 'newest',
-            dataSortChat: 'newest'
+            title: 'Show chat replay'
         },
         ycs_btn_quick_transcript: {
             name: 'quickTranscript',
-            title: 'Show transcript (Newest)',
-            dataSort: 'newest',
-            dataSortTrp: 'newest'
+            title: 'Show transcript'
+        },
+        ycs_btn_comments: {
+            name: 'comments',
+            title: 'Show comments and replies'
+        },
+        ycs_btn_origin: {
+            name: 'origin',
+            title: 'Show non-reply comments only'
         }
     };
 
     const config = buttonConfigs[buttonId];
     if (!config) return '';
 
-    const dataSortAttr = config.dataSort ? `data-sort="${config.dataSort}"` : '';
-    const dataSortChatAttr = config.dataSortChat ? `data-sort-chat="${config.dataSortChat}"` : '';
-    const dataSortTrpAttr = config.dataSortTrp ? `data-sort-trp="${config.dataSortTrp}"` : '';
-    const sortIcon = config.dataSort ? iconSortDown() : '';
     const icon = config.icon || '';
 
     return `
         <button id="${buttonId}"
-            ${dataSortAttr}
-            ${dataSortChatAttr}
-            ${dataSortTrpAttr}
             class="ycs-btn-search ycs-title"
             name="${config.name}" type="button"
             title="${config.title}">
@@ -1185,17 +1150,18 @@ function generateFilterButtonHTML(buttonId: string): string {
                                     ? 'Members'
                                     : config.name === 'donated'
                                       ? 'Donated'
-                                      : config.name === 'sortFirst'
-                                        ? 'All'
+                                      : config.name === 'comments'
+                                        ? 'Comments'
                                         : config.name === 'random'
                                           ? 'Random'
                                           : config.name === 'quickChat'
                                             ? 'Chat'
                                             : config.name === 'quickTranscript'
                                               ? 'Transcript'
-                                              : config.name
+                                              : config.name === 'origin'
+                                                ? 'Origin'
+                                                : config.name
             }
-            ${sortIcon}
         </button>`;
 }
 
@@ -1209,12 +1175,19 @@ function renderSearch(node: HTMLElement): void {
                     <input title="Write the search query, press Enter or click the button Search."
                         class="ycs-search__input ycs_noselect" type="text" id="ycs-input-search" placeholder="Search">
                 </div>
-                <select title="Select a search category." name="ycs_search_select"
-                    id="ycs_search_select" class="ycs-btn-search ycs-title ycs-search-select ycs_noselect">
-                    <option value="comments">Comments</option>
-                    <option value="chat">Chat replay</option>
-                    <option value="video">Trpt. video</option>
-                    <option selected value="all">All</option>
+                <select title="Sort by." name="ycs_sort_select"
+                    id="ycs_sort_select" class="ycs-btn-search ycs-title ycs_sort_select ycs_noselect">
+                    <option selected value="relevance">Relevance</option>
+                    <option value="newest">Newest</option>
+                    <option value="oldest">Oldest</option>
+                    <option value="most_likes">Most Likes</option>
+                    <option value="least_likes">Least Likes</option>
+                    <option value="most_replies">Most Replies</option>
+                    <option value="least_replies">Least Replies</option>
+                    <option value="author_az">Author(a-z)</option>
+                    <option value="author_za">Author(z-a)</option>
+                    <option value="longest">Longest</option>
+                    <option value="shortest">Shortest</option>
                 </select>
                 <button id="ycs_btn_search" class="ycs-btn-search ycs-title ycs_noselect" type="button">
                     Search
@@ -1226,6 +1199,10 @@ function renderSearch(node: HTMLElement): void {
                         <label for="ycs_extended_search" class="ycs_noselect ycs-title" title="Enables the use of unix-like search commands">
                             <input type="checkbox" name="ycs_extended_search" id="ycs_extended_search">
                             <span class="ycs-ext-search_title">Extended search</span>
+                        </label>
+                        <label hidden id="ycs_timestamp_sort_label" for="ycs_timestamp_sort" class="ycs_noselect ycs-title" title="Only applies when sorted by newest or oldest">
+                            <input type="checkbox" id="ycs_timestamp_sort" name="ycs_timestamp_sort">
+                            <span class="ycs-ext-search_title">Sort by video time</span>
                         </label>
                         <div class="ycs-ext-search-opts">
                             <fieldset>
@@ -1239,7 +1216,6 @@ function renderSearch(node: HTMLElement): void {
                                     <input type="radio" id="ycs_extended_search_main" name="ycs_ext_search_opts" value="main" disabled checked>
                                     <span class="ycs-ext-search_title">Main</span>
                                 </label>
-
                             </fieldset>
                         </div>
                         <a href="https://github.com/sonigy/YCS#extended-search" class="ycs-title ycs-ext-search_link" target="_blank" rel="noopener noreferrer" title="How to use">?</a>

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -14,7 +14,7 @@ import {
     MemberBadgeViewModel,
     DonatedChipViewModel
 } from './viewModels';
-import { iconCollapse, iconExpandShowMore, iconReload, iconSortDown, iconCurve } from './icons';
+import { iconCollapse, iconExpandShowMore, iconReload, iconCurve } from './icons';
 import { EXPORT_FORMAT } from './constants';
 
 /**

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -25,8 +25,8 @@ import {
     clearCurrentVideoAgeRestricted
 } from '../utils/innertube';
 
-import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
-import type { ChatItem, CommentItem } from '../utils/interfaces/i_types';
+import { IParamSearch, IYCSOptions } from '../utils/interfaces/i_types';
+import type { ChatItem, CommentItem, ISelectedSort } from '../utils/interfaces/i_types';
 
 import { iconOk, iconReload, iconWarning, iconError, iconStop, iconInfo } from '../utils/icons';
 import { renderLoadComments, renderSearch, loadFilterButtons } from '../utils/renderView';
@@ -108,26 +108,22 @@ import { registerCommentInteractions } from './ui/commentInteractions';
 import { runSearch as runCommentsSearch, clearCommentsFuseCache } from './search/commentsSearch';
 import { runSearch as runChatSearch, clearChatFuseCache } from './search/chatSearch';
 import { runSearch as runTranscriptSearch, clearTranscriptFuseCache } from './search/transcriptSearch';
-import { SearchContext, SortOrder } from './search/types';
+import { SearchContext } from './search/types';
 import { renderCommentsResult, renderChatResult, renderTranscriptResult } from './ui/render';
 
 const DEBUG = false;
 
-const CHAT_UNSUPPORTED_FILTERS = ['heart', 'likes', 'replied', 'random', 'quickTranscript', 'timestampViz'] as const;
+const CHAT_UNSUPPORTED_FILTERS = ['heart', 'random', 'timestampViz', 'origin'] as const;
 const TRANSCRIPT_UNSUPPORTED_FILTERS = [
     'heart',
-    'likes',
-    'replied',
     'random',
     'author',
     'donated',
     'members',
     'verified',
-    'quickChat',
-    'timestampViz'
+    'timestampViz',
+    'origin'
 ] as const;
-
-type SortAttribute = 'sort' | 'sortChat' | 'sortTrp';
 
 const dropdownMenus = new Set<HTMLElement>();
 
@@ -154,34 +150,6 @@ const cleanupShortsUI = (): void => {
     console.log('YCS: YouTube Shorts support is disabled');
 };
 
-const getSortableButtonIds = (): string[] => {
-    if (filterRegistry?.sortButtonIds?.length) {
-        return filterRegistry.sortButtonIds;
-    }
-
-    return FILTER_BUTTONS.filter((config) => config.supportsSort).map((config) => config.elementId);
-};
-
-const parseSortOrder = (value: string | undefined): SortOrder | undefined => {
-    if (value === 'newest' || value === 'oldest') {
-        return value;
-    }
-    return undefined;
-};
-
-const readSortOrders = (attribute: SortAttribute): Partial<Record<string, SortOrder>> => {
-    const map: Partial<Record<string, SortOrder>> = {};
-    for (const id of getSortableButtonIds()) {
-        const element = document.getElementById(id) as HTMLElement | null;
-        if (!element) continue;
-        const parsed = parseSortOrder(element.dataset?.[attribute]);
-        if (parsed) {
-            map[id] = parsed;
-        }
-    }
-    return map;
-};
-
 const getParamByElementId = (elementId: string): FilterParamKey | undefined => {
     const mapped = filterRegistry?.idToCode?.[elementId];
     if (mapped) {
@@ -203,6 +171,7 @@ const buildSearchContext = (): SearchContext => {
     const extendedToggle = document.getElementById('ycs_extended_search') as HTMLInputElement | null;
     const extendedTitle = document.getElementById('ycs_extended_search_title') as HTMLInputElement | null;
     const extendedMain = document.getElementById('ycs_extended_search_main') as HTMLInputElement | null;
+    const tsSort = document.getElementById('ycs_timestamp_sort') as HTMLInputElement | null;
 
     return {
         extendedSearch: {
@@ -210,11 +179,7 @@ const buildSearchContext = (): SearchContext => {
             title: Boolean(extendedTitle?.checked),
             main: Boolean(extendedMain?.checked)
         },
-        sortOrders: {
-            comments: readSortOrders('sort'),
-            chat: readSortOrders('sortChat'),
-            transcript: readSortOrders('sortTrp')
-        }
+        timestampSort: Boolean(tsSort?.checked)
     };
 };
 
@@ -482,20 +447,22 @@ export function initApp(): void {
 
         const setActiveFilterByElement = (param: FilterParamKey | null, el?: HTMLElement): void => {
             try {
-                FILTER_BUTTONS.forEach(({ elementId }) => {
-                    const button = document.getElementById(elementId);
-                    button?.classList.remove('ycs_btn_active');
-                });
-
-                if (param && el) {
-                    el.classList.add('ycs_btn_active');
+                if (param === null) {
+                    const activeButtons = document.getElementsByClassName('ycs_btn_active');
+                    for (const btn of Array.from(activeButtons)) {
+                        btn.classList.remove('ycs_btn_active');
+                    }
                 }
 
-                // toggle clear-filter button visibility
-                const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
-                if (btnClear) {
-                    const hasActive = !!param;
-                    btnClear.style.visibility = hasActive ? 'visible' : 'hidden';
+                if (param === 'timestamp') {
+                    const tsSortLabel = document.getElementById('ycs_timestamp_sort_label') as HTMLInputElement;
+                    if (tsSortLabel) tsSortLabel.hidden = !tsSortLabel.hidden;
+                }
+
+                if (el?.classList.contains('ycs_btn_active')) {
+                    el.classList.remove('ycs_btn_active');
+                } else {
+                    el?.classList.add('ycs_btn_active');
                 }
             } catch {
                 // Silently ignore DOM manipulation errors
@@ -506,25 +473,16 @@ export function initApp(): void {
 
         const getActiveFilterParam = (): IParamSearch | undefined => {
             try {
-                const active = document.querySelector('.ycs_btn_active') as HTMLElement | null;
-                const paramKey = active?.id ? getParamByElementId(active.id) : undefined;
-                if (!paramKey) return undefined;
-
-                const param: IParamSearch = { [paramKey]: true } as IParamSearch;
-
-                // Get sort order from the active button's dataset
-                if (active) {
-                    const sortDatasetKeys: Array<'sort' | 'sortChat' | 'sortTrp'> = ['sort', 'sortChat', 'sortTrp'];
-
-                    for (const key of sortDatasetKeys) {
-                        const datasetOrder = active.dataset[key] as SortOrder | undefined;
-                        if (datasetOrder === 'newest' || datasetOrder === 'oldest') {
-                            param.sortOrder = datasetOrder;
-                            break;
-                        }
-                    }
+                const activeEls = Array.from(document.querySelectorAll('.ycs_btn_active')) as HTMLElement[];
+                const param: IParamSearch = {};
+                for (const el of activeEls) {
+                    param[getParamByElementId(el.id) as FilterParamKey] = true;
                 }
 
+                const elSelectSortSearch = document.getElementById('ycs_sort_select') as HTMLSelectElement;
+                param.sortOrder = elSelectSortSearch
+                    ? (elSelectSortSearch.options[elSelectSortSearch.options.selectedIndex].value as ISelectedSort)
+                    : 'relevance';
                 return param;
             } catch {
                 return undefined;
@@ -539,49 +497,19 @@ export function initApp(): void {
             },
             callbacks: {
                 updateTotalResultDisplay,
-                getSearchQuery
+                getSearchQuery,
+                getActiveFilterParam
             }
         };
         const handleTimestampViz = createTimestampVizHandler(timestampVizDeps);
 
-        const executeSearchBasedOnType = (param?: IParamSearch, forceType?: ISelectedSearch): void => {
-            const elSelectOptSearch = document.getElementById('ycs_search_select') as HTMLSelectElement | null;
-            const query = getSearchQuery();
-
+        const executeSearchBasedOnType = (param?: IParamSearch): void => {
             // Special handling for timestampViz
             if (param?.timestampViz) {
                 handleTimestampViz();
                 return;
             }
-
-            const selected =
-                forceType ||
-                (elSelectOptSearch
-                    ? (elSelectOptSearch.options[elSelectOptSearch.options.selectedIndex].value as ISelectedSearch)
-                    : 'all');
-
-            switch (selected) {
-                case 'comments': {
-                    const result = runCommentsPipeline('#ycs-search-result', query, param);
-                    updateTotalResultDisplay(result.summary);
-                    break;
-                }
-                case 'chat': {
-                    const result = runChatPipeline('#ycs-search-result', query, param);
-                    updateTotalResultDisplay(result.summary);
-                    break;
-                }
-                case 'video': {
-                    const result = runTranscriptPipeline('#ycs-search-result', query, param);
-                    updateTotalResultDisplay(result.summary);
-                    break;
-                }
-                case 'all':
-                default: {
-                    searchCommentsAll('#ycs-search-result', param);
-                    break;
-                }
-            }
+            searchCommentsAll('#ycs-search-result', param);
         };
 
         const initFilterButtons = (filterButtons?: Array<{ id: string; enabled: boolean }>): void => {
@@ -629,24 +557,20 @@ export function initApp(): void {
 
                         state = resetSearchCounts(state);
 
-                        const eInputSearch = document.getElementById('ycs-input-search') as HTMLInputElement;
+                        const elSearchRes = document.getElementById('ycs-search-result');
+                        const elSearchTotalRes = document.getElementById(
+                            'ycs-search-total-result'
+                        ) as HTMLElement | null;
 
-                        if (eInputSearch?.value && eInputSearch.value.trim()) {
-                            requestAnimationFrame(() => {
-                                const searchBtn = document.getElementById('ycs_btn_search');
-                                searchBtn?.click();
-                            });
-                        } else {
-                            const elSearchRes = document.getElementById('ycs-search-result');
-                            const elSearchTotalRes = document.getElementById(
-                                'ycs-search-total-result'
-                            ) as HTMLElement | null;
-
-                            if (elSearchRes && elSearchTotalRes) {
-                                elSearchRes.innerText = '';
-                                elSearchTotalRes.innerText = 'Search cleared';
-                            }
+                        if (elSearchRes && elSearchTotalRes) {
+                            elSearchRes.innerText = '';
+                            elSearchTotalRes.innerText = 'Search cleared';
                         }
+
+                        const tsSortLabel = document.getElementById('ycs_timestamp_sort_label') as HTMLInputElement;
+                        if (tsSortLabel) tsSortLabel.hidden = true;
+                        const tsSort = document.getElementById('ycs_timestamp_sort') as HTMLInputElement | null;
+                        if (tsSort) tsSort.checked = false;
 
                         const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
                         if (btnClear) btnClear.style.visibility = 'hidden';
@@ -1098,7 +1022,7 @@ export function initApp(): void {
                     const elSearchRes = document.getElementById('ycs-search-result');
                     const elSearchTotalRes = document.getElementById('ycs-search-total-result') as HTMLElement | null;
 
-                    if (activeParam) {
+                    if (Object.keys(activeParam ?? { SortOrder: 'newest' }).length > 1) {
                         // Reapply current filter while only clearing the text query
                         requestAnimationFrame(() => {
                             btnSearch?.click();
@@ -1467,10 +1391,15 @@ export function initApp(): void {
              */
 
             const hasChatUnsupportedFilter = CHAT_UNSUPPORTED_FILTERS.some((filter) => param?.[filter]);
-            const shouldRenderChat = !param || param.sortFirst === true || !hasChatUnsupportedFilter;
+            const shouldRenderChat =
+                (param?.quickChat || (!param?.quickComments && !param?.quickTranscript)) && !hasChatUnsupportedFilter;
 
             const hasTranscriptUnsupportedFilter = TRANSCRIPT_UNSUPPORTED_FILTERS.some((filter) => param?.[filter]);
-            const shouldRenderTranscript = !param || param.sortFirst === true || !hasTranscriptUnsupportedFilter;
+            const shouldRenderTranscript =
+                (param?.quickTranscript || (!param?.quickComments && !param?.quickChat)) &&
+                !hasTranscriptUnsupportedFilter;
+
+            const shouldRenderComments = param?.quickComments || (!param?.quickTranscript && !param?.quickChat);
 
             if (elSearchAll) elSearchAll.textContent = '';
 
@@ -1486,7 +1415,7 @@ export function initApp(): void {
             state = resetSearchCounts(state);
 
             try {
-                if (comments.length > 0) {
+                if (shouldRenderComments && comments.length > 0) {
                     elSearchAll?.appendChild(elWrapComments);
                     runCommentsPipeline('#ycs_allsearch__wrap_comments', query, param);
                 }
@@ -1504,32 +1433,12 @@ export function initApp(): void {
                 const searchCounts = getSearchCounts(state);
                 const resTotalSearch = searchCounts.comments + searchCounts.commentsChat + searchCounts.commentsTrVideo;
 
-                let resultText = '';
-                if (param?.timestamp) {
-                    resultText = `Time stamps, found: ${resTotalSearch}`;
-                } else if (param?.author) {
-                    resultText = `Author, found: ${resTotalSearch}`;
-                } else if (param?.heart) {
-                    resultText = `Heart, found: ${resTotalSearch}`;
-                } else if (param?.verified) {
-                    resultText = `Verified authors, found: ${resTotalSearch}`;
-                } else if (param?.links) {
-                    resultText = `Links, found: ${resTotalSearch}`;
-                } else if (param?.likes) {
-                    resultText = `Likes, found: ${resTotalSearch}`;
-                } else if (param?.replied) {
-                    resultText = `Replied, found: ${resTotalSearch}`;
-                } else if (param?.members) {
-                    resultText = `Members, found: ${resTotalSearch}`;
-                } else if (param?.donated) {
-                    resultText = `Donated, found: ${resTotalSearch}`;
-                } else if (param?.random) {
-                    resultText = `Random, found: ${resTotalSearch}`;
-                } else if (param?.sortFirst) {
-                    resultText = `All comments, found: ${resTotalSearch}`;
-                } else {
-                    resultText = `(All) Found: ${resTotalSearch}`;
+                const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
+                if (param && btnClear) {
+                    btnClear.style.visibility = 'visible';
                 }
+
+                const resultText = `Found: ${resTotalSearch}`;
                 updateTotalResultDisplay(resultText);
             } catch (err) {
                 console.error(err);
@@ -1539,9 +1448,9 @@ export function initApp(): void {
             btnSearch.addEventListener('click', (): void => {
                 // keep current active filter when performing a generic Search
 
-                const elSelectOptSearch = document.getElementById('ycs_search_select') as HTMLSelectElement;
+                const elSelectSortSearch = document.getElementById('ycs_sort_select') as HTMLSelectElement;
 
-                if (elSelectOptSearch) {
+                if (elSelectSortSearch) {
                     const activeParam = getActiveFilterParam();
                     executeSearchBasedOnType(activeParam);
                 }
@@ -1598,14 +1507,6 @@ export function initApp(): void {
                     }
                 };
 
-                const optSortTimestamp = (value: boolean): void => {
-                    try {
-                        GlobalStore.sortTimestamp = value;
-                    } catch (err) {
-                        console.error(err);
-                    }
-                };
-
                 const optHiddenByDefault = (opts: IYCSOptions): void => {
                     try {
                         const app = document.querySelector('.ycs-app') as HTMLElement;
@@ -1654,10 +1555,6 @@ export function initApp(): void {
 
                             case 'cache':
                                 optCached(Boolean(opts.cache));
-                                break;
-
-                            case 'sortTimestamp':
-                                optSortTimestamp(Boolean(opts.sortTimestamp));
                                 break;
 
                             case 'hiddenByDefault':

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -29,7 +29,7 @@ import { IParamSearch, IYCSOptions } from '../utils/interfaces/i_types';
 import type { ChatItem, CommentItem, ISelectedSort } from '../utils/interfaces/i_types';
 
 import { iconOk, iconReload, iconWarning, iconError, iconStop, iconInfo } from '../utils/icons';
-import { renderLoadComments, renderSearch, loadFilterButtons } from '../utils/renderView';
+import { renderLoadComments, renderSearch, loadFilterButtons, selectSortOption } from '../utils/renderView';
 import { loadFromCache, saveToCache, updateBadge } from './services/cacheService';
 import type { CacheData } from './services/cacheService';
 import { YouTubeApiMessageError, requestYouTubeApiComments } from './handlers/youtubeDataApiHandler';
@@ -1599,6 +1599,10 @@ export function initApp(): void {
                                 GlobalStore.youtubeApiEnabled = opts.youtubeApiEnabled !== false; // default true
                                 break;
 
+                            case 'defaultSort':
+                                GlobalStore.defaultSort = opts.defaultSort ?? 'relevance';
+                                selectSortOption(GlobalStore.defaultSort);
+                                break;
                             default:
                                 break;
                         }

--- a/app/src/source/web-resources/features/timestampVizHandler.ts
+++ b/app/src/source/web-resources/features/timestampVizHandler.ts
@@ -9,7 +9,7 @@
  */
 
 import { extractVideoDuration } from '../../utils/common';
-import type { CommentItem } from '../../utils/interfaces/i_types';
+import type { CommentItem, IParamSearch } from '../../utils/interfaces/i_types';
 import {
     extractTimestamps,
     createTimeIntervals,
@@ -37,6 +37,7 @@ export interface TimestampVizStateDeps {
 export interface TimestampVizCallbacks {
     updateTotalResultDisplay: (text: string) => void;
     getSearchQuery: () => string;
+    getActiveFilterParam: () => IParamSearch | undefined;
 }
 
 export interface TimestampVizDeps {
@@ -71,17 +72,15 @@ export function createTimestampVizHandler(deps: TimestampVizDeps): () => void {
 
             // Get search query and filter comments if needed
             const query = callbacks.getSearchQuery();
+            const filters = callbacks.getActiveFilterParam();
             let filteredComments = comments;
 
-            if (query.trim()) {
-                // Use existing search logic to filter comments by search query
-                const context: SearchContext = {
-                    extendedSearch: { enabled: false, title: false, main: false },
-                    sortOrders: { comments: {}, chat: {}, transcript: {} }
-                };
-                const searchResult = runCommentsSearch(query.trim(), {}, state.getState(), context);
-                filteredComments = searchResult.results.map((result) => result.item as CommentItem);
-            }
+            // Use existing search logic to filter comments by search query
+            const context: SearchContext = {
+                extendedSearch: { enabled: false, title: false, main: false }
+            };
+            const searchResult = runCommentsSearch(query.trim(), filters, state.getState(), context);
+            filteredComments = searchResult.results.map((result) => result.item as CommentItem);
 
             // Extract timestamps from filtered comments
             const timestamps = extractTimestamps(filteredComments);

--- a/app/src/source/web-resources/search/chatSearch.ts
+++ b/app/src/source/web-resources/search/chatSearch.ts
@@ -10,7 +10,8 @@ import {
     createChatVerifiedFilter,
     createChatLinksFilter,
     DerivedChatMessage,
-    ChatFilterConfig
+    ChatFilterConfig,
+    createChatEmojiFilter
 } from '../../utils/filters/chatAgg';
 import type { ChatItem, FuseSupportedItem, ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getCommentsChat, WebResourcesState } from '../state';
@@ -218,6 +219,9 @@ export function runSearch(
                 break;
             case 'links':
                 filterConfigs.push(createChatLinksFilter());
+                break;
+            case 'emoji':
+                filterConfigs.push(createChatEmojiFilter());
                 break;
             default:
                 break;

--- a/app/src/source/web-resources/search/chatSearch.ts
+++ b/app/src/source/web-resources/search/chatSearch.ts
@@ -15,7 +15,6 @@ import {
 import type { ChatItem, FuseSupportedItem, ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getCommentsChat, WebResourcesState } from '../state';
 import { SearchContext } from './types';
-import { FilterConfig } from '../../utils/filters/types';
 
 export interface SearchButtonState {
     title?: string;

--- a/app/src/source/web-resources/search/chatSearch.ts
+++ b/app/src/source/web-resources/search/chatSearch.ts
@@ -2,7 +2,6 @@ import Fuse from '../../../../node_modules/fuse.js/dist/fuse';
 
 import { buildKeysSignature, buildOptionsSignature, cloneFuseOptions } from './fuseCacheUtils';
 
-import { filterChatNewestFirst } from '../../utils/filters/chat';
 import {
     applyChatFilters,
     createChatAuthorFilter,
@@ -10,14 +9,15 @@ import {
     createChatDonatedFilter,
     createChatVerifiedFilter,
     createChatLinksFilter,
-    DerivedChatMessage
+    DerivedChatMessage,
+    ChatFilterConfig
 } from '../../utils/filters/chatAgg';
 import type { ChatItem, FuseSupportedItem, ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getCommentsChat, WebResourcesState } from '../state';
 import { SearchContext } from './types';
+import { FilterConfig } from '../../utils/filters/types';
 
 export interface SearchButtonState {
-    order?: 'newest' | 'oldest';
     title?: string;
     label?: string;
     dataset?: Record<string, string>;
@@ -31,7 +31,9 @@ export interface ChatSearchResult {
     buttonStates: Record<string, SearchButtonState>;
 }
 
-const UNSUPPORTED_FILTERS: (keyof IParamSearch)[] = ['heart', 'likes', 'replied', 'random', 'quickTranscript'];
+const UNSUPPORTED_FILTERS: (keyof IParamSearch)[] = ['heart', 'random', 'origin'];
+
+const UNSUPPORTED_SORTS: IParamSearch['sortOrder'][] = ['most_likes', 'least_likes', 'most_replies', 'least_replies'];
 
 // Fuse cache for the full chat array (subsets still use transient instances).
 interface ChatFuseCache<T> {
@@ -72,10 +74,6 @@ function mapFuseResults<T extends FuseSupportedItem>(raw: readonly Fuse.FuseResu
         refIndex: (result.item as { _index?: number })?._index ?? result.refIndex ?? 0,
         score: result.score
     }));
-}
-
-function ensureSortOrder(order?: 'newest' | 'oldest'): 'newest' | 'oldest' {
-    return order === 'oldest' ? 'oldest' : 'newest';
 }
 
 function mapDerivedToResults(items: DerivedChatMessage[]): ICommentsFuseResult<ChatItem>[] {
@@ -176,220 +174,104 @@ export function runSearch(
     const buttonStates: Record<string, SearchButtonState> = {};
     let resultSearch: ICommentsFuseResult<ChatItem>[] = [];
 
-    const updateButtonState = (id: string, order: 'newest' | 'oldest', title: string, label?: string): void => {
-        buttonStates[id] = {
-            order,
-            title,
-            label,
-            dataset: {
-                sortChat: order,
-                sort: order
-            }
+    // Convert all chat items to search results format
+    const allResults: ICommentsFuseResult<ChatItem>[] = cmntsChat.map((item, _index) => {
+        const firstAction = item.replayChatItemAction.actions?.[0];
+        const liveChatRenderer = firstAction?.addChatItemAction?.item?.liveChatTextMessageRenderer;
+
+        return {
+            item,
+            refIndex: toTimestampRef(liveChatRenderer?.timestampUsec),
+            score: 0
         };
-    };
+    });
 
-    if (param.author) {
-        const derived = applyChatFilters(cmntsChat, [createChatAuthorFilter()]);
+    // Use filterWithQuery to handle empty queries properly
+    resultSearch = filterWithQuery(allResults, trimmedQuery, options);
+    if (param.sortOrder === 'relevance' && trimmedQuery.length === 0) {
+        // No such thing as sorting by relevance for empty query, default to newest
+        param.sortOrder = 'newest';
+    }
+
+    const filterConfigs = [] as ChatFilterConfig[];
+    for (const key of Object.keys(param)) {
+        switch (key) {
+            case 'author':
+                filterConfigs.push(createChatAuthorFilter());
+                break;
+            case 'donated':
+                filterConfigs.push(createChatDonatedFilter());
+                break;
+            case 'members':
+                filterConfigs.push(createChatMembersFilter());
+                break;
+            case 'timestamp': {
+                const timestampOptions: Fuse.IFuseOptions<any> = {
+                    ...options,
+                    keys: ['replayChatItemAction.actions.addChatItemAction.item.liveChatTextMessageRenderer.isTimeLine']
+                };
+                const fuse = getChatFuseInstance<ChatItem>(cmntsChat, timestampOptions);
+                resultSearch = mapFuseResults(fuse.search('timeline'));
+                break;
+            }
+            case 'verified':
+                filterConfigs.push(createChatVerifiedFilter());
+                break;
+            case 'links':
+                filterConfigs.push(createChatLinksFilter());
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (filterConfigs.length > 0) {
+        const derived = applyChatFilters(cmntsChat, filterConfigs);
         resultSearch = mapDerivedToResults(derived);
+    }
 
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_author']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_author',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies, chat from the author (Oldest)'
-                    : 'Show comments, replies, chat from the author (Newest)',
-                'Author'
+    if (resultSearch.length > 1) {
+        if (param.sortOrder === 'oldest') {
+            resultSearch.sort((a, b) => b.refIndex - a.refIndex);
+        } else if (param.sortOrder === 'longest') {
+            resultSearch.sort(
+                (a, b) =>
+                    ((b.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.message?.fullText?.length ?? '') -
+                    ((a.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.message?.fullText?.length ?? '')
             );
-        }
-    } else if (param.donated) {
-        const derived = applyChatFilters(cmntsChat, [createChatDonatedFilter()]);
-        resultSearch = mapDerivedToResults(derived);
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_donated']);
-            if (resolvedOrder === 'newest') {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
-            } else {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options, true);
-            }
-
-            updateButtonState(
-                'ycs_btn_donated',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show chat comments from users who have donated (Oldest)'
-                    : 'Show chat comments from users who have donated (Newest)',
-                'Donated'
+        } else if (param.sortOrder === 'shortest') {
+            resultSearch.sort(
+                (a, b) =>
+                    ((a.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.message?.fullText?.length ?? '') -
+                    ((b.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.message?.fullText?.length ?? '')
             );
-        }
-    } else if (param.members) {
-        const derived = applyChatFilters(cmntsChat, [createChatMembersFilter()]);
-        resultSearch = mapDerivedToResults(derived);
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_members']);
-            if (resolvedOrder === 'newest') {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
-            } else {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options, true);
-            }
-
-            updateButtonState(
-                'ycs_btn_members',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies, chat from channel members (Oldest)'
-                    : 'Show comments, replies, chat from channel members (Newest)',
-                'Members'
+        } else if (param.sortOrder === 'author_az') {
+            resultSearch.sort((a, b) =>
+                (
+                    (a.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.authorName?.simpleText ?? ''
+                ).localeCompare(
+                    (b.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.authorName?.simpleText ?? ''
+                )
             );
-        }
-    } else if (param.timestamp) {
-        const timestampOptions: Fuse.IFuseOptions<any> = {
-            ...options,
-            keys: ['replayChatItemAction.actions.addChatItemAction.item.liveChatTextMessageRenderer.isTimeLine']
-        };
-
-        const fuse = getChatFuseInstance<ChatItem>(cmntsChat, timestampOptions);
-        resultSearch = mapFuseResults(fuse.search('timeline'));
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_timestamps']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_timestamps',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies, chat with time stamps (Oldest)'
-                    : 'Show comments, replies, chat with time stamps (Newest)',
-                'Time stamps'
+        } else if (param.sortOrder === 'author_za') {
+            resultSearch.sort((a, b) =>
+                (
+                    (b.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.authorName?.simpleText ?? ''
+                ).localeCompare(
+                    (a.item as any)?.replayChatItemAction?.actions?.[0]?.addChatItemAction?.item
+                        ?.liveChatTextMessageRenderer?.authorName?.simpleText ?? ''
+                )
             );
-        }
-    } else if (param.sortFirst) {
-        resultSearch = filterChatNewestFirst(commentsChat) ?? [];
-
-        if (trimmedQuery) {
-            try {
-                const fuseBase = getChatFuseInstance<ChatItem>(cmntsChat, options);
-                const matched = new Set<ChatItem>(fuseBase.search(trimmedQuery).map((entry) => entry.item));
-                resultSearch = resultSearch.filter((entry) => matched.has(entry.item));
-            } catch (error) {
-                console.error(error);
-            }
-        }
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_sort_first']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_sort_first',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show all comments, chat, video transcript sorted by date (Oldest)'
-                    : 'Show all comments, chat, video transcript sorted by date (Newest)',
-                'All'
-            );
-        }
-    } else if (param.verified) {
-        const derived = applyChatFilters(cmntsChat, [createChatVerifiedFilter()]);
-        resultSearch = mapDerivedToResults(derived);
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_verified']);
-            if (resolvedOrder === 'newest') {
-                // Use query to further filter if present
-                if (trimmedQuery) {
-                    resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
-                }
-            } else {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options, true);
-            }
-
-            updateButtonState(
-                'ycs_btn_verified',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies and chat from verified authors (Oldest)'
-                    : 'Show comments, replies and chat from verified authors (Newest)'
-            );
-        }
-    } else if (param.links) {
-        const derived = applyChatFilters(cmntsChat, [createChatLinksFilter()]);
-        resultSearch = mapDerivedToResults(derived);
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_links']);
-            if (resolvedOrder === 'newest') {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options);
-            } else {
-                resultSearch = filterWithQuery(resultSearch, trimmedQuery, options, true);
-            }
-
-            updateButtonState(
-                'ycs_btn_links',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Shows links in comments, replies, chat, video transcript (Oldest)'
-                    : 'Shows links in comments, replies, chat, video transcript (Newest)',
-                'Links'
-            );
-        }
-    } else {
-        // Convert all chat items to search results format
-        const allResults: ICommentsFuseResult<ChatItem>[] = cmntsChat.map((item, _index) => {
-            const firstAction = item.replayChatItemAction.actions?.[0];
-            const liveChatRenderer = firstAction?.addChatItemAction?.item?.liveChatTextMessageRenderer;
-
-            return {
-                item,
-                refIndex: toTimestampRef(liveChatRenderer?.timestampUsec),
-                score: 0
-            };
-        });
-
-        // Use filterWithQuery to handle empty queries properly
-        resultSearch = filterWithQuery(allResults, trimmedQuery, options);
-
-        // Apply sorting for quickChat filter
-        if (param.quickChat && resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.chat['ycs_btn_quick_chat']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_quick_chat',
-                resolvedOrder,
-                resolvedOrder === 'oldest' ? 'Show chat replay (Oldest)' : 'Show chat replay (Newest)',
-                'Chat'
-            );
+        } else if (param.sortOrder === 'newest' || UNSUPPORTED_SORTS.some((key) => param.sortOrder === key)) {
+            // Unsupported sorts default to newest
+            resultSearch.sort((a, b) => a.refIndex - b.refIndex);
         }
     }
 

--- a/app/src/source/web-resources/search/commentsSearch.ts
+++ b/app/src/source/web-resources/search/commentsSearch.ts
@@ -2,27 +2,23 @@ import Fuse from '../../../../node_modules/fuse.js/dist/fuse';
 
 import { buildKeysSignature, buildOptionsSignature, cloneFuseOptions } from './fuseCacheUtils';
 
-import { getRandomComment } from '../../utils/dom';
-import { filterNewestFirst } from '../../utils/filters/comments';
 import { applyFilters } from '../../utils/filters/engine';
 import {
-    createLikesFilter,
-    createRepliesFilter,
     createVerifiedFilter,
     createMemberFilter,
     createCreatorHeartFilter,
     createLinksFilter,
     createTimelineFilter,
     createDonatedFilter,
-    createChannelOwnerFilter
+    createChannelOwnerFilter,
+    createOriginalCommentsFilter
 } from '../../utils/filters/commentsAgg';
 import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getComments, WebResourcesState } from '../state';
 import { SearchContext } from './types';
-import { GlobalStore } from '../../utils/common';
+import { FilterConfig } from '../../utils/filters/types';
 
 export interface SearchButtonState {
-    order?: 'newest' | 'oldest';
     title?: string;
     label?: string;
     dataset?: Record<string, string>;
@@ -85,22 +81,21 @@ function applyTextMatches(results: ICommentsFuseResult[], matches: Set<any> | nu
     return results.filter((entry) => matches.has(entry.item));
 }
 
-function ensureSortOrder(order?: 'newest' | 'oldest'): 'newest' | 'oldest' {
-    return order === 'oldest' ? 'oldest' : 'newest';
-}
-
-function searchWithinSubset(
-    subset: ICommentsFuseResult[],
-    options: Fuse.IFuseOptions<any>,
-    query: string
-): ICommentsFuseResult[] {
-    if (!query.trim()) {
-        return subset;
-    }
-
-    const base = subset.map((entry) => entry.item);
-    const fuse = new Fuse(base, options);
-    return mapFuseResults(fuse.search(query.trim())) as ICommentsFuseResult[];
+function sortByTimestamp(results: ICommentsFuseResult[]): ICommentsFuseResult[] {
+    return results.sort((a, b) => {
+        const getFirstTimestamp = (item: any): number => {
+            const runs = item.commentRenderer?.contentText?.runs;
+            if (runs && runs.length > 0) {
+                for (const run of runs) {
+                    if (run.navigationEndpoint?.watchEndpoint?.startTimeSeconds >= 0) {
+                        return run.navigationEndpoint.watchEndpoint.startTimeSeconds * 1000;
+                    }
+                }
+            }
+            return 0;
+        };
+        return getFirstTimestamp(a.item) - getFirstTimestamp(b.item);
+    });
 }
 
 export function runSearch(
@@ -155,274 +150,119 @@ export function runSearch(
     const buttonStates: Record<string, SearchButtonState> = {};
     let resultSearch: ICommentsFuseResult[] = [];
 
-    const updateButtonState = (id: string, order: 'newest' | 'oldest', title: string, label?: string): void => {
-        buttonStates[id] = {
-            order,
-            title,
-            label
-        };
-    };
-
-    if (param.likes) {
-        const agg = applyFilters(comments, [createLikesFilter({})]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-        resultSearch.sort((a, b) => {
-            const likesA = (a.item as any)?.commentRenderer?.likesForSort || 0;
-            const likesB = (b.item as any)?.commentRenderer?.likesForSort || 0;
-            if (likesB !== likesA) return likesB - likesA;
-            return (a.refIndex || 0) - (b.refIndex || 0);
-        });
-    } else if (param.links) {
-        const agg = applyFilters(comments, [createLinksFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            let sortOrder = param.sortOrder ?? context.sortOrders.comments['ycs_btn_links'];
-            if (sortOrder === undefined && trimmedQuery) {
-                resultSearch = searchWithinSubset(resultSearch, options, trimmedQuery);
-                sortOrder = 'newest';
-            }
-
-            const resolvedOrder = ensureSortOrder(sortOrder);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_links',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Shows links in comments, replies, chat, video transcript (Oldest)'
-                    : 'Shows links in comments, replies, chat, video transcript (Newest)',
-                'Links'
-            );
-        }
-    } else if (param.members) {
-        const agg = applyFilters(comments, [createMemberFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_members']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_members',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies, chat from channel members (Oldest)'
-                    : 'Show comments, replies, chat from channel members (Newest)',
-                'Members'
-            );
-        }
-    } else if (param.donated) {
-        const agg = applyFilters(comments, [createDonatedFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_donated']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_donated',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments from users who have donated (Oldest)'
-                    : 'Show comments from users who have donated (Newest)',
-                'Donated'
-            );
-        }
-    } else if (param.replied) {
-        const agg = applyFilters(comments, [createRepliesFilter({ min: 1 })]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-        resultSearch.sort((a, b) => {
-            const repliedA = (a.item as any)?.commentRenderer?.repliedForSort || 0;
-            const repliedB = (b.item as any)?.commentRenderer?.repliedForSort || 0;
-            if (repliedB !== repliedA) return repliedB - repliedA;
-            return (a.refIndex || 0) - (b.refIndex || 0);
-        });
-    } else if (param.author) {
-        const agg = applyFilters(comments, [createChannelOwnerFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_author']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_author',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies, chat from the author (Oldest)'
-                    : 'Show comments, replies, chat from the author (Newest)',
-                'Author'
-            );
-        }
-    } else if (param.heart) {
-        const agg = applyFilters(comments, [createCreatorHeartFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_heart']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_heart',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments and replies that the author likes (Oldest)'
-                    : 'Show comments and replies that the author likes (Newest)'
-            );
-        }
-    } else if (param.verified) {
-        const agg = applyFilters(comments, [createVerifiedFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_verified']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_verified',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies and chat from verified authors (Oldest)'
-                    : 'Show comments, replies and chat from verified authors (Newest)'
-            );
-        }
-    } else if (param.random) {
-        if (trimmedQuery) {
-            const subset = Array.from(matches ?? []);
-            if (subset.length > 0) {
-                const pick = subset[Math.floor(Math.random() * subset.length)];
-                resultSearch = [
-                    {
-                        item: pick,
-                        refIndex: (pick as any)?._index ?? 0
-                    }
-                ];
-            } else {
-                resultSearch = [];
-            }
-        } else {
-            resultSearch = getRandomComment(comments) as ICommentsFuseResult[];
-        }
-    } else if (param.timestamp) {
-        const agg = applyFilters(comments, [createTimelineFilter(true)]);
-        resultSearch = applyTextMatches(
-            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
-            matches
-        );
-
-        if (resultSearch.length > 0) {
-            if (GlobalStore?.sortTimestamp === true) {
-                resultSearch.sort((a, b) => {
-                    const getFirstTimestamp = (item: any): number => {
-                        const runs = item.commentRenderer?.contentText?.runs;
-                        if (runs && runs.length > 0) {
-                            for (const run of runs) {
-                                if (run.navigationEndpoint?.watchEndpoint?.startTimeSeconds >= 0) {
-                                    return run.navigationEndpoint.watchEndpoint.startTimeSeconds * 1000;
-                                }
-                            }
-                        }
-                        return 0;
-                    };
-                    return getFirstTimestamp(a.item) - getFirstTimestamp(b.item);
-                });
-            } else {
-                resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-            }
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_timestamps']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_timestamps',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show comments, replies, chat with time stamps (Oldest)'
-                    : 'Show comments, replies, chat with time stamps (Newest)',
-                'Time stamps'
-            );
-        }
-    } else if (param.sortFirst) {
-        const newest = filterNewestFirst(comments) || [];
-        resultSearch = applyTextMatches(newest, matches);
-
-        if (resultSearch.length > 0) {
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.comments['ycs_btn_sort_first']);
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_sort_first',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show all comments, chat, video transcript sorted by date (Oldest)'
-                    : 'Show all comments, chat, video transcript sorted by date (Newest)',
-                'All'
-            );
-        }
+    if (trimmedQuery) {
+        const fuse = getFuseInstance(comments, options);
+        resultSearch = mapFuseResults(fuse.search(trimmedQuery));
     } else {
-        if (trimmedQuery) {
-            const fuse = getFuseInstance(comments, options);
-            resultSearch = mapFuseResults(fuse.search(trimmedQuery));
-        } else {
-            // Handle empty query by returning all results
-            resultSearch = comments.map((item, index) => ({
-                item,
-                refIndex: index,
-                score: 0
-            }));
+        // Handle empty query by returning all results
+        resultSearch = comments.map((item, index) => ({
+            item,
+            refIndex: index,
+            score: 0
+        }));
+        if (param.sortOrder === 'relevance') {
+            // No such thing as sorting by relevance for empty query, default to newest
+            param.sortOrder = 'newest';
+        }
+    }
+
+    const filterConfigs = [] as FilterConfig[];
+    for (const key of Object.keys(param)) {
+        switch (key) {
+            case 'links':
+                filterConfigs.push(createLinksFilter(true));
+                break;
+            case 'members':
+                filterConfigs.push(createMemberFilter(true));
+                break;
+            case 'donated':
+                filterConfigs.push(createDonatedFilter(true));
+                break;
+            case 'author':
+                filterConfigs.push(createChannelOwnerFilter(true));
+                break;
+            case 'heart':
+                filterConfigs.push(createCreatorHeartFilter(true));
+                break;
+            case 'verified':
+                filterConfigs.push(createVerifiedFilter(true));
+                break;
+            case 'timestamp':
+                filterConfigs.push(createTimelineFilter(true));
+                break;
+            case 'origin':
+                filterConfigs.push(createOriginalCommentsFilter(true));
+                break;
+            default:
+                break;
+        }
+    }
+
+    if (filterConfigs.length > 0) {
+        const agg = applyFilters(comments, filterConfigs);
+        resultSearch = applyTextMatches(
+            agg.items.map((item) => ({ item, refIndex: (item as any)?._index ?? 0 })),
+            matches
+        );
+    }
+
+    if (param.random && resultSearch.length > 1) {
+        resultSearch = [resultSearch[Math.floor(Math.random() * resultSearch.length)]];
+    }
+
+    if (resultSearch.length > 1) {
+        if (context.timestampSort == true && param.sortOrder === 'newest') {
+            resultSearch = sortByTimestamp(resultSearch);
+        } else if (context.timestampSort == true && param.sortOrder === 'oldest') {
+            resultSearch = sortByTimestamp(resultSearch).reverse();
+        } else if (param.sortOrder === 'newest') {
+            resultSearch.sort((a, b) => a.refIndex - b.refIndex);
+        } else if (param.sortOrder === 'oldest') {
+            resultSearch.sort((a, b) => b.refIndex - a.refIndex);
+        } else if (param.sortOrder === 'most_likes') {
+            resultSearch.sort(
+                (a, b) => (b.item as any)?.commentRenderer?.likeCount - (a.item as any)?.commentRenderer?.likeCount
+            );
+        } else if (param.sortOrder === 'least_likes') {
+            resultSearch.sort(
+                (a, b) => (a.item as any)?.commentRenderer?.likeCount - (b.item as any)?.commentRenderer?.likeCount
+            );
+        } else if (param.sortOrder === 'most_replies') {
+            resultSearch.sort(
+                (a, b) =>
+                    ((b.item as any)?.commentRenderer?.replyCount ?? 0) -
+                    ((a.item as any)?.commentRenderer?.replyCount ?? 0)
+            );
+        } else if (param.sortOrder === 'least_replies') {
+            resultSearch.sort(
+                (a, b) =>
+                    ((a.item as any)?.commentRenderer?.replyCount ?? 0) -
+                    ((b.item as any)?.commentRenderer?.replyCount ?? 0)
+            );
+        } else if (param.sortOrder === 'author_az') {
+            resultSearch.sort((a, b) =>
+                (a.item as any)?.commentRenderer?.authorText?.simpleText.localeCompare(
+                    (b.item as any)?.commentRenderer?.authorText?.simpleText
+                )
+            );
+        } else if (param.sortOrder === 'author_za') {
+            resultSearch.sort((a, b) =>
+                (b.item as any)?.commentRenderer?.authorText?.simpleText.localeCompare(
+                    (a.item as any)?.commentRenderer?.authorText?.simpleText
+                )
+            );
+        } else if (param.sortOrder === 'longest') {
+            resultSearch.sort(
+                (a, b) =>
+                    (b.item as any)?.commentRenderer?.contentText?.fullText.length -
+                    (a.item as any)?.commentRenderer?.contentText?.fullText.length
+            );
+        } else if (param.sortOrder === 'shortest') {
+            resultSearch.sort(
+                (a, b) =>
+                    (a.item as any)?.commentRenderer?.contentText?.fullText.length -
+                    (b.item as any)?.commentRenderer?.contentText?.fullText.length
+            );
         }
     }
 

--- a/app/src/source/web-resources/search/commentsSearch.ts
+++ b/app/src/source/web-resources/search/commentsSearch.ts
@@ -11,7 +11,8 @@ import {
     createTimelineFilter,
     createDonatedFilter,
     createChannelOwnerFilter,
-    createOriginalCommentsFilter
+    createOriginalCommentsFilter,
+    createEmojiCommentsFilter
 } from '../../utils/filters/commentsAgg';
 import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
 import { getComments, WebResourcesState } from '../state';
@@ -192,6 +193,9 @@ export function runSearch(
                 break;
             case 'origin':
                 filterConfigs.push(createOriginalCommentsFilter(true));
+                break;
+            case 'emoji':
+                filterConfigs.push(createEmojiCommentsFilter(true));
                 break;
             default:
                 break;

--- a/app/src/source/web-resources/search/fuseCacheUtils.ts
+++ b/app/src/source/web-resources/search/fuseCacheUtils.ts
@@ -13,7 +13,8 @@ const BASE_FUSE_OPTIONS: FuseOptions = {
     minMatchCharLength: 1,
     shouldSort: true,
     threshold: 0.15,
-    distance: 100000
+    distance: 100000,
+    fieldNormWeight: 0.1
 };
 
 export function cloneFuseOptions(): Fuse.IFuseOptions<any> {

--- a/app/src/source/web-resources/search/transcriptSearch.ts
+++ b/app/src/source/web-resources/search/transcriptSearch.ts
@@ -38,7 +38,8 @@ const UNSUPPORTED_FILTERS: (keyof IParamSearch)[] = [
     'donated',
     'members',
     'verified',
-    'origin'
+    'origin',
+    'emoji'
 ];
 
 // Fuse cache for the full cueGroups array (subsets still use transient instances).

--- a/app/src/source/web-resources/search/transcriptSearch.ts
+++ b/app/src/source/web-resources/search/transcriptSearch.ts
@@ -2,14 +2,13 @@ import Fuse from '../../../../node_modules/fuse.js/dist/fuse';
 
 import { buildKeysSignature, buildOptionsSignature, cloneFuseOptions } from './fuseCacheUtils';
 
-import { filterAllTrpVideoComments, filterLinksTrpVideoComments } from '../../utils/filters/comments';
-import { ICommentsFuseResult, IParamSearch } from '../../utils/interfaces/i_types';
+import { filterLinksTrpVideoComments } from '../../utils/filters/comments';
+import { ICommentsFuseResult, IParamSearch, ISelectedSort } from '../../utils/interfaces/i_types';
 import { wrapTryCatch } from '../../utils/common';
 import { getCommentsTrVideo, WebResourcesState } from '../state';
 import { SearchContext } from './types';
 
 export interface SearchButtonState {
-    order?: 'newest' | 'oldest';
     title?: string;
     label?: string;
     dataset?: Record<string, string>;
@@ -23,16 +22,23 @@ export interface TranscriptSearchResult {
     buttonStates: Record<string, SearchButtonState>;
 }
 
+const UNSUPPORTED_SORTS: ISelectedSort[] = [
+    'most_likes',
+    'least_likes',
+    'most_replies',
+    'least_replies',
+    'author_az',
+    'author_za'
+];
+
 const UNSUPPORTED_FILTERS: (keyof IParamSearch)[] = [
     'heart',
-    'likes',
-    'replied',
     'random',
     'author',
     'donated',
     'members',
     'verified',
-    'quickChat'
+    'origin'
 ];
 
 // Fuse cache for the full cueGroups array (subsets still use transient instances).
@@ -77,10 +83,6 @@ function mapTranscriptResults(raw: readonly Fuse.FuseResult<any>[]): ICommentsFu
             ) || 0,
         score: result.score
     }));
-}
-
-function ensureSortOrder(order?: 'newest' | 'oldest'): 'newest' | 'oldest' {
-    return order === 'oldest' ? 'oldest' : 'newest';
 }
 
 function filterByMatches(results: ICommentsFuseResult[], matches: Set<any> | null): ICommentsFuseResult[] {
@@ -159,154 +161,82 @@ export function runSearch(
     const buttonStates: Record<string, SearchButtonState> = {};
     let resultSearch: ICommentsFuseResult[] = [];
 
-    const updateButtonState = (
-        id: string,
-        order: 'newest' | 'oldest',
-        title: string,
-        label?: string,
-        dataset?: Record<string, string>
-    ): void => {
-        buttonStates[id] = { order, title, label, dataset };
-    };
-
-    if (param.links) {
-        resultSearch = filterLinksTrpVideoComments(cueGroups) as ICommentsFuseResult[];
-        resultSearch = filterByMatches(resultSearch, matches);
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(param.sortOrder ?? context.sortOrders.transcript['ycs_btn_links']);
-            if (resolvedOrder === 'newest') {
-                if (trimmedQuery) {
-                    const fuse = getTranscriptFuseInstance<any>(
-                        resultSearch.map((entry) => entry.item),
-                        options
-                    );
-                    resultSearch = mapTranscriptResults(fuse.search(trimmedQuery));
-                }
-            } else {
-                if (trimmedQuery) {
-                    const base = resultSearch.map((entry) => entry.item).reverse();
-                    const fuse = getTranscriptFuseInstance<any>(base, options);
-                    resultSearch = mapTranscriptResults(fuse.search(trimmedQuery));
-                } else {
-                    resultSearch = Array.from(resultSearch).reverse();
-                }
-            }
-
-            updateButtonState(
-                'ycs_btn_links',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Shows links in comments, replies, chat, video transcript (Oldest)'
-                    : 'Shows links in comments, replies, chat, video transcript (Newest)',
-                'Links'
-            );
-        }
-    } else if (param.sortFirst) {
-        resultSearch = (filterAllTrpVideoComments(cueGroups) as ICommentsFuseResult[]) || [];
-        resultSearch = filterByMatches(resultSearch, matches);
-
-        if (resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
-
-            const resolvedOrder = ensureSortOrder(
-                param.sortOrder ?? context.sortOrders.transcript['ycs_btn_sort_first']
-            );
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-            }
-
-            updateButtonState(
-                'ycs_btn_sort_first',
-                resolvedOrder,
-                resolvedOrder === 'oldest'
-                    ? 'Show all comments, chat, video transcript sorted by date (Oldest)'
-                    : 'Show all comments, chat, video transcript sorted by date (Newest)',
-                'All'
-            );
-        }
-    } else if (param.timestamp) {
-        const mmRe = /^(\d{1,3})(?::(\d{1,2}))?$/;
-        const match = mmRe.exec(trimmedQuery);
-
-        if (match) {
-            const minutes = parseInt(match[1] || '0', 10);
-            const seconds = match[2] ? parseInt(match[2], 10) : undefined;
-            const fromMs = minutes * 60 * 1000 + (seconds ? seconds * 1000 : 0);
-            const toMs = seconds === undefined ? (minutes + 1) * 60 * 1000 : fromMs + 1000;
-
-            resultSearch = cueGroups
-                .filter((group: any) => {
-                    const start = wrapTryCatch(
-                        () => group?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer?.startOffsetMs
-                    ) as number;
-                    return typeof start === 'number' && start >= fromMs && start < toMs;
-                })
-                .map((group: any) => ({
-                    item: group,
-                    refIndex:
-                        wrapTryCatch(
-                            () => group?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer?.startOffsetMs
-                        ) || 0
-                }));
-
-            const currentOrder = context.sortOrders.transcript['ycs_btn_timestamps'] ?? 'newest';
-            if (currentOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
-                updateButtonState(
-                    'ycs_btn_timestamps',
-                    'oldest',
-                    'Show comments, replies, chat with time stamps (Oldest)',
-                    'Time stamps',
-                    { sortTrp: 'newest' }
-                );
-            } else {
-                updateButtonState(
-                    'ycs_btn_timestamps',
-                    'newest',
-                    'Show comments, replies, chat with time stamps (Newest)',
-                    'Time stamps',
-                    { sortTrp: 'oldest' }
-                );
-            }
-        } else {
-            const fuse = getTranscriptFuseInstance<any>(cueGroups, options);
-            resultSearch = mapTranscriptResults(fuse.search(trimmedQuery));
-        }
+    if (trimmedQuery) {
+        const fuse = getTranscriptFuseInstance<any>(cueGroups, options);
+        resultSearch = mapTranscriptResults(fuse.search(trimmedQuery));
     } else {
         // Handle empty query by returning all results
-        if (!trimmedQuery) {
-            resultSearch = mapTranscriptResults(
-                cueGroups.map((item, index) => ({
-                    item,
-                    refIndex: index,
-                    score: 0
-                }))
-            );
-        } else {
-            const fuse = getTranscriptFuseInstance<any>(cueGroups, options);
-            resultSearch = mapTranscriptResults(fuse.search(trimmedQuery));
+        resultSearch = mapTranscriptResults(
+            cueGroups.map((item, index) => ({
+                item,
+                refIndex: index,
+                score: 0
+            }))
+        );
+        if (param.sortOrder === 'relevance') {
+            // No such thing as sorting by relevance for empty query, default to newest
+            param.sortOrder = 'newest';
         }
+    }
 
-        // Apply sorting for quickTranscript filter
-        if (param.quickTranscript && resultSearch.length > 0) {
-            resultSearch.sort((a, b) => (a.refIndex || 0) - (b.refIndex || 0));
+    for (const key of Object.keys(param)) {
+        switch (key) {
+            case 'links':
+                resultSearch = filterLinksTrpVideoComments(cueGroups) as ICommentsFuseResult[];
+                resultSearch = filterByMatches(resultSearch, matches);
+                break;
+            case 'timestamp': {
+                const mmRe = /^(\d{1,3})(?::(\d{1,2}))?$/;
+                const match = mmRe.exec(trimmedQuery);
 
-            const resolvedOrder = ensureSortOrder(
-                param.sortOrder ?? context.sortOrders.transcript['ycs_btn_quick_transcript']
-            );
-            if (resolvedOrder === 'oldest') {
-                resultSearch = Array.from(resultSearch).reverse();
+                if (match) {
+                    const minutes = parseInt(match[1] || '0', 10);
+                    const seconds = match[2] ? parseInt(match[2], 10) : undefined;
+                    const fromMs = minutes * 60 * 1000 + (seconds ? seconds * 1000 : 0);
+                    const toMs = seconds === undefined ? (minutes + 1) * 60 * 1000 : fromMs + 1000;
+
+                    resultSearch = cueGroups
+                        .filter((group: any) => {
+                            const start = wrapTryCatch(
+                                () => group?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer?.startOffsetMs
+                            ) as number;
+                            return typeof start === 'number' && start >= fromMs && start < toMs;
+                        })
+                        .map((group: any) => ({
+                            item: group,
+                            refIndex:
+                                wrapTryCatch(
+                                    () =>
+                                        group?.transcriptCueGroupRenderer?.cues?.[0]?.transcriptCueRenderer
+                                            ?.startOffsetMs
+                                ) || 0
+                        }));
+                }
+                break;
             }
+            default:
+                break;
+        }
+    }
 
-            updateButtonState(
-                'ycs_btn_quick_transcript',
-                resolvedOrder,
-                resolvedOrder === 'oldest' ? 'Show transcript (Oldest)' : 'Show transcript (Newest)',
-                'Transcript'
+    if (resultSearch.length > 1) {
+        if (param.sortOrder === 'oldest') {
+            resultSearch.sort((a, b) => b.refIndex - a.refIndex);
+        } else if (param.sortOrder === 'longest') {
+            resultSearch.sort(
+                (a, b) =>
+                    (b.item as any).transcriptCueGroupRenderer.cues[0].transcriptCueRenderer.cue.simpleText.length -
+                    (a.item as any).transcriptCueGroupRenderer.cues[0].transcriptCueRenderer.cue.simpleText.length
             );
+        } else if (param.sortOrder === 'shortest') {
+            resultSearch.sort(
+                (a, b) =>
+                    (a.item as any).transcriptCueGroupRenderer.cues[0].transcriptCueRenderer.cue.simpleText.length -
+                    (b.item as any).transcriptCueGroupRenderer.cues[0].transcriptCueRenderer.cue.simpleText.length
+            );
+        } else if (param.sortOrder === 'newest' || UNSUPPORTED_SORTS.some((key) => param.sortOrder === key)) {
+            // Unsupported sorts default to newest
+            resultSearch.sort((a, b) => a.refIndex - b.refIndex);
         }
     }
 

--- a/app/src/source/web-resources/search/types.ts
+++ b/app/src/source/web-resources/search/types.ts
@@ -1,14 +1,8 @@
-export type SortOrder = 'newest' | 'oldest';
-
 export interface SearchContext {
     extendedSearch: {
         enabled: boolean;
         title: boolean;
         main: boolean;
     };
-    sortOrders: {
-        comments: Partial<Record<string, SortOrder>>;
-        chat: Partial<Record<string, SortOrder>>;
-        transcript: Partial<Record<string, SortOrder>>;
-    };
+    timestampSort?: boolean;
 }

--- a/app/src/source/web-resources/ui/filters.ts
+++ b/app/src/source/web-resources/ui/filters.ts
@@ -22,7 +22,8 @@ export const FILTER_BUTTONS: FilterButtonConfig[] = [
     { elementId: 'ycs_btn_comments', param: 'quickComments' },
     { elementId: 'ycs_btn_quick_chat', param: 'quickChat' },
     { elementId: 'ycs_btn_quick_transcript', param: 'quickTranscript' },
-    { elementId: 'ycs_btn_origin', param: 'origin' }
+    { elementId: 'ycs_btn_origin', param: 'origin' },
+    { elementId: 'ycs_btn_emoji', param: 'emoji' }
 ];
 
 export interface RegisterFilterButtonsOptions {

--- a/app/src/source/web-resources/ui/filters.ts
+++ b/app/src/source/web-resources/ui/filters.ts
@@ -1,5 +1,4 @@
-import { iconSortDown, iconSortUp } from '../../utils/icons';
-import { IParamSearch, ISelectedSearch } from '../../utils/interfaces/i_types';
+import { IParamSearch, ISelectedSort } from '../../utils/interfaces/i_types';
 import { resetSearchCounts, WebResourcesState } from '../state';
 import { options } from '../../config/options';
 
@@ -8,25 +7,22 @@ export type FilterParamKey = Exclude<keyof IParamSearch, 'sortOrder'>;
 export interface FilterButtonConfig {
     elementId: string;
     param: FilterParamKey;
-    supportsSort?: boolean;
-    searchType?: ISelectedSearch;
 }
 
 export const FILTER_BUTTONS: FilterButtonConfig[] = [
-    { elementId: 'ycs_btn_timestamps', param: 'timestamp', supportsSort: true },
+    { elementId: 'ycs_btn_timestamps', param: 'timestamp' },
     { elementId: 'ycs_btn_timestamp_viz', param: 'timestampViz' },
-    { elementId: 'ycs_btn_author', param: 'author', supportsSort: true },
-    { elementId: 'ycs_btn_heart', param: 'heart', supportsSort: true },
-    { elementId: 'ycs_btn_verified', param: 'verified', supportsSort: true },
-    { elementId: 'ycs_btn_links', param: 'links', supportsSort: true },
-    { elementId: 'ycs_btn_likes', param: 'likes' },
-    { elementId: 'ycs_btn_replied_comments', param: 'replied' },
-    { elementId: 'ycs_btn_members', param: 'members', supportsSort: true },
-    { elementId: 'ycs_btn_donated', param: 'donated', supportsSort: true },
+    { elementId: 'ycs_btn_author', param: 'author' },
+    { elementId: 'ycs_btn_heart', param: 'heart' },
+    { elementId: 'ycs_btn_verified', param: 'verified' },
+    { elementId: 'ycs_btn_links', param: 'links' },
+    { elementId: 'ycs_btn_members', param: 'members' },
+    { elementId: 'ycs_btn_donated', param: 'donated' },
     { elementId: 'ycs_btn_random', param: 'random' },
-    { elementId: 'ycs_btn_sort_first', param: 'sortFirst', supportsSort: true },
-    { elementId: 'ycs_btn_quick_chat', param: 'quickChat', supportsSort: true, searchType: 'chat' },
-    { elementId: 'ycs_btn_quick_transcript', param: 'quickTranscript', supportsSort: true, searchType: 'video' }
+    { elementId: 'ycs_btn_comments', param: 'quickComments' },
+    { elementId: 'ycs_btn_quick_chat', param: 'quickChat' },
+    { elementId: 'ycs_btn_quick_transcript', param: 'quickTranscript' },
+    { elementId: 'ycs_btn_origin', param: 'origin' }
 ];
 
 export interface RegisterFilterButtonsOptions {
@@ -34,7 +30,7 @@ export interface RegisterFilterButtonsOptions {
         get(): WebResourcesState;
         set(next: WebResourcesState): void;
     };
-    executeSearch(param: IParamSearch, forceType?: ISelectedSearch): void;
+    executeSearch(param: IParamSearch): void;
     setActiveFilter(param: FilterParamKey | null, element?: HTMLElement): void;
     buttonConfigs: FilterButtonConfig[];
 }
@@ -42,65 +38,6 @@ export interface RegisterFilterButtonsOptions {
 export interface FilterButtonRegistry {
     codeToId: Record<FilterParamKey, string>;
     idToCode: Record<string, FilterParamKey>;
-    sortButtonIds: string[];
-}
-
-type SortDatasetKey = 'sort' | 'sortChat' | 'sortTrp';
-type SortOrder = 'newest' | 'oldest';
-
-const SORT_DATASET_KEYS: SortDatasetKey[] = ['sort', 'sortChat', 'sortTrp'];
-
-function extractBaseLabel(html: string): string {
-    const temp = document.createElement('div');
-    temp.innerHTML = html;
-    // Remove all .ycs-icons elements to extract base label
-    temp.querySelectorAll('.ycs-icons').forEach((el) => el.remove());
-    return temp.innerHTML.trim();
-}
-
-function getCurrentSortOrder(button: HTMLElement): SortOrder {
-    for (const key of SORT_DATASET_KEYS) {
-        const value = button.dataset[key] as SortOrder | undefined;
-        if (value === 'newest' || value === 'oldest') {
-            return value;
-        }
-    }
-
-    return 'newest';
-}
-
-function toggleSortDatasets(button: HTMLElement): SortOrder {
-    let order: SortOrder = 'newest';
-
-    for (const key of SORT_DATASET_KEYS) {
-        const current = button.dataset[key] as SortOrder | undefined;
-        if (current === 'newest' || current === 'oldest') {
-            const next = current === 'newest' ? 'oldest' : 'newest';
-            button.dataset[key] = next;
-            order = next;
-        }
-    }
-
-    return order;
-}
-
-export function updateSortIndicator(button: HTMLElement, order: SortOrder): void {
-    const baseLabel = button.dataset.labelHtml ?? extractBaseLabel(button.innerHTML);
-    button.dataset.labelHtml = baseLabel;
-
-    const icon = order === 'oldest' ? iconSortUp() : iconSortDown();
-    button.innerHTML = `${baseLabel} ${icon}`;
-}
-
-export function toggleFilter(button: HTMLElement, supportsSort: boolean, wasActive: boolean): SortOrder | undefined {
-    if (!supportsSort) {
-        return undefined;
-    }
-
-    const order = wasActive ? toggleSortDatasets(button) : getCurrentSortOrder(button);
-    updateSortIndicator(button, order);
-
-    return order;
 }
 
 export function registerFilterButtons({
@@ -125,8 +62,6 @@ export function registerFilterButtons({
         {} as Record<string, FilterParamKey>
     );
 
-    const sortButtonIds = buttonConfigs.filter((config) => config.supportsSort).map((config) => config.elementId);
-
     buttonConfigs.forEach((config) => {
         const button = document.getElementById(config.elementId) as HTMLElement | null;
         if (!button) return;
@@ -137,33 +72,25 @@ export function registerFilterButtons({
             button.removeEventListener('click', oldHandler);
         }
 
-        if (config.supportsSort) {
-            SORT_DATASET_KEYS.forEach((key) => {
-                const value = button.dataset[key];
-                if (value !== 'newest' && value !== 'oldest') {
-                    button.dataset[key] = 'newest';
-                }
-            });
-        }
-
         const clickHandler = (event: Event) => {
             try {
                 const currentTarget = event.currentTarget as HTMLElement;
-                const wasActive = currentTarget.classList.contains('ycs_btn_active');
-                const sortOrder = toggleFilter(currentTarget, !!config.supportsSort, wasActive);
-
                 setActiveFilter(config.param, currentTarget);
 
                 const nextState = resetSearchCounts(state.get());
                 state.set(nextState);
 
-                const searchParam: IParamSearch = { [config.param]: true } as IParamSearch;
-                if (sortOrder) {
-                    searchParam.sortOrder = sortOrder;
+                const activeEls = Array.from(document.querySelectorAll('.ycs_btn_active')) as HTMLElement[];
+                const searchParam: IParamSearch = {};
+                for (const el of activeEls) {
+                    searchParam[idToCode[el.id]] = true;
                 }
-
+                const elSelectSortSearch = document.getElementById('ycs_sort_select') as HTMLSelectElement;
+                searchParam.sortOrder = elSelectSortSearch
+                    ? (elSelectSortSearch.options[elSelectSortSearch.options.selectedIndex].value as ISelectedSort)
+                    : 'relevance';
                 // If search type is specified, force use that type
-                executeSearch(searchParam, config.searchType);
+                executeSearch(searchParam);
             } catch (error) {
                 console.error(error);
             }
@@ -176,8 +103,7 @@ export function registerFilterButtons({
 
     return {
         codeToId,
-        idToCode,
-        sortButtonIds
+        idToCode
     };
 }
 

--- a/app/src/source/web-resources/ui/render.ts
+++ b/app/src/source/web-resources/ui/render.ts
@@ -3,20 +3,6 @@ import { CommentsSearchResult } from '../search/commentsSearch';
 import { ChatSearchResult } from '../search/chatSearch';
 import { TranscriptSearchResult } from '../search/transcriptSearch';
 
-const BUTTON_LABELS: Record<string, string> = {
-    ycs_btn_links: 'Links',
-    ycs_btn_members: 'Members',
-    ycs_btn_donated: 'Donated',
-    ycs_btn_author: 'Author',
-    ycs_btn_timestamps: 'Time stamps',
-    ycs_btn_comments: 'Comments'
-};
-
-const BUTTON_PREFIX_HTML: Record<string, string> = {
-    ycs_btn_heart: '<span class="ycs-creator-heart_icon">❤</span>',
-    ycs_btn_verified: '<span class="ycs-creator-verified_icon">✔</span>'
-};
-
 interface ButtonState {
     title?: string;
     label?: string;

--- a/app/src/source/web-resources/ui/render.ts
+++ b/app/src/source/web-resources/ui/render.ts
@@ -1,4 +1,3 @@
-import { iconSortDown, iconSortUp } from '../../utils/icons';
 import { renderComment, renderCommentChat, renderCommentTrVideo } from '../../utils/renderView';
 import { CommentsSearchResult } from '../search/commentsSearch';
 import { ChatSearchResult } from '../search/chatSearch';
@@ -10,7 +9,7 @@ const BUTTON_LABELS: Record<string, string> = {
     ycs_btn_donated: 'Donated',
     ycs_btn_author: 'Author',
     ycs_btn_timestamps: 'Time stamps',
-    ycs_btn_sort_first: 'All'
+    ycs_btn_comments: 'Comments'
 };
 
 const BUTTON_PREFIX_HTML: Record<string, string> = {
@@ -19,7 +18,6 @@ const BUTTON_PREFIX_HTML: Record<string, string> = {
 };
 
 interface ButtonState {
-    order?: 'newest' | 'oldest';
     title?: string;
     label?: string;
     dataset?: Record<string, string>;
@@ -42,21 +40,6 @@ function applyButtonStates(states: ButtonStateMap): void {
 
         if (state.title) {
             button.title = state.title;
-        }
-
-        if (state.order) {
-            const baseLabel = state.label ?? BUTTON_LABELS[id] ?? '';
-            const prefix = BUTTON_PREFIX_HTML[id];
-            const htmlLabel = prefix ? `${prefix}${baseLabel ? ` ${baseLabel}` : ''}` : baseLabel;
-            const icon = state.order === 'oldest' ? iconSortUp() : iconSortDown();
-
-            if (htmlLabel) {
-                button.innerHTML = `${htmlLabel} ${icon}`;
-                button.dataset.labelHtml = htmlLabel;
-            } else {
-                button.innerHTML = icon;
-                button.dataset.labelHtml = '';
-            }
         }
     }
 }


### PR DESCRIPTION
This PR aims to improve how YCS filters search results. This PR resolves #124 and improves #118. 

Background:
Currently, you can only select one filter at a time. For example there isn't a possible way to filter by timestamps made by channel members. Furthermore, its slightly annoying having to click each filter to change the sorting order so I believe having a global sort dropdown for users to sort the search results would be more intuitive.

Changes:
This pull request makes significant improvements to the filter button system and search sorting functionality in the extension. Changes include reworking how the filter buttons work, adding a sort selector, and other misc changes.

**Filter Button:**

- Multiple filter buttons can be selected at the same time to make filtering more advanced
- New filter: `origin` this filter shows original comments aka comments that aren't replies.
- New filter: `emoji` this filter shows comments and chat messages that contain emojis
- Moved filters to sorting: likes and replied
- Timestamp visualizer works with these new filter changes
- Simplified random filter, not really sure why the original code to pick a random comment was so convoluted so I just picked a random comment using Math.random in the resultSearch array 

**Sorting and searching:**
- Replaced the old category-based search dropdown with a new global sort dropdown, supporting options like "Relevance", "Newest", "Most Likes", etc., and updated the corresponding types and interfaces. 
- If a sort isn't supported, the content will be sorted by newest (ex: selecting sort by most likes will sort transcript by newest)
- Added a "Sort by video time" checkbox to the search UI, which is only shown when the timestamp filter is selected. The sort is only applied to newest and oldest sorting.
- Relevance sorting is implemented by sorting by fusescore and changed fieldNormWeight to 0.1 to make the length of the item less relevant to the query.

**Options:**
- With the addition of global sorting, option has been added to change default sort in options
- Removed the "Sort timestamps by time" option, essentially reverting #118.
- When the extension updates, the filter buttons in options will reset in background.js this is because quickchat and quicktranscript filters were set to disabled and search categories have been removed so these filters should be enabled by default now.

These changes are based on my subjective opinion on what is considered better so let me know if you have any concerns or find any bugs.