### PR TITLE
Add max comments option

### DIFF
--- a/app/src/source/background.ts
+++ b/app/src/source/background.ts
@@ -17,7 +17,7 @@ const activeYouTubeApiRequests = new Map<string, ActiveRequest>();
  */
 interface FetchState {
     quotaUsed: number;
-    maxComments: number;
+    maxComments: number | undefined;
     signal: AbortSignal | undefined;
     replyFetchErrors: number; // Track failed reply fetches
 }
@@ -158,14 +158,14 @@ async function fetchAllRepliesBackground(
 
     do {
         if (fetchState.signal?.aborted) break;
-        if (comments.length >= fetchState.maxComments) break;
+        if (fetchState.maxComments && comments.length >= fetchState.maxComments) break;
 
         try {
             const response = await fetchCommentReplies(parentId, apiKey, pageToken, fetchState.signal);
             fetchState.quotaUsed += 1;
 
             for (const apiComment of response.items) {
-                if (comments.length >= fetchState.maxComments) break;
+                if (fetchState.maxComments && comments.length >= fetchState.maxComments) break;
                 const replyItem = transformReplyToCommentItem(apiComment, videoId, parentItem);
                 comments.push(replyItem);
             }
@@ -176,7 +176,11 @@ async function fetchAllRepliesBackground(
             fetchState.replyFetchErrors += 1;
             break;
         }
-    } while (pageToken && comments.length < fetchState.maxComments && !fetchState.signal?.aborted);
+    } while (
+        pageToken &&
+        (!fetchState.maxComments || comments.length < fetchState.maxComments) &&
+        !fetchState.signal?.aborted
+    );
 }
 
 /**
@@ -187,11 +191,11 @@ async function fetchAllCommentsBackground(
     apiKey: string,
     tabId: number,
     requestId: string,
-    signal: AbortSignal
+    signal: AbortSignal,
+    maxComments: number | undefined
 ): Promise<void> {
     const comments: CommentItem[] = [];
     let pageToken: string | undefined;
-    const maxComments = 500000;
 
     const fetchState: FetchState = {
         quotaUsed: 0,
@@ -206,13 +210,13 @@ async function fetchAllCommentsBackground(
     try {
         do {
             if (signal.aborted) break;
-            if (comments.length >= maxComments) break;
+            if (maxComments && comments.length >= maxComments) break;
 
             const response = await fetchCommentThreads(videoId, apiKey, pageToken, signal);
             fetchState.quotaUsed += 1;
 
             for (const thread of response.items) {
-                if (comments.length >= maxComments) break;
+                if (maxComments && comments.length >= maxComments) break;
 
                 const threadItems = transformThreadToCommentItems(thread, videoId);
                 const parentItem = threadItems[0];
@@ -221,7 +225,7 @@ async function fetchAllCommentsBackground(
                 // Add inline replies
                 const inlineReplies = threadItems.slice(1);
                 for (const reply of inlineReplies) {
-                    if (comments.length >= maxComments) break;
+                    if (maxComments && comments.length >= maxComments) break;
                     comments.push(reply);
                 }
 
@@ -229,7 +233,7 @@ async function fetchAllCommentsBackground(
                 const totalReplyCount = thread.snippet.totalReplyCount;
                 const inlineReplyCount = thread.replies?.comments?.length ?? 0;
 
-                if (totalReplyCount > inlineReplyCount && comments.length < maxComments) {
+                if (totalReplyCount > inlineReplyCount && (!maxComments || comments.length < maxComments)) {
                     const parentId = thread.snippet.topLevelComment.id;
                     const replyPromise = replyQueue.add(async () => {
                         await fetchAllRepliesBackground(parentId, apiKey, videoId, parentItem, comments, fetchState);
@@ -257,7 +261,7 @@ async function fetchAllCommentsBackground(
             }
 
             pageToken = response.nextPageToken;
-        } while (pageToken && comments.length < maxComments && !signal.aborted);
+        } while (pageToken && (!maxComments || comments.length < maxComments) && !signal.aborted);
 
         // Wait for all reply fetches
         await Promise.all(replyPromises);
@@ -394,7 +398,7 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
 
     // YouTube Data API: Start loading comments
     if (message?.type === 'YCS_YT_API_COMMENTS_START') {
-        const { videoId, requestId } = message.body ?? {};
+        const { videoId, requestId, maxComments } = message.body ?? {};
         const tabId = sender.tab?.id;
 
         if (!tabId || !videoId || !requestId) {
@@ -403,7 +407,7 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
         }
 
         // Read API key from storage (secure - never sent to web page)
-        const opts = await chrome.storage.local.get(['youtubeApiKey', 'youtubeApiEnabled']);
+        const opts = await chrome.storage.local.get(['youtubeApiKey', 'youtubeApiEnabled', 'maxComments']);
         const apiKey = (opts.youtubeApiKey as string)?.trim();
         const apiEnabled = opts.youtubeApiEnabled !== false;
 
@@ -423,7 +427,7 @@ chrome.runtime.onMessage.addListener(async (message, sender) => {
         activeYouTubeApiRequests.set(requestId, { controller, tabId });
 
         // Execute fetch (non-blocking)
-        fetchAllCommentsBackground(videoId, apiKey, tabId, requestId, controller.signal).then(
+        fetchAllCommentsBackground(videoId, apiKey, tabId, requestId, controller.signal, maxComments).then(
             () => activeYouTubeApiRequests.delete(requestId),
             () => activeYouTubeApiRequests.delete(requestId)
         );

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -9,6 +9,7 @@ const options = {
     hiddenByDefaultShorts: false,
     enableShortsSupport: true,
     transcriptLanguage: '',
+    maxComments: 500000,
     youtubeApiKey: '', // Empty = use Innertube (default); Filled = use YouTube Data API
     youtubeApiEnabled: true, // Enable YouTube Data API (requires API key to take effect)
     filterButtons: [

--- a/app/src/source/options/assets/css/style.css
+++ b/app/src/source/options/assets/css/style.css
@@ -499,6 +499,17 @@ tbody#ycs_all_cache_body_table > tr > td > div {
   font-size: 14px;
 }
 
+#y_opts_max_comments_input {
+  height: 36px;
+  width: 20%;
+  font-size: 16px;
+  padding: 0px 8px;
+  background-color: #1f1f1f;
+  color: #fff;
+  border: 1px solid #3a3a3a;
+  border-radius: 4px;
+}
+
 /* Code tag styling */
 code {
   background-color: #1f1f1f;

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -164,6 +164,23 @@ window.onload = async (): Promise<void> => {
             }
         };
 
+        const setRenderMaxComments = (param: number): void => {
+            const input = document.getElementById('y_opts_max_comments_input') as HTMLInputElement | null;
+            if (!input) return;
+            input.valueAsNumber = param ?? 500000;
+        };
+
+        const optSetMaxComments = async (e: Event): Promise<void> => {
+            try {
+                const value = (e.target as HTMLInputElement).valueAsNumber;
+                await chrome.storage.local.set({
+                    maxComments: value
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
         // YouTube Data API handlers
         let currentApiEnabled = true;
         let currentApiKey = '';
@@ -708,6 +725,10 @@ window.onload = async (): Promise<void> => {
                         setRenderTranscriptLanguage(storageOpts[key]);
                         break;
 
+                    case 'maxComments':
+                        setRenderMaxComments(storageOpts[key]);
+                        break;
+
                     case 'filterButtons':
                         setRenderFilterButtons(storageOpts[key]);
                         break;
@@ -793,6 +814,9 @@ window.onload = async (): Promise<void> => {
 
         const elCacheQuota = document.getElementById('y_opts_cache_quota') as HTMLInputElement;
         elCacheQuota?.addEventListener('input', optSetAutoClearCache);
+
+        const elMaxComments = document.getElementById('y_opts_max_comments_input') as HTMLInputElement;
+        elMaxComments?.addEventListener('input', optSetMaxComments);
 
         const transcriptLanguageSelect = document.getElementById(
             'y_opts_transcript_language_select'

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -26,6 +26,22 @@
           </div>
         </div>
 
+        <div class="y_opts_max_comments">
+          <label for="y_opts_max_comments_input">Max comments:</label>
+          <input
+            type="number"
+            name="Max comments to load"
+            id="y_opts_max_comments_input"
+            class="ycs_opts_input_quota"
+          />
+          <div class="ycs_description_option ycs_api_desc">
+            <p>
+              Set the max number of comments that will be autoloaded (Manually loading comments will ignore this
+              number).
+            </p>
+          </div>
+        </div>
+
         <div class="ycs_group" id="ycs-highlight-group">
           <div>
             <label for="y_opts_highlight">Highlight text:</label>
@@ -127,16 +143,6 @@
           <div class="ycs_description_option ycs_api_desc">
             <p>Select a language or enter a custom BCP-47 code like <code>en</code> or <code>ja</code>.</p>
           </div>
-        </div>
-
-        <div class="y_opts_max_comments">
-          <label for="y_opts_max_comments_input">Max comments:</label>
-          <input
-            type="number"
-            name="Max comments to load"
-            id="y_opts_max_comments_input"
-            class="ycs_opts_input_quota"
-          />
         </div>
 
         <div class="ycs_filter_buttons_wrap">

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -129,6 +129,16 @@
           </div>
         </div>
 
+        <div class="y_opts_max_comments">
+          <label for="y_opts_max_comments_input">Max comments:</label>
+          <input
+            type="number"
+            name="Max comments to load"
+            id="y_opts_max_comments_input"
+            class="ycs_opts_input_quota"
+          />
+        </div>
+
         <div class="ycs_filter_buttons_wrap">
           <div>
             <label>Filter Buttons:</label>

--- a/app/src/source/utils/innertube/comments.ts
+++ b/app/src/source/utils/innertube/comments.ts
@@ -44,7 +44,7 @@ async function getAllCommentsModeV2(
     elShowLoading: HTMLElement,
     signal: AbortSignal | undefined = undefined,
     container: object[] | undefined = undefined,
-    maxComments = 500000,
+    maxComments: number | undefined = undefined,
     sortOrder: CommentSortOrder = CommentSortOrder.NewestFirst
 ): Promise<object[]> {
     const comments: object[] = container || [];
@@ -74,7 +74,7 @@ async function getAllCommentsModeV2(
         }
 
         for (const comment of parentResults) {
-            if (comments.length >= maxComments) {
+            if (maxComments && comments.length >= maxComments) {
                 limitReached = true;
                 break;
             }
@@ -90,7 +90,7 @@ async function getAllCommentsModeV2(
                 fetchContinuation: (continuation) =>
                     fetchRepliesBatch({ windowRef: window, signal, continuation, sortOrder }),
                 onReply: (reply) => {
-                    if (comments.length < maxComments) {
+                    if (!maxComments || comments.length < maxComments) {
                         comments.push(reply);
                         showLoadComments(comments.length, elShowLoading);
                     }
@@ -130,7 +130,7 @@ async function getAllCommentsModeV2(
         (comments[idx] as any)._index = idx;
     }
 
-    if (comments.length >= maxComments) {
+    if (maxComments && comments.length >= maxComments) {
         console.warn(`[YCS] Reached comment limit: ${maxComments} for post/video ${currentVideoId}`);
     }
     return comments;

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -322,6 +322,7 @@ export interface CommentSortOption {
 }
 
 export interface IYCSOptions {
+    maxComments?: number;
     autoload?: boolean;
     highlightText?: boolean;
     sortTimestamp?: boolean;

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -735,7 +735,7 @@ export function initApp(): void {
 
                         // Check if YouTube Data API key is configured and enabled
                         const hasApiKey = GlobalStore.hasYoutubeApiKey;
-                        const apiEnabled = GlobalStore.youtubeApiEnabled !== false; // default true
+                        const apiEnabled = GlobalStore.youtubeApiEnabled;
                         // Track if YouTube API result was incomplete (for status icon)
                         let youtubeApiIncomplete = false;
 
@@ -746,6 +746,7 @@ export function initApp(): void {
                                 const result = await requestYouTubeApiComments(
                                     startVideoId,
                                     controller.signal,
+                                    GlobalStore.autoload ? GlobalStore.maxComments : undefined,
                                     (count) => showLoadComments(count, elLoadCmnts)
                                 );
                                 comments.push(...result.comments);
@@ -837,10 +838,11 @@ export function initApp(): void {
                                 elLoadCmnts,
                                 controller.signal,
                                 comments,
-                                500000,
+                                GlobalStore.autoload ? GlobalStore.maxComments : undefined,
                                 selectedSortOrder
                             );
                         }
+                        GlobalStore.autoload = false;
 
                         // Verify video or post hasn't changed before saving cache
                         const currentId = getVideoId(window.location.href) ?? getPostId(window.location.href);
@@ -1560,6 +1562,14 @@ export function initApp(): void {
             if (e.data?.type === 'YCS_OPTIONS' && e.data?.text) {
                 console.log('YCS_OPTIONS', e.data);
 
+                const optMaxComments = (value: number): void => {
+                    try {
+                        GlobalStore.maxComments = value;
+                    } catch (err) {
+                        console.error(err);
+                    }
+                };
+
                 const optAutoload = (value: boolean): void => {
                     if (value === true) {
                         elLoadAll?.click();
@@ -1639,6 +1649,21 @@ export function initApp(): void {
                         return;
                     }
 
+                    if (opts.maxComments) {
+                        // Set maxComments first before autoload
+                        optMaxComments(Number(opts.maxComments));
+                    }
+
+                    if (opts.hasYoutubeApiKey) {
+                        // Set hasYoutubeApiKey flag before autoload
+                        GlobalStore.hasYoutubeApiKey = Boolean(opts.hasYoutubeApiKey);
+                    }
+
+                    if (opts.youtubeApiEnabled) {
+                        // Set youtubeApiEnabled flag before autoload
+                        GlobalStore.youtubeApiEnabled = Boolean(opts.youtubeApiEnabled);
+                    }
+
                     (Object.keys(opts) as Array<keyof IYCSOptions>).forEach((key) => {
                         switch (key) {
                             case 'autoload':
@@ -1690,16 +1715,6 @@ export function initApp(): void {
                                         ? opts.transcriptLanguage.trim()
                                         : undefined
                                 );
-                                break;
-
-                            case 'hasYoutubeApiKey':
-                                // Store whether API key is configured (actual key stays in background)
-                                GlobalStore.hasYoutubeApiKey = Boolean(opts.hasYoutubeApiKey);
-                                break;
-
-                            case 'youtubeApiEnabled':
-                                // Store YouTube Data API enabled state in GlobalStore
-                                GlobalStore.youtubeApiEnabled = opts.youtubeApiEnabled !== false; // default true
                                 break;
 
                             default:
@@ -1839,6 +1854,7 @@ export function initApp(): void {
             }
 
             if (e.data?.type === 'YCS_AUTOLOAD') {
+                GlobalStore.autoload = true;
                 elLoadAll?.click();
             }
         };

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -842,7 +842,6 @@ export function initApp(): void {
                                 selectedSortOrder
                             );
                         }
-                        GlobalStore.autoload = false;
 
                         // Verify video or post hasn't changed before saving cache
                         const currentId = getVideoId(window.location.href) ?? getPostId(window.location.href);
@@ -891,6 +890,7 @@ export function initApp(): void {
 
                     updateTitleCount(totalCount);
                 } finally {
+                    GlobalStore.autoload = false;
                     currentTarget.disabled = false;
                     currentTarget.innerText = defaultLabel;
                 }
@@ -1577,6 +1577,7 @@ export function initApp(): void {
                 };
 
                 const wrapOptAutoload = (value: boolean, opts: IYCSOptions): void => {
+                    GlobalStore.autoload = value;
                     if (!opts.cache) {
                         optAutoload(value);
                     }
@@ -1649,18 +1650,14 @@ export function initApp(): void {
                         return;
                     }
 
-                    if (opts.maxComments) {
-                        // Set maxComments first before autoload
+                    // Set following options first before autoload
+                    if (typeof opts.maxComments !== 'undefined') {
                         optMaxComments(Number(opts.maxComments));
                     }
-
-                    if (opts.hasYoutubeApiKey) {
-                        // Set hasYoutubeApiKey flag before autoload
+                    if (typeof opts.youtubeApiEnabled !== 'undefined') {
                         GlobalStore.hasYoutubeApiKey = Boolean(opts.hasYoutubeApiKey);
                     }
-
-                    if (opts.youtubeApiEnabled) {
-                        // Set youtubeApiEnabled flag before autoload
+                    if (typeof opts.youtubeApiEnabled !== 'undefined') {
                         GlobalStore.youtubeApiEnabled = Boolean(opts.youtubeApiEnabled);
                     }
 
@@ -1854,7 +1851,6 @@ export function initApp(): void {
             }
 
             if (e.data?.type === 'YCS_AUTOLOAD') {
-                GlobalStore.autoload = true;
                 elLoadAll?.click();
             }
         };

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1654,7 +1654,7 @@ export function initApp(): void {
                     if (typeof opts.maxComments !== 'undefined') {
                         optMaxComments(Number(opts.maxComments));
                     }
-                    if (typeof opts.youtubeApiEnabled !== 'undefined') {
+                    if (typeof opts.hasYoutubeApiKey !== 'undefined') {
                         GlobalStore.hasYoutubeApiKey = Boolean(opts.hasYoutubeApiKey);
                     }
                     if (typeof opts.youtubeApiEnabled !== 'undefined') {

--- a/app/src/source/web-resources/handlers/youtubeDataApiHandler.ts
+++ b/app/src/source/web-resources/handlers/youtubeDataApiHandler.ts
@@ -57,6 +57,7 @@ const REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
 export function requestYouTubeApiComments(
     videoId: string,
     signal: AbortSignal | undefined,
+    maxComments: number | undefined,
     onProgress: (count: number) => void
 ): Promise<YouTubeApiCommentsResult> {
     const requestId = crypto.randomUUID();
@@ -176,7 +177,7 @@ export function requestYouTubeApiComments(
         window.postMessage(
             {
                 type: 'YCS_YT_API_COMMENTS_START',
-                body: { videoId, requestId }
+                body: { videoId, requestId, maxComments }
             },
             window.location.origin
         );


### PR DESCRIPTION
This PR adds a max comments option. I created this PR because if you are using the youtube data api theres is a quota of 10,000 units so if a user opens a video with a lot of comments they could end up wasting a lot of their credits for the day so having an option will make it easier to limit credit usage. Max comments only applies for autoload not when clicking the load button manually.

I set the options for YouTube api and max comments before the opts for loop because they need to be set before autoload starts.

Let me know if you find any bugs