### PR TITLE
Fix loading all comments with cache and show clear button with empty query

### DIFF
--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -159,6 +159,8 @@ html[dark] .ycs_btn_load-stop:hover {
 /* clear-text button near the input */
 #ycs_btn_search_clear_text {
   padding: 0px 7px;
+  border-left: 0px;
+  vertical-align: top;
   height: 32px;
   line-height: 1;
   visibility: hidden; /* toggled by script */

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1218,7 +1218,7 @@ function renderSearch(node: HTMLElement): void {
                 </select>
                 <button id="ycs_btn_search" class="ycs-btn-search ycs-title ycs_noselect" type="button">
                     Search
-                </button><button id="ycs_btn_search_clear_text" class="ycs-btn-search ycs-title ycs-search-clear" type="button" title="Clear text" style="margin-left:1px;">✕</button>
+                </button><button id="ycs_btn_search_clear_text" class="ycs-btn-search ycs-title ycs-search-clear" type="button" title="Clear text">✕</button>
 
                 <div class="ycs-ext-search_block">
                     <p id="ycs-search-total-result" class="ycs-title"></p>

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -473,6 +473,10 @@ export function initApp(): void {
                     nodeTotalSearchResult.classList.add('ycs-hidden');
                 }
             }
+            const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
+            if (btnClear && !text.includes('Found: 0')) {
+                btnClear.style.visibility = 'visible';
+            }
         };
 
         const getSearchQuery = (): string => {
@@ -629,23 +633,14 @@ export function initApp(): void {
 
                         state = resetSearchCounts(state);
 
-                        const eInputSearch = document.getElementById('ycs-input-search') as HTMLInputElement;
+                        const elSearchRes = document.getElementById('ycs-search-result');
+                        const elSearchTotalRes = document.getElementById(
+                            'ycs-search-total-result'
+                        ) as HTMLElement | null;
 
-                        if (eInputSearch?.value && eInputSearch.value.trim()) {
-                            requestAnimationFrame(() => {
-                                const searchBtn = document.getElementById('ycs_btn_search');
-                                searchBtn?.click();
-                            });
-                        } else {
-                            const elSearchRes = document.getElementById('ycs-search-result');
-                            const elSearchTotalRes = document.getElementById(
-                                'ycs-search-total-result'
-                            ) as HTMLElement | null;
-
-                            if (elSearchRes && elSearchTotalRes) {
-                                elSearchRes.innerText = '';
-                                elSearchTotalRes.innerText = 'Search cleared';
-                            }
+                        if (elSearchRes && elSearchTotalRes) {
+                            elSearchRes.innerText = '';
+                            elSearchTotalRes.innerText = 'Search cleared';
                         }
 
                         const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
@@ -1075,15 +1070,6 @@ export function initApp(): void {
         const eInputSearch = document.getElementById('ycs-input-search');
         const btnSearchClearText = document.getElementById('ycs_btn_search_clear_text');
 
-        const setClearTextButtonVisibility = (): void => {
-            const btnVisible =
-                ((eInputSearch as HTMLInputElement)?.value?.trim()?.length ?? 0) > 0 ||
-                document.getElementById('ycs-search-result')?.hasChildNodes();
-            if (btnSearchClearText) {
-                (btnSearchClearText as HTMLButtonElement).style.visibility = btnVisible ? 'visible' : 'hidden';
-            }
-        };
-
         if (eInputSearch) {
             eInputSearch.onkeyup = (e): void => {
                 if (e.key === 'Enter' || e.code === 'Enter') {
@@ -1092,13 +1078,17 @@ export function initApp(): void {
             };
             // toggle clear-text button visibility
             eInputSearch.addEventListener('input', () => {
-                setClearTextButtonVisibility();
+                const hasText = (eInputSearch as HTMLInputElement).value.trim().length > 0;
+                if (btnSearchClearText) {
+                    (btnSearchClearText as HTMLButtonElement).style.visibility = hasText ? 'visible' : 'hidden';
+                }
             });
         }
 
         // initialize clear-text button visibility
         if (btnSearchClearText) {
-            setClearTextButtonVisibility();
+            (btnSearchClearText as HTMLButtonElement).style.visibility =
+                (eInputSearch as HTMLInputElement)?.value?.trim()?.length > 0 ? 'visible' : 'hidden';
             btnSearchClearText.addEventListener('click', () => {
                 try {
                     if (eInputSearch) {
@@ -1121,6 +1111,10 @@ export function initApp(): void {
 
                     // hide clear button after clearing
                     (btnSearchClearText as HTMLButtonElement).style.visibility = 'hidden';
+                    const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
+                    if (btnClear) {
+                        (btnClear as HTMLButtonElement).style.visibility = 'hidden';
+                    }
                 } catch (err) {
                     console.error(err);
                 }
@@ -1583,12 +1577,12 @@ export function initApp(): void {
 
                 const optAutoload = (value: boolean): void => {
                     if (value === true) {
+                        GlobalStore.autoload = true;
                         elLoadAll?.click();
                     }
                 };
 
                 const wrapOptAutoload = (value: boolean, opts: IYCSOptions): void => {
-                    GlobalStore.autoload = value;
                     if (!opts.cache) {
                         optAutoload(value);
                     }
@@ -1860,6 +1854,7 @@ export function initApp(): void {
             }
 
             if (e.data?.type === 'YCS_AUTOLOAD') {
+                GlobalStore.autoload = true;
                 elLoadAll?.click();
             }
         };

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -474,9 +474,7 @@ export function initApp(): void {
                 }
             }
             const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
-            if (btnClear && !text.includes('Found: 0')) {
-                btnClear.style.visibility = 'visible';
-            }
+            if (btnClear) btnClear.style.visibility = !text.includes('Found: 0') ? 'visible' : 'hidden';
         };
 
         const getSearchQuery = (): string => {

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1100,9 +1100,19 @@ export function initApp(): void {
                         (eInputSearch as HTMLInputElement).value = '';
                     }
 
-                    requestAnimationFrame(() => {
-                        btnSearch?.click();
-                    });
+                    const activeParam = getActiveFilterParam();
+                    const elSearchRes = document.getElementById('ycs-search-result');
+                    const elSearchTotalRes = document.getElementById('ycs-search-total-result') as HTMLElement | null;
+
+                    if (activeParam) {
+                        // Reapply current filter while only clearing the text query
+                        requestAnimationFrame(() => {
+                            btnSearch?.click();
+                        });
+                    } else if (elSearchRes) {
+                        elSearchRes.innerText = '';
+                        if (elSearchTotalRes) elSearchTotalRes.innerText = 'Search cleared';
+                    }
 
                     // hide clear button after clearing
                     (btnSearchClearText as HTMLButtonElement).style.visibility = 'hidden';

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -473,8 +473,13 @@ export function initApp(): void {
                     nodeTotalSearchResult.classList.add('ycs-hidden');
                 }
             }
+            const searchCounts = getSearchCounts(state);
+            const resTotalSearch = searchCounts.comments + searchCounts.commentsChat + searchCounts.commentsTrVideo;
             const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
-            if (btnClear) btnClear.style.visibility = !text.includes('Found: 0') ? 'visible' : 'hidden';
+            const hasActiveFilter = document.querySelector('.ycs_btn_active') !== null;
+            const hasQuery = getSearchQuery().trim().length > 0;
+            if (btnClear)
+                btnClear.style.visibility = (!hasQuery && resTotalSearch > 0) || hasActiveFilter ? 'visible' : 'hidden';
         };
 
         const getSearchQuery = (): string => {
@@ -491,13 +496,6 @@ export function initApp(): void {
 
                 if (param && el) {
                     el.classList.add('ycs_btn_active');
-                }
-
-                // toggle clear-filter button visibility
-                const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
-                if (btnClear) {
-                    const hasActive = !!param;
-                    btnClear.style.visibility = hasActive ? 'visible' : 'hidden';
                 }
             } catch {
                 // Silently ignore DOM manipulation errors
@@ -631,14 +629,23 @@ export function initApp(): void {
 
                         state = resetSearchCounts(state);
 
-                        const elSearchRes = document.getElementById('ycs-search-result');
-                        const elSearchTotalRes = document.getElementById(
-                            'ycs-search-total-result'
-                        ) as HTMLElement | null;
+                        const eInputSearch = document.getElementById('ycs-input-search') as HTMLInputElement;
 
-                        if (elSearchRes && elSearchTotalRes) {
-                            elSearchRes.innerText = '';
-                            elSearchTotalRes.innerText = 'Search cleared';
+                        if (eInputSearch?.value && eInputSearch.value.trim()) {
+                            requestAnimationFrame(() => {
+                                const searchBtn = document.getElementById('ycs_btn_search');
+                                searchBtn?.click();
+                            });
+                        } else {
+                            const elSearchRes = document.getElementById('ycs-search-result');
+                            const elSearchTotalRes = document.getElementById(
+                                'ycs-search-total-result'
+                            ) as HTMLElement | null;
+
+                            if (elSearchRes && elSearchTotalRes) {
+                                elSearchRes.innerText = '';
+                                elSearchTotalRes.innerText = 'Search cleared';
+                            }
                         }
 
                         const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
@@ -1093,19 +1100,9 @@ export function initApp(): void {
                         (eInputSearch as HTMLInputElement).value = '';
                     }
 
-                    const activeParam = getActiveFilterParam();
-                    const elSearchRes = document.getElementById('ycs-search-result');
-                    const elSearchTotalRes = document.getElementById('ycs-search-total-result') as HTMLElement | null;
-
-                    if (activeParam) {
-                        // Reapply current filter while only clearing the text query
-                        requestAnimationFrame(() => {
-                            btnSearch?.click();
-                        });
-                    } else if (elSearchRes) {
-                        elSearchRes.innerText = '';
-                        if (elSearchTotalRes) elSearchTotalRes.innerText = 'Search cleared';
-                    }
+                    requestAnimationFrame(() => {
+                        btnSearch?.click();
+                    });
 
                     // hide clear button after clearing
                     (btnSearchClearText as HTMLButtonElement).style.visibility = 'hidden';


### PR DESCRIPTION
Apologies as I introduced a small bug in #132, where loading comments manually on a page with cached comments would load comments up to maxComments, forcing the user to click the load button twice to get all comments. Ex: Set max comments to 50, go to a video and have the comments autoload, then refresh the page, you need to click load comments twice to get all comments. This is because `GlobalStore.autoload` would always be set to true even if comments weren't autoloaded since they were cached.


I also made it so the clear button would show for empty queries with no filters being selected.