### PR TITLE
feat(comments): add inline reply support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,7 @@ Canonical behavior baseline doc:
 - Fallback: WEB client with SAPISIDHASH auth + racyCheckOk/contentCheckOk (for age-restricted)
 - AbortError is rethrown in both stages to respect cancellation
 
-5. Sidebar comment reply via Innertube write API
+5. Inline comment reply via Innertube write API
 - `reply.ts` sends POST to `create_comment_reply` endpoint, reusing existing auth/request infrastructure
 - `createReplyParams` token extracted from `engagementToolbarSurfaceEntityPayload` in FW pipeline
 - Reply UI is inline per-comment at all nesting levels, handled in `commentInteractions.ts`
@@ -284,6 +284,7 @@ Manual smoke checklist:
 - `app/docs/sap-sid-authorization.md`
 - `app/docs/adaptive-authorization-headers.md`
 - `app/docs/youtube-data-api-messaging.md`
-- `app/docs/filter-search-behavior-regression-spec.md`
+- `app/docs/filter-search-behavior-regression-spec.md` — regression baseline for search/filter/clear-button behavior
+- `app/docs/inline-reply-behavior-regression-spec.md` — regression baseline for inline reply form, rate limiting, and synthetic preview lifecycle
 
 When behavior rules change, update the relevant doc in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,8 @@ Canonical behavior baseline doc:
 - Reply UI is inline per-comment at all nesting levels, handled in `commentInteractions.ts`
 - 30-second global cooldown enforced at attempt time (not success time)
 - Opt-in via `enableInlineReply` setting (forces authenticated comment loading; not compatible with Data API mode)
+- Successful replies insert a synthetic DOM element (not state) as visual feedback; cleaned up when real replies are toggled or comments reloaded
+- Rate limit displays a live countdown timer; uses MutationObserver for cleanup on form removal
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,8 @@ Canonical behavior baseline doc:
 - Opt-in via `enableInlineReply` setting (forces authenticated comment loading; not compatible with Data API mode)
 - Successful replies insert a synthetic DOM element (not state) as visual feedback; cleaned up when real replies are toggled or comments reloaded
 - Rate limit displays a live countdown timer; uses MutationObserver for cleanup on form removal
+- Reply response data is injected into state + cache via event-based pipeline (`ycs-reply-success` CustomEvent); no reload needed to persist the new reply
+- `buildReplyCommentFromResponse()` in pipeline.ts converts reply API response to CommentItem using existing FW pipeline functions
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ Canonical behavior baseline doc:
 - `createReplyParams` token extracted from `engagementToolbarSurfaceEntityPayload` in FW pipeline
 - Reply UI is inline per-comment at all nesting levels, handled in `commentInteractions.ts`
 - 30-second global cooldown enforced at attempt time (not success time)
-- Requires authenticated comment loading (`__YCS_FORCE_AUTH = true` or member-only/age-restricted)
+- Opt-in via `enableInlineReply` setting (forces authenticated comment loading; not compatible with Data API mode)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,12 @@ Canonical behavior baseline doc:
 5. Innertube client type and auth header must be consistent
    ANDROID client + browser SAPISIDHASH authorization = HTTP 400. Only send auth headers with WEB client requests.
 
+6. Write operations (reply) always require auth enabled
+   `reply.ts` uses `disableAuth: false` — unlike read operations which conditionally disable auth based on access restriction status. Never apply `shouldDisableAuth()` to write endpoints.
+
+7. `createReplyParams` is extracted before field cleanup deletes raw API data
+   In `pipeline.ts`, `prepareFieldsComment()` deletes `actionButtons` and `replyButton`. The `createReplyParams` token must be extracted before those deletions. Same pattern as `creatorHeart` extraction.
+
 ---
 
 ## Recent Significant Changes
@@ -226,6 +232,13 @@ Canonical behavior baseline doc:
 - Fallback: WEB client with SAPISIDHASH auth + racyCheckOk/contentCheckOk (for age-restricted)
 - AbortError is rethrown in both stages to respect cancellation
 
+5. Sidebar comment reply via Innertube write API
+- `reply.ts` sends POST to `create_comment_reply` endpoint, reusing existing auth/request infrastructure
+- `createReplyParams` opaque token extracted from comment pipeline (both legacy and FW paths)
+- Reply UI is inline per-comment (button → textarea → send), handled in `commentInteractions.ts`
+- 30-second global cooldown enforced at attempt time (not success time)
+- Only parent comments show reply button; replies-to-replies are out of scope
+
 ---
 
 ## Testing Guidance
@@ -247,6 +260,7 @@ Manual smoke checklist:
 3. Verify search + filter + clear-button interactions
 4. Verify export still works
 5. Verify Shorts page behavior
+6. Verify comment reply (click Reply → type → send → check success/error/rate-limit)
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,8 +206,17 @@ Canonical behavior baseline doc:
 6. Write operations (reply) always require auth enabled
    `reply.ts` uses `disableAuth: false` — unlike read operations which conditionally disable auth based on access restriction status. Never apply `shouldDisableAuth()` to write endpoints.
 
-7. `createReplyParams` is extracted before field cleanup deletes raw API data
-   In `pipeline.ts`, `prepareFieldsComment()` deletes `actionButtons` and `replyButton`. The `createReplyParams` token must be extracted before those deletions. Same pattern as `creatorHeart` extraction.
+7. `createReplyParams` lives in `engagementToolbarSurfaceEntityPayload`, not in `commentEntityPayload`
+   Extracted via `vm.toolbarSurfaceKey` → `replyCommand.innertubeCommand.createCommentReplyDialogEndpoint...createReplyParams`. Only present in **authenticated** responses — logged-out mode returns a sign-in modal instead.
+
+8. FW pipeline has 4 mutation payload types — all must be indexed
+   `getFrameworkUpdatesById()` must handle: `commentEntityPayload`, `commentSurfaceEntityPayload`, `engagementToolbarStateEntityPayload`, and `engagementToolbarSurfaceEntityPayload`. Missing any of these silently drops data.
+
+9. `generateCommentObjectFromFW` has multiple call sites — keep in sync
+   Currently 3 call sites in `pipeline.ts` (parent comments, reply ViewModels, sub-threads). All must pass the same set of FW updates including `toolbarSurfaceUpdate`. Adding a new parameter to the function signature requires updating all call sites.
+
+10. Dynamic import chunks must be registered in `manifest.json` `web_accessible_resources`
+    Parcel code-splits dynamic `import()` into separate `.js` files (e.g., `reply.*.js`). These chunks must match a pattern in `web_accessible_resources.resources` or Chrome will block loading them.
 
 ---
 
@@ -234,10 +243,10 @@ Canonical behavior baseline doc:
 
 5. Sidebar comment reply via Innertube write API
 - `reply.ts` sends POST to `create_comment_reply` endpoint, reusing existing auth/request infrastructure
-- `createReplyParams` opaque token extracted from comment pipeline (both legacy and FW paths)
-- Reply UI is inline per-comment (button → textarea → send), handled in `commentInteractions.ts`
+- `createReplyParams` token extracted from `engagementToolbarSurfaceEntityPayload` in FW pipeline
+- Reply UI is inline per-comment at all nesting levels, handled in `commentInteractions.ts`
 - 30-second global cooldown enforced at attempt time (not success time)
-- Only parent comments show reply button; replies-to-replies are out of scope
+- Requires authenticated comment loading (`__YCS_FORCE_AUTH = true` or member-only/age-restricted)
 
 ---
 

--- a/app/docs/inline-reply-behavior-regression-spec.md
+++ b/app/docs/inline-reply-behavior-regression-spec.md
@@ -1,0 +1,225 @@
+# Inline Reply Behavior Specification (Regression Baseline)
+
+---
+
+## 1. Purpose
+
+Define observable behavior for the inline reply feature as a regression baseline for code review.
+If implementation deviates from this spec without an explicit requirement change, it should be flagged as a regression issue.
+
+---
+
+## 2. Scope and Components
+
+### 2.1 Component Definitions
+
+- `ReplyButton`: `.ycs-reply-btn` — rendered per comment when `createReplyParams` is present
+- `ReplyForm`: `.ycs-reply-form` — inline form containing textarea, action buttons, and status area
+- `ReplyTextarea`: `.ycs-reply-textarea`
+- `CancelButton`: `.ycs-reply-cancel`
+- `SendButton`: `.ycs-reply-send`
+- `StatusArea`: `.ycs-reply-status`
+- `SyntheticReply`: `.ycs-synthetic-reply` — DOM-only preview inserted after successful send
+- `SyntheticRepliesWrap`: `.ycs-synthetic-replies-wrap` — container for synthetic reply elements
+
+### 2.2 State Symbols
+
+- `P`: `createReplyParams` token (present only in authenticated responses)
+- `T`: `ReplyTextarea.value.trim()`
+- `S`: form sending state (`form.dataset.sending`)
+- `C`: countdown active flag (rate limit timer running)
+- `R`: rate limit interval (30 seconds, `RATE_LIMIT_INTERVAL_MS`)
+
+---
+
+## 3. Preconditions (MUST)
+
+1. `enableInlineReply` must be `true` in extension settings.
+2. When `enableInlineReply` is `true`, `shouldDisableAuth()` always returns `false`, forcing authenticated comment loading regardless of member-only or age-restricted status.
+3. `createReplyParams` is only present in authenticated Innertube responses. Logged-out mode returns a sign-in modal instead — no reply button is rendered.
+4. Not compatible with YouTube Data API mode. Data API responses do not contain `createReplyParams`.
+
+---
+
+## 4. Reply Button Visibility Rules (MUST)
+
+1. `ReplyButton` is rendered per comment element only when the comment's `createReplyParams` is non-empty. The rendering path does not check `enableInlineReply` directly — visibility is determined solely by presence of the token.
+2. `ReplyButton` carries `data-create-reply-params` attribute. `data-comment-id` is set conditionally when the comment has a `commentId`.
+3. When `enableInlineReply` is `false`, auth may be disabled for normal videos, so `createReplyParams` is absent from responses and no button renders. Exception: member-only or age-restricted videos always send auth regardless of `enableInlineReply`, so `createReplyParams` may be present and the button may render even with the setting off.
+
+---
+
+## 5. Reply Form Toggle Behavior (MUST)
+
+### 5.1 Open Form (click `ReplyButton`, no existing form)
+
+1. Create `ReplyForm` inside the comment's `.ycs-comment-block`.
+2. `SendButton` starts as `disabled`.
+3. `ReplyTextarea` receives focus.
+
+### 5.2 Close Form (click `ReplyButton`, form already exists)
+
+1. If `S === 'true'` (sending in progress): **do nothing**, ignore click.
+2. If `S !== 'true'`: remove the form immediately.
+
+### 5.3 Cancel Button
+
+1. Remove the form immediately, regardless of state.
+
+---
+
+## 6. Send Button State Rules (MUST)
+
+1. `SendButton` is `disabled` when `T` is empty.
+2. `SendButton` is `disabled` during sending (`S === 'true'`).
+3. `SendButton` is `disabled` during active countdown (`C === true`), regardless of `T`.
+4. `SendButton` is enabled only when `T` is non-empty AND `S !== 'true'` AND `C === false`.
+5. `ReplyTextarea` `input` events update `SendButton` disabled state (unless countdown is active).
+
+---
+
+## 7. Rate Limiting Rules (MUST)
+
+### 7.1 Client-Side Rate Limit
+
+1. Global cooldown of 30 seconds (`RATE_LIMIT_INTERVAL_MS = 30_000`).
+2. `lastReplyTimestamp` is set at **attempt time** (when send is clicked), not on success.
+3. `canSendReply()` checks elapsed time since last attempt.
+
+### 7.2 Countdown Timer Behavior
+
+1. When rate limited, `StatusArea` shows `Please wait Ns` with class `ycs-reply-countdown`.
+2. Countdown decrements every 1 second.
+3. During countdown: `SendButton` is disabled, `ReplyTextarea` and `CancelButton` are re-enabled.
+4. `form.dataset.sending` is cleared (form is not in sending state during countdown).
+5. When countdown reaches 0: status is cleared, `C` resets to `false`, `SendButton` follows normal `T`-based enable logic.
+
+### 7.3 Countdown Cleanup
+
+1. A `MutationObserver` watches the form's parent for `childList` changes.
+2. If the form is removed from the DOM during countdown, the interval is cleared and observer is disconnected.
+
+### 7.4 Server-Side Rate Limit (HTTP 429)
+
+1. Returns `rateLimited: true` with error message.
+2. Displayed as error status; does not trigger client countdown.
+
+---
+
+## 8. Sending State Machine (MUST)
+
+### 8.1 Sending Phase
+
+1. All controls disabled (`SendButton`, `ReplyTextarea`, `CancelButton`).
+2. `form.dataset.sending = 'true'`.
+3. `StatusArea` shows "Sending..." with class `ycs-reply-sending`.
+
+### 8.2 Success
+
+1. Synthetic reply element is inserted (see Section 9).
+2. `StatusArea` shows "Reply sent!" with class `ycs-reply-success`.
+3. `ReplyTextarea` is cleared, `SendButton` disabled.
+4. Form auto-removes after 1500ms.
+
+### 8.3 Error (non-rate-limit)
+
+1. `StatusArea` shows error message with class `ycs-reply-error`.
+2. Special case: if error contains "expired", display "Token expired — please reload comments and retry".
+3. `ReplyTextarea` and `CancelButton` are re-enabled.
+4. `SendButton` follows normal `T`-based enable logic.
+
+### 8.4 Unexpected Error (catch)
+
+1. Same recovery as 8.3; status shows "Unexpected error".
+
+### 8.5 Finally
+
+1. `form.dataset.sending` is always cleared in `finally` block.
+
+---
+
+## 9. Synthetic Reply Lifecycle (MUST)
+
+### 9.1 Insertion
+
+1. On successful reply, a `SyntheticReply` element is created with:
+   - User avatar from `#avatar-btn img`
+   - Author text: "You"
+   - Timestamp text: "Just now"
+   - Reply text as plain text (not HTML)
+2. Insertion target priority:
+   1. Existing real replies container (`.ycs-com-replies-{safeId}`)
+   2. Existing `.ycs-synthetic-replies-wrap`
+   3. New `.ycs-synthetic-replies-wrap` appended to `commentContainer`
+
+### 9.2 Cleanup
+
+1. When `handleOpenReply` loads real replies for a comment, any existing `.ycs-synthetic-replies-wrap` is removed first.
+2. When comments are reloaded (new search or data fetch), the entire rendered area is replaced, removing all synthetic elements.
+
+---
+
+## 10. API and Auth Rules (MUST)
+
+1. Reply endpoint: `POST /youtubei/v1/comment/create_comment_reply`.
+2. Auth is always enabled (`disableAuth: false`). Never apply `shouldDisableAuth()` to write endpoints.
+3. `credentials: 'include'` and `mode: 'cors'` are required.
+4. Success is determined by `actionResult.status === 'STATUS_SUCCEEDED'` in response body.
+
+### 10.1 Error Status Handling
+
+| HTTP Status | Error Message | `rateLimited` |
+|---|---|---|
+| 401, 403 | Authentication failed. Please sign in to YouTube. | omitted |
+| 429 | Rate limited by YouTube. Please wait. | `true` |
+| 400 | Reply params expired. Please reload comments. | omitted |
+| Other | Request failed ({status}) | omitted |
+| AbortError | Request cancelled | omitted |
+| Network error | Network error | omitted |
+
+---
+
+## 11. Token Extraction Rules (MUST)
+
+### 11.1 FW Pipeline Path (primary)
+
+1. `getFrameworkUpdatesById()` indexes `engagementToolbarSurfaceEntityPayload` by its `key`.
+2. `generateCommentObjectFromFW` extracts `createReplyParams` from `toolbarSurfaceUpdate.replyCommand.innertubeCommand.createCommentReplyDialogEndpoint.dialog.commentReplyDialogRenderer.replyButton.buttonRenderer.serviceEndpoint.createCommentReplyEndpoint.createReplyParams`.
+3. All 3 call sites of `generateCommentObjectFromFW` (parent comments, reply ViewModels, sub-threads) must pass `toolbarSurfaceUpdate`.
+
+### 11.2 Legacy Path (fallback)
+
+1. `prepareFieldsComment()` extracts `createReplyParams` from `actionButtons.commentActionButtonsRenderer.replyButton.buttonRenderer.navigationEndpoint.createCommentReplyDialogEndpoint.dialog.commentReplyDialogRenderer.replyButton.buttonRenderer.serviceEndpoint.createCommentReplyEndpoint.createReplyParams`.
+2. This path handles responses that use the classic comment renderer format rather than FW mutations.
+
+---
+
+## 12. Regression Criteria
+
+If any of the following occurs, mark it as a regression:
+
+1. Reply form opens or sends when `enableInlineReply` is `false`.
+2. `ReplyButton` is rendered for a comment without `createReplyParams`.
+3. `SendButton` becomes enabled while `T` is empty or during countdown.
+4. Reply is sent without `disableAuth: false`.
+5. `shouldDisableAuth()` returns `true` when `enableInlineReply` is `true`.
+6. Clicking `ReplyButton` during active sending (`S === 'true'`) removes or modifies the form.
+7. Countdown timer continues running after form is removed from DOM.
+8. Synthetic reply is inserted on failed send.
+9. `handleOpenReply` does not clean up `.ycs-synthetic-replies-wrap` before loading real replies.
+10. `lastReplyTimestamp` is set on success instead of attempt time.
+11. Rate limit interval deviates from 30 seconds without explicit requirement change.
+12. Any `generateCommentObjectFromFW` call site does not pass `toolbarSurfaceUpdate`.
+
+---
+
+## 13. Confirmed Design Decisions (Fixed Behavior)
+
+The following behaviors are explicitly confirmed as fixed rules and must not change without product requirement updates:
+
+1. Inline reply is opt-in only. Default is `false`.
+2. Enabling inline reply forces authenticated comment loading for all videos, overriding the normal member-only/age-restricted conditional auth logic.
+3. Rate limit cooldown starts at attempt time, not success time. Failed attempts still consume the cooldown window.
+4. Synthetic replies are DOM-only visual feedback. They are not persisted to state and are not searchable.
+5. The reply form is a toggle: clicking `ReplyButton` again closes the form (unless sending is in progress).
+6. The feature is not compatible with YouTube Data API mode. This is by design — Data API responses lack `createReplyParams` tokens.

--- a/app/docs/inline-reply-behavior-regression-spec.md
+++ b/app/docs/inline-reply-behavior-regression-spec.md
@@ -117,9 +117,10 @@ If implementation deviates from this spec without an explicit requirement change
 ### 8.2 Success
 
 1. Synthetic reply element is inserted (see Section 9).
-2. `StatusArea` shows "Reply sent!" with class `ycs-reply-success`.
-3. `ReplyTextarea` is cleared, `SendButton` disabled.
-4. Form auto-removes after 1500ms.
+2. `ycs-reply-success` CustomEvent is dispatched on `document` with raw `responseData` (see Section 14).
+3. `StatusArea` shows "Reply sent!" with class `ycs-reply-success`.
+4. `ReplyTextarea` is cleared, `SendButton` disabled.
+5. Form auto-removes after 1500ms.
 
 ### 8.3 Error (non-rate-limit)
 
@@ -164,7 +165,7 @@ If implementation deviates from this spec without an explicit requirement change
 1. Reply endpoint: `POST /youtubei/v1/comment/create_comment_reply`.
 2. Auth is always enabled (`disableAuth: false`). Never apply `shouldDisableAuth()` to write endpoints.
 3. `credentials: 'include'` and `mode: 'cors'` are required.
-4. Success is determined by `actionResult.status === 'STATUS_SUCCEEDED'` in response body.
+4. Success is determined by `actionResult.status === 'STATUS_SUCCEEDED'` in response body. On success, full response JSON is returned as `responseData` in `ReplyResult` for state injection (Section 14).
 
 ### 10.1 Error Status Handling
 
@@ -210,6 +211,10 @@ If any of the following occurs, mark it as a regression:
 10. `lastReplyTimestamp` is set on success instead of attempt time.
 11. Rate limit interval deviates from 30 seconds without explicit requirement change.
 12. Any `generateCommentObjectFromFW` call site does not pass `toolbarSurfaceUpdate`.
+13. Reply success does not dispatch `ycs-reply-success` event when `responseData` is present.
+14. State injection silently drops the new reply without updating `state.comments`.
+15. Thread root `replyCount` is not incremented when replying to a nested comment (`replyToCommentId !== parentCommentId`).
+16. Duplicate reply is injected into state (same `commentId` already exists in `state.comments`).
 
 ---
 
@@ -220,6 +225,44 @@ The following behaviors are explicitly confirmed as fixed rules and must not cha
 1. Inline reply is opt-in only. Default is `false`.
 2. Enabling inline reply forces authenticated comment loading for all videos, overriding the normal member-only/age-restricted conditional auth logic.
 3. Rate limit cooldown starts at attempt time, not success time. Failed attempts still consume the cooldown window.
-4. Synthetic replies are DOM-only visual feedback. They are not persisted to state and are not searchable.
+4. Synthetic replies are DOM-only visual feedback for immediate display. Real reply data is injected into state and cache via event pipeline (Section 14) and is searchable after the next search execution.
 5. The reply form is a toggle: clicking `ReplyButton` again closes the form (unless sending is in progress).
 6. The feature is not compatible with YouTube Data API mode. This is by design — Data API responses lack `createReplyParams` tokens.
+
+---
+
+## 14. Reply State Injection (MUST)
+
+### 14.1 Event Flow
+
+1. On successful reply, `commentInteractions.ts` dispatches `CustomEvent('ycs-reply-success')` on `document` with `detail.responseData` containing the full API response JSON.
+2. Event is dispatched **after** synthetic DOM insertion (Section 9.1), not before.
+3. `appController.ts` listens for `ycs-reply-success` and processes the response.
+
+### 14.2 Response Processing
+
+1. `createCommentReplyAction` is extracted from `responseData.actions` to obtain `parentCommentId` (thread root) and `replyToCommentId` (direct parent).
+2. `originComment` is found in `state.comments` by scanning for `commentRenderer.commentId` matching `replyToCommentId` first, then `parentCommentId` as fallback.
+3. `buildReplyCommentFromResponse()` in `pipeline.ts` converts the response via existing FW pipeline: `getFrameworkUpdatesById` → `generateCommentObjectFromFW` → `enrichCommentRenderer`.
+4. The `commentViewModel` entity keys from the response's `createCommentReplyAction.contents` are used to look up the correct FW mutations.
+5. `replyLevel` is extracted from FW data; fallback is `(originComment.replyLevel ?? 0) + 1`.
+
+### 14.3 State Update Rules
+
+1. Dedup guard: if a comment with the same `commentId` already exists in `state.comments`, injection is skipped.
+2. New reply is appended to `state.comments` with `_index = comments.length`.
+3. `originComment.commentRenderer.replyCount` is incremented by 1 (direct parent).
+4. If `replyToCommentId !== parentCommentId`, the thread root's `commentRenderer.replyCount` is also incremented by 1.
+5. `replyCount` coercion uses `Number()` to handle both `number` and `string` types.
+6. `state.count.comments` is updated via `setCount`.
+7. Badge is updated via `updateBadge`.
+
+### 14.4 Cache Persistence
+
+1. After state update, `saveToCache()` is called with the updated `state.comments`.
+2. `saveToCache` internally calls `stripReplyTokens` which recursively strips `createReplyParams` from the entire `originComment` chain via `stripOriginChain`. The in-memory state retains tokens for chain replying.
+
+### 14.5 Failure Handling
+
+1. If `responseData` is absent, `createCommentReplyAction` is not found, `originComment` is not in state, or `buildReplyCommentFromResponse` returns `undefined` — injection is silently skipped. The synthetic DOM preview remains as visual feedback.
+2. All processing is wrapped in try-catch; errors are logged to console.

--- a/app/manifest.json
+++ b/app/manifest.json
@@ -41,7 +41,7 @@
   "web_accessible_resources": [
     {
       "matches": ["*://*.youtube.com/*"],
-      "resources": ["web-resources/*.js", "web-resources/*.js.map", "xlsx.*.js"]
+      "resources": ["web-resources/*.js", "web-resources/*.js.map", "xlsx.*.js", "reply.*.js"]
     }
   ]
 }

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -12,6 +12,7 @@ const options = {
     maxComments: 500000,
     youtubeApiKey: '', // Empty = use Innertube (default); Filled = use YouTube Data API
     youtubeApiEnabled: true, // Enable YouTube Data API (requires API key to take effect)
+    enableInlineReply: false, // Show reply buttons; forces authenticated comment loading (not compatible with Data API)
     filterButtons: [
         { id: 'ycs_btn_timestamps', enabled: true },
         { id: 'ycs_btn_timestamp_viz', enabled: true },

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -693,6 +693,128 @@ html[dark] .ycs-comment__main-text {
   color: #fff;
 }
 
+.ycs-reply-btn {
+  font-size: 12px;
+  font-weight: 500;
+  color: #065fd4;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 0;
+  margin-top: 4px;
+  display: block;
+}
+.ycs-reply-btn:hover {
+  text-decoration: underline;
+}
+html[dark='true'] .ycs-reply-btn,
+html[dark] .ycs-reply-btn {
+  color: #3ea6ff;
+}
+
+.ycs-reply-form {
+  margin-top: 8px;
+  margin-bottom: 4px;
+}
+.ycs-reply-textarea {
+  width: 100%;
+  min-height: 60px;
+  max-height: 150px;
+  padding: 8px;
+  font-family: Roboto, Arial, sans-serif;
+  font-size: 13px;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+html[dark='true'] .ycs-reply-textarea,
+html[dark] .ycs-reply-textarea {
+  background-color: #313131;
+  border-color: #303030;
+  color: #fff;
+}
+.ycs-reply-textarea:focus {
+  outline: none;
+  border-color: #065fd4;
+}
+html[dark='true'] .ycs-reply-textarea:focus,
+html[dark] .ycs-reply-textarea:focus {
+  border-color: #3ea6ff;
+}
+.ycs-reply-textarea:disabled {
+  opacity: 0.6;
+}
+
+.ycs-reply-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 6px;
+}
+.ycs-reply-cancel,
+.ycs-reply-send {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 6px 16px;
+  border-radius: 18px;
+  border: none;
+  cursor: pointer;
+}
+.ycs-reply-cancel {
+  background: transparent;
+  color: #606060;
+}
+.ycs-reply-cancel:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+html[dark='true'] .ycs-reply-cancel,
+html[dark] .ycs-reply-cancel {
+  color: #aaa;
+}
+html[dark='true'] .ycs-reply-cancel:hover,
+html[dark] .ycs-reply-cancel:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+.ycs-reply-send {
+  background-color: #065fd4;
+  color: #fff;
+}
+.ycs-reply-send:hover:not(:disabled) {
+  background-color: #0550b3;
+}
+html[dark='true'] .ycs-reply-send,
+html[dark] .ycs-reply-send {
+  background-color: #3ea6ff;
+  color: #0d0d0d;
+}
+.ycs-reply-cancel:disabled,
+.ycs-reply-send:disabled {
+  opacity: 0.5;
+  cursor: default;
+  pointer-events: none;
+}
+
+.ycs-reply-status {
+  font-size: 12px;
+  margin-top: 4px;
+  min-height: 16px;
+}
+.ycs-reply-success {
+  color: #2e7d32;
+}
+html[dark='true'] .ycs-reply-success,
+html[dark] .ycs-reply-success {
+  color: #4caf50;
+}
+.ycs-reply-error {
+  color: #c62828;
+}
+html[dark='true'] .ycs-reply-error,
+html[dark] .ycs-reply-error {
+  color: #ef5350;
+}
+
 .ycs-head__title-main {
   height: 20px;
 }

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -814,6 +814,40 @@ html[dark='true'] .ycs-reply-error,
 html[dark] .ycs-reply-error {
   color: #ef5350;
 }
+.ycs-reply-sending {
+  animation: ycs-pulse 1.5s infinite ease-in-out;
+}
+.ycs-reply-countdown {
+  color: #e65100;
+  font-weight: 500;
+}
+html[dark='true'] .ycs-reply-countdown,
+html[dark] .ycs-reply-countdown {
+  color: #ff9800;
+}
+.ycs-synthetic-reply {
+  opacity: 0.8;
+  animation: ycs-reply-fade-in 0.3s ease-out;
+}
+.ycs-synthetic-replies-wrap {
+  margin-left: 15px;
+  border-left: 2px solid #e0e0e0;
+  padding-left: 8px;
+}
+html[dark='true'] .ycs-synthetic-replies-wrap,
+html[dark] .ycs-synthetic-replies-wrap {
+  border-left-color: #404040;
+}
+@keyframes ycs-reply-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 0.8;
+    transform: translateY(0);
+  }
+}
 
 .ycs-head__title-main {
   height: 20px;

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -109,6 +109,11 @@ window.onload = async (): Promise<void> => {
             (document.getElementById('y_opts_hidden_by_default_shorts') as HTMLInputElement).checked = param;
         };
 
+        const setRenderEnableInlineReply = (param: boolean): void => {
+            if (typeof param !== 'boolean') return;
+            (document.getElementById('y_opts_enable_inline_reply') as HTMLInputElement).checked = param;
+        };
+
         const setRenderEnableShortsSupport = (param: boolean): void => {
             if (typeof param !== 'boolean') return;
 
@@ -592,6 +597,14 @@ window.onload = async (): Promise<void> => {
             }
         };
 
+        const optSetEnableInlineReply = async (opt: HTMLInputElement): Promise<void> => {
+            try {
+                await chrome.storage.local.set({ enableInlineReply: opt.checked });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
         const optSetEnableShortsSupport = async (opt: HTMLInputElement): Promise<void> => {
             try {
                 await chrome.storage.local.set({
@@ -721,6 +734,10 @@ window.onload = async (): Promise<void> => {
                         setRenderEnableShortsSupport(storageOpts[key]);
                         break;
 
+                    case 'enableInlineReply':
+                        setRenderEnableInlineReply(storageOpts[key]);
+                        break;
+
                     case 'transcriptLanguage':
                         setRenderTranscriptLanguage(storageOpts[key]);
                         break;
@@ -797,6 +814,10 @@ window.onload = async (): Promise<void> => {
 
                 case 'y_opts_enable_shorts_support':
                     optSetEnableShortsSupport(e.target as HTMLInputElement);
+                    break;
+
+                case 'y_opts_enable_inline_reply':
+                    optSetEnableInlineReply(e.target as HTMLInputElement);
                     break;
 
                 case 'ycs_opts_btn_reset_filters':

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -117,8 +117,7 @@
             </p>
             <p>After toggling, reload comments for changes to take effect.</p>
             <p>
-              After a successful reply, a preview appears instantly. To see the actual reply from YouTube, reload
-              comments.
+              After a successful reply, the new reply is saved automatically and will appear in future searches.
             </p>
             <p>Not compatible with YouTube Data API mode.</p>
           </div>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -108,6 +108,19 @@
         </div>
 
         <div>
+          <label for="y_opts_enable_inline_reply">Enable inline reply:</label>
+          <input type="checkbox" name="Enable inline reply" id="y_opts_enable_inline_reply" class="ycs_opts_checkbox" />
+          <div class="ycs_description_option ycs_api_desc">
+            <p>
+              Show reply buttons on comments. Requires YouTube login. When enabled, comments are loaded with
+              authentication to retrieve reply tokens.
+            </p>
+            <p>After toggling, reload comments for changes to take effect.</p>
+            <p>Not compatible with YouTube Data API mode.</p>
+          </div>
+        </div>
+
+        <div>
           <label for="y_opts_transcript_language_select">Default transcript language:</label>
           <select id="y_opts_transcript_language_select" class="ycs_opts_select">
             <option value="">YouTube default</option>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -116,9 +116,7 @@
               authentication to retrieve reply tokens.
             </p>
             <p>After toggling, reload comments for changes to take effect.</p>
-            <p>
-              After a successful reply, the new reply is saved automatically and will appear in future searches.
-            </p>
+            <p>After a successful reply, the new reply is saved automatically and will appear in future searches.</p>
             <p>Not compatible with YouTube Data API mode.</p>
           </div>
         </div>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -116,6 +116,10 @@
               authentication to retrieve reply tokens.
             </p>
             <p>After toggling, reload comments for changes to take effect.</p>
+            <p>
+              After a successful reply, a preview appears instantly. To see the actual reply from YouTube, reload
+              comments.
+            </p>
             <p>Not compatible with YouTube Data API mode.</p>
           </div>
         </div>

--- a/app/src/source/utils/innertube.ts
+++ b/app/src/source/utils/innertube.ts
@@ -11,7 +11,8 @@ export {
     getAllCommentsModeV2,
     extractNextContinuation,
     applyFrameworkUpdatesToComment,
-    generateCommentObjectFromFW
+    generateCommentObjectFromFW,
+    buildReplyCommentFromResponse
 } from './innertube/comments';
 export { getTranscriptVideo, getTranscriptTracks } from './innertube/transcript';
 export { buildSapSidAuthorizationHeader } from './innertube/authHeaders';

--- a/app/src/source/utils/innertube/comments.ts
+++ b/app/src/source/utils/innertube/comments.ts
@@ -137,4 +137,10 @@ async function getAllCommentsModeV2(
     return comments;
 }
 
-export { getAllCommentsModeV2, extractNextContinuation, applyFrameworkUpdatesToComment, generateCommentObjectFromFW, buildReplyCommentFromResponse };
+export {
+    getAllCommentsModeV2,
+    extractNextContinuation,
+    applyFrameworkUpdatesToComment,
+    generateCommentObjectFromFW,
+    buildReplyCommentFromResponse
+};

--- a/app/src/source/utils/innertube/comments.ts
+++ b/app/src/source/utils/innertube/comments.ts
@@ -13,6 +13,7 @@ import {
     generateCommentObjectFromFW,
     processParentComment,
     scheduleReplyFetches,
+    buildReplyCommentFromResponse,
     type CommentBatchResult,
     type ReplyContinuation
 } from './comments/pipeline';
@@ -136,4 +137,4 @@ async function getAllCommentsModeV2(
     return comments;
 }
 
-export { getAllCommentsModeV2, extractNextContinuation, applyFrameworkUpdatesToComment, generateCommentObjectFromFW };
+export { getAllCommentsModeV2, extractNextContinuation, applyFrameworkUpdatesToComment, generateCommentObjectFromFW, buildReplyCommentFromResponse };

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -225,6 +225,10 @@ export function getFrameworkUpdatesById(response: any): Record<string, any> {
                 if (toolbar && toolbar.key) {
                     map[toolbar.key] = toolbar;
                 }
+                const toolbarSurface = wrapTryCatch(() => payload.engagementToolbarSurfaceEntityPayload);
+                if (toolbarSurface && toolbarSurface.key) {
+                    map[toolbarSurface.key] = toolbarSurface;
+                }
             } catch (e) {
                 console.error(e);
                 continue;
@@ -328,9 +332,10 @@ export function generateCommentObjectFromFW(params: {
     update: any;
     surfaceUpdate?: any;
     toolbarStateUpdate?: any;
+    toolbarSurfaceUpdate?: any;
 }): any {
     try {
-        const { commentId, update, surfaceUpdate, toolbarStateUpdate } = params;
+        const { commentId, update, surfaceUpdate, toolbarStateUpdate, toolbarSurfaceUpdate } = params;
         if (!update) return undefined;
 
         const propContent = wrapTryCatch(() => update.properties.content) || {};
@@ -525,11 +530,14 @@ export function generateCommentObjectFromFW(params: {
             if (engagementToolbar) {
                 comment.commentRenderer.engagementToolbar = engagementToolbar;
             }
+        }
 
+        if (toolbarSurfaceUpdate) {
             const fwCreateReplyParams = wrapTryCatch(
                 () =>
-                    engagementToolbar?.replyButton?.buttonRenderer?.serviceEndpoint?.createCommentReplyCommand
-                        ?.createReplyParams
+                    toolbarSurfaceUpdate.replyCommand?.innertubeCommand?.createCommentReplyDialogEndpoint?.dialog
+                        ?.commentReplyDialogRenderer?.replyButton?.buttonRenderer?.serviceEndpoint
+                        ?.createCommentReplyEndpoint?.createReplyParams
             );
             if (fwCreateReplyParams) {
                 comment.commentRenderer.createReplyParams = fwCreateReplyParams;
@@ -587,11 +595,13 @@ export function migrateContinuationItemsWithFW(
                         const update = frameworkUpdatesById[commentId];
                         const surfaceUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.commentSurfaceKey)];
                         const toolbarStateUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.toolbarStateKey)];
+                        const toolbarSurfaceUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.toolbarSurfaceKey)];
                         const comment = generateCommentObjectFromFW({
                             commentId,
                             update,
                             surfaceUpdate,
-                            toolbarStateUpdate
+                            toolbarStateUpdate,
+                            toolbarSurfaceUpdate
                         });
                         if (comment) {
                             const newItem = { ...item };
@@ -624,7 +634,13 @@ export function migrateContinuationItemsWithFW(
                         const commentId = wrapTryCatch(() => vm.commentId);
                         const update = frameworkUpdatesById[commentId];
                         const surfaceUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.commentSurfaceKey)];
-                        const comment = generateCommentObjectFromFW({ commentId, update, surfaceUpdate });
+                        const toolbarSurfaceUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.toolbarSurfaceKey)];
+                        const comment = generateCommentObjectFromFW({
+                            commentId,
+                            update,
+                            surfaceUpdate,
+                            toolbarSurfaceUpdate
+                        });
                         if (comment) {
                             const newItem = { ...item };
                             newItem.commentRenderer = comment.commentRenderer;
@@ -766,11 +782,14 @@ export function extractSubThreads(
                     const surfaceUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.commentSurfaceKey)];
                     const toolbarStateUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.toolbarStateKey)];
 
+                    const toolbarSurfaceUpdate = frameworkUpdatesById[wrapTryCatch(() => vm.toolbarSurfaceKey)];
+
                     const comment = generateCommentObjectFromFW({
                         commentId,
                         update,
                         surfaceUpdate,
-                        toolbarStateUpdate
+                        toolbarStateUpdate,
+                        toolbarSurfaceUpdate
                     });
 
                     if (comment) {
@@ -961,7 +980,7 @@ export function prepareFieldsComment(cmnt: any): object {
             () =>
                 cmnt.commentRenderer.actionButtons.commentActionButtonsRenderer.replyButton.buttonRenderer
                     .navigationEndpoint.createCommentReplyDialogEndpoint.dialog.commentReplyDialogRenderer.replyButton
-                    .buttonRenderer.serviceEndpoint.createCommentReplyCommand.createReplyParams
+                    .buttonRenderer.serviceEndpoint.createCommentReplyEndpoint.createReplyParams
         );
 
         // Extract verified status from authorCommentBadge before deletion (legacy format fallback)

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -525,6 +525,15 @@ export function generateCommentObjectFromFW(params: {
             if (engagementToolbar) {
                 comment.commentRenderer.engagementToolbar = engagementToolbar;
             }
+
+            const fwCreateReplyParams = wrapTryCatch(
+                () =>
+                    engagementToolbar?.replyButton?.buttonRenderer?.serviceEndpoint?.createCommentReplyCommand
+                        ?.createReplyParams
+            );
+            if (fwCreateReplyParams) {
+                comment.commentRenderer.createReplyParams = fwCreateReplyParams;
+            }
         }
 
         if (toolbarStateUpdate && wrapTryCatch(() => toolbarStateUpdate.heartState) === 'TOOLBAR_HEART_STATE_HEARTED') {
@@ -948,6 +957,13 @@ export function prepareFieldsComment(cmnt: any): object {
             }
         }
 
+        const preservedCreateReplyParams = wrapTryCatch(
+            () =>
+                cmnt.commentRenderer.actionButtons.commentActionButtonsRenderer.replyButton.buttonRenderer
+                    .navigationEndpoint.createCommentReplyDialogEndpoint.dialog.commentReplyDialogRenderer.replyButton
+                    .buttonRenderer.serviceEndpoint.createCommentReplyCommand.createReplyParams
+        );
+
         // Extract verified status from authorCommentBadge before deletion (legacy format fallback)
         if (
             wrapTryCatch(() => {
@@ -983,6 +999,10 @@ export function prepareFieldsComment(cmnt: any): object {
         wrapTryCatch(() => delete cmnt.commentRenderer.isLiked);
 
         wrapTryCatch(() => delete cmnt.commentRenderer.analyticsTrackingParams);
+
+        if (preservedCreateReplyParams) {
+            cmnt.commentRenderer.createReplyParams = preservedCreateReplyParams;
+        }
 
         wrapTryCatch(() => delete cmnt.commentRenderer.authorText.accessibility);
 

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -2295,10 +2295,44 @@ export async function fetchRepliesBatch(params: FetchRepliesParams): Promise<Com
     }
 }
 
-export function buildReplyCommentFromResponse(_params: {
+export function buildReplyCommentFromResponse(params: {
     response: any;
     originComment: any;
     currentVideoId: string;
 }): any | undefined {
-    return undefined;
+    try {
+        const { response, originComment, currentVideoId } = params;
+
+        const replyAction = response?.actions?.find((a: any) => a.createCommentReplyAction)?.createCommentReplyAction;
+        if (!replyAction) return undefined;
+
+        const vm = replyAction.contents?.commentThreadRenderer?.commentViewModel?.commentViewModel;
+        if (!vm?.commentId) return undefined;
+
+        const fwById = getFrameworkUpdatesById(response);
+        const commentId = vm.commentId;
+        const update = fwById[commentId] || fwById[vm.commentKey];
+        if (!update) return undefined;
+
+        const comment = generateCommentObjectFromFW({
+            commentId,
+            update,
+            surfaceUpdate: vm.commentSurfaceKey ? fwById[vm.commentSurfaceKey] : undefined,
+            toolbarStateUpdate: vm.toolbarStateKey ? fwById[vm.toolbarStateKey] : undefined,
+            toolbarSurfaceUpdate: vm.toolbarSurfaceKey ? fwById[vm.toolbarSurfaceKey] : undefined
+        });
+        if (!comment) return undefined;
+
+        const enriched = enrichCommentRenderer(comment, currentVideoId, originComment, 'R');
+        if (!enriched) return undefined;
+
+        if (typeof enriched.replyLevel !== 'number') {
+            enriched.replyLevel = (originComment?.replyLevel ?? 0) + 1;
+        }
+
+        return enriched;
+    } catch (e) {
+        console.error('[YCS] buildReplyCommentFromResponse error:', e);
+        return undefined;
+    }
 }

--- a/app/src/source/utils/innertube/comments/pipeline.ts
+++ b/app/src/source/utils/innertube/comments/pipeline.ts
@@ -2294,3 +2294,11 @@ export async function fetchRepliesBatch(params: FetchRepliesParams): Promise<Com
         return undefined;
     }
 }
+
+export function buildReplyCommentFromResponse(_params: {
+    response: any;
+    originComment: any;
+    currentVideoId: string;
+}): any | undefined {
+    return undefined;
+}

--- a/app/src/source/utils/innertube/memberOnly.ts
+++ b/app/src/source/utils/innertube/memberOnly.ts
@@ -391,6 +391,8 @@ export function updateAccessRestrictionStatus(ytData: any): AccessRestrictionSta
  * @returns true if auth should be disabled, false if auth should be sent
  */
 export function shouldDisableAuth(): boolean {
+    if ((GlobalStore as any).enableInlineReply === true) return false;
+
     const memberOnly = (GlobalStore as any).isMemberOnly;
     const ageRestricted = (GlobalStore as any).isAgeRestricted;
 

--- a/app/src/source/utils/innertube/reply.ts
+++ b/app/src/source/utils/innertube/reply.ts
@@ -1,0 +1,90 @@
+import { buildInnertubeHeaders, buildInnertubeBody } from './request';
+import { getPageCfgData, getInnertubeApiKey } from './core';
+
+const RATE_LIMIT_INTERVAL_MS = 30_000;
+let lastReplyTimestamp = 0;
+
+export interface ReplyResult {
+    success: boolean;
+    error?: string;
+    rateLimited?: boolean;
+}
+
+export function canSendReply(): { allowed: boolean; waitMs: number } {
+    const now = Date.now();
+    const elapsed = now - lastReplyTimestamp;
+    if (elapsed < RATE_LIMIT_INTERVAL_MS) {
+        return { allowed: false, waitMs: RATE_LIMIT_INTERVAL_MS - elapsed };
+    }
+    return { allowed: true, waitMs: 0 };
+}
+
+export async function sendCommentReply(params: {
+    createReplyParams: string;
+    commentText: string;
+    globalContext: Window & typeof globalThis;
+    signal?: AbortSignal;
+}): Promise<ReplyResult> {
+    const { createReplyParams, commentText, globalContext, signal } = params;
+
+    const rateCheck = canSendReply();
+    if (!rateCheck.allowed) {
+        return {
+            success: false,
+            error: `Please wait ${Math.ceil(rateCheck.waitMs / 1000)}s`,
+            rateLimited: true
+        };
+    }
+
+    lastReplyTimestamp = Date.now();
+
+    try {
+        const ytcfgData = await getPageCfgData(globalContext, signal);
+        const apiKey = getInnertubeApiKey(globalContext);
+
+        const headers = buildInnertubeHeaders(ytcfgData, {}, globalContext, { disableAuth: false });
+        const body = buildInnertubeBody({
+            ytcfgData,
+            extra: { commentText, createReplyParams }
+        });
+
+        const url = `https://www.youtube.com/youtubei/v1/comment/create_comment_reply?prettyPrint=false${apiKey ? `&key=${apiKey}` : ''}`;
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+            credentials: 'include',
+            mode: 'cors',
+            signal
+        });
+
+        if (!response.ok) {
+            if (response.status === 401 || response.status === 403) {
+                return { success: false, error: 'Authentication failed. Please sign in to YouTube.' };
+            }
+            if (response.status === 429) {
+                return { success: false, error: 'Rate limited by YouTube. Please wait.', rateLimited: true };
+            }
+            if (response.status === 400) {
+                return { success: false, error: 'Reply params expired. Please reload comments.' };
+            }
+            return { success: false, error: `Request failed (${response.status})` };
+        }
+
+        const data = await response.json();
+        const status = data?.actionResult?.status;
+
+        if (status === 'STATUS_SUCCEEDED') {
+            return { success: true };
+        }
+
+        return { success: false, error: `Unexpected status: ${status || 'unknown'}` };
+    } catch (e) {
+        if ((e as Error).name === 'AbortError') {
+            return { success: false, error: 'Request cancelled' };
+        }
+        console.error('[YCS] Reply error:', e);
+        return { success: false, error: 'Network error' };
+    }
+}

--- a/app/src/source/utils/innertube/reply.ts
+++ b/app/src/source/utils/innertube/reply.ts
@@ -8,6 +8,7 @@ export interface ReplyResult {
     success: boolean;
     error?: string;
     rateLimited?: boolean;
+    responseData?: any;
 }
 
 export function canSendReply(): { allowed: boolean; waitMs: number } {
@@ -76,7 +77,7 @@ export async function sendCommentReply(params: {
         const status = data?.actionResult?.status;
 
         if (status === 'STATUS_SUCCEEDED') {
-            return { success: true };
+            return { success: true, responseData: data };
         }
 
         return { success: false, error: `Unexpected status: ${status || 'unknown'}` };

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -82,6 +82,7 @@ export interface CommentRenderer extends Record<string, unknown> {
         };
     };
     verifiedAuthor?: boolean;
+    createReplyParams?: string;
     voteCount?: {
         simpleText?: string;
     };

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -338,6 +338,7 @@ export interface IYCSOptions {
     youtubeApiKey?: string; // Empty = use Innertube; Filled = use YouTube Data API (storage only)
     hasYoutubeApiKey?: boolean; // Flag exposed to web page (API key never exposed)
     youtubeApiEnabled?: boolean; // Enable YouTube Data API (default: true, requires API key)
+    enableInlineReply?: boolean;
 }
 
 // =============================================================================

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -355,6 +355,18 @@ function createCommentElement(model: CommentViewModel, index: number): HTMLEleme
     content.innerHTML = model.contentHtml;
 
     block.append(header, content);
+
+    if (model.createReplyParams && !model.isReplyType) {
+        const replyBtn = document.createElement('button');
+        replyBtn.className = 'ycs-reply-btn';
+        replyBtn.textContent = 'Reply';
+        replyBtn.dataset.createReplyParams = model.createReplyParams;
+        if (model.commentId) {
+            replyBtn.dataset.commentId = model.commentId;
+        }
+        block.appendChild(replyBtn);
+    }
+
     container.append(left, block);
 
     return container;

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -356,7 +356,7 @@ function createCommentElement(model: CommentViewModel, index: number): HTMLEleme
 
     block.append(header, content);
 
-    if (model.createReplyParams && !model.isReplyType) {
+    if (model.createReplyParams) {
         const replyBtn = document.createElement('button');
         replyBtn.className = 'ycs-reply-btn';
         replyBtn.textContent = 'Reply';

--- a/app/src/source/utils/viewModels.ts
+++ b/app/src/source/utils/viewModels.ts
@@ -37,6 +37,7 @@ export interface CommentViewModel {
     replyLevel?: number;
     hideExpandUp?: boolean;
     forceSmallAvatar?: boolean;
+    createReplyParams?: string;
 }
 
 export interface ChatMessageViewModel {
@@ -359,7 +360,8 @@ export function buildCommentViewModels(
             contentHtml: renderFullText ? renderFullText : encode(fallbackText),
             replyLevel,
             hideExpandUp,
-            forceSmallAvatar
+            forceSmallAvatar,
+            createReplyParams: coerceString(wrapTryCatch(() => renderer.createReplyParams)) || undefined
         });
     }
 

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1945,7 +1945,7 @@ export function initApp(): void {
                 }
                 if (!originComment) return;
 
-                const currentVideoId = getVideoId(window.location.href) || '';
+                const currentVideoId = getVideoId(window.location.href) ?? getPostId(window.location.href) ?? '';
                 const newReply = buildReplyCommentFromResponse({
                     response: responseData,
                     originComment,
@@ -1956,9 +1956,6 @@ export function initApp(): void {
                 const newCommentId = newReply?.commentRenderer?.commentId;
                 if (newCommentId && comments.some((c) => c.commentRenderer?.commentId === newCommentId)) return;
 
-                newReply._index = comments.length;
-                state = setComments(state, [...comments, newReply]);
-
                 if (originComment?.commentRenderer) {
                     originComment.commentRenderer.replyCount =
                         (typeof originComment.commentRenderer.replyCount === 'number'
@@ -1966,9 +1963,14 @@ export function initApp(): void {
                             : 0) + 1;
                 }
 
+                newReply._index = comments.length;
+                state = setComments(state, [...comments, newReply]);
+                state = setCount(state, 'comments', getComments(state).length);
+                updateBadge('NUMBER_COMMENTS', getComments(state).length);
+
                 saveToCache(
                     {
-                        videoId: getVideoId(window.location.href) ?? getPostId(window.location.href),
+                        videoId: currentVideoId || undefined,
                         comments: getComments(state),
                         commentsChat: JSON.stringify(Array.from(getCommentsChat(state).entries())),
                         commentsTrVideo: getCommentsTrVideo(state),

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1718,6 +1718,9 @@ export function initApp(): void {
                     if (typeof opts.youtubeApiEnabled !== 'undefined') {
                         GlobalStore.youtubeApiEnabled = Boolean(opts.youtubeApiEnabled);
                     }
+                    if (typeof opts.enableInlineReply !== 'undefined') {
+                        GlobalStore.enableInlineReply = Boolean(opts.enableInlineReply);
+                    }
                     if (typeof opts.transcriptLanguage !== 'undefined') {
                         state = setSelectedTranscriptLanguage(
                             state,

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -22,7 +22,8 @@ import {
     getAllCommentsModeV2,
     getChatComments,
     clearCurrentVideoMemberOnly,
-    clearCurrentVideoAgeRestricted
+    clearCurrentVideoAgeRestricted,
+    buildReplyCommentFromResponse
 } from '../utils/innertube';
 
 import { IParamSearch, ISelectedSearch, IYCSOptions } from '../utils/interfaces/i_types';
@@ -1916,6 +1917,69 @@ export function initApp(): void {
         };
 
         window.addEventListener('message', handleMessageEvent);
+
+        document.addEventListener('ycs-reply-success', ((event: CustomEvent) => {
+            try {
+                const { responseData } = event.detail;
+                if (!responseData) return;
+
+                const comments = getComments(state);
+                if (comments.length === 0) return;
+
+                const replyAction = responseData.actions?.find(
+                    (a: any) => a.createCommentReplyAction
+                )?.createCommentReplyAction;
+                if (!replyAction) return;
+
+                const replyToId = replyAction.replyToCommentId;
+                const parentId = replyAction.parentCommentId;
+
+                let originComment: CommentItem | undefined;
+                for (const c of comments) {
+                    const cId = c.commentRenderer?.commentId;
+                    if (cId === replyToId) {
+                        originComment = c;
+                        break;
+                    }
+                    if (cId === parentId && !originComment) originComment = c;
+                }
+                if (!originComment) return;
+
+                const currentVideoId = getVideoId(window.location.href) || '';
+                const newReply = buildReplyCommentFromResponse({
+                    response: responseData,
+                    originComment,
+                    currentVideoId
+                });
+                if (!newReply) return;
+
+                const newCommentId = newReply?.commentRenderer?.commentId;
+                if (newCommentId && comments.some((c) => c.commentRenderer?.commentId === newCommentId)) return;
+
+                newReply._index = comments.length;
+                state = setComments(state, [...comments, newReply]);
+
+                if (originComment?.commentRenderer) {
+                    originComment.commentRenderer.replyCount =
+                        (typeof originComment.commentRenderer.replyCount === 'number'
+                            ? originComment.commentRenderer.replyCount
+                            : 0) + 1;
+                }
+
+                saveToCache(
+                    {
+                        videoId: getVideoId(window.location.href) ?? getPostId(window.location.href),
+                        comments: getComments(state),
+                        commentsChat: JSON.stringify(Array.from(getCommentsChat(state).entries())),
+                        commentsTrVideo: getCommentsTrVideo(state),
+                        channelId: extractChannelId()
+                    },
+                    buildCacheMeta()
+                );
+            } catch (err) {
+                console.error('[YCS] Reply state injection error:', err);
+            }
+        }) as EventListener);
 
         initShowBarFAQ();
         initShowViewMode();

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1958,9 +1958,15 @@ export function initApp(): void {
 
                 if (originComment?.commentRenderer) {
                     originComment.commentRenderer.replyCount =
-                        (typeof originComment.commentRenderer.replyCount === 'number'
-                            ? originComment.commentRenderer.replyCount
-                            : 0) + 1;
+                        (Number(originComment.commentRenderer.replyCount) || 0) + 1;
+                }
+
+                if (replyToId !== parentId) {
+                    const threadRoot = comments.find((c) => c.commentRenderer?.commentId === parentId);
+                    if (threadRoot?.commentRenderer && threadRoot !== originComment) {
+                        threadRoot.commentRenderer.replyCount =
+                            (Number(threadRoot.commentRenderer.replyCount) || 0) + 1;
+                    }
                 }
 
                 newReply._index = comments.length;

--- a/app/src/source/web-resources/services/cacheService.ts
+++ b/app/src/source/web-resources/services/cacheService.ts
@@ -22,10 +22,29 @@ export function loadFromCache(url: string): void {
     sendGetCacheInIDB(url);
 }
 
+function stripCommentToken(item: any): any {
+    if (!item?.commentRenderer?.createReplyParams) return item;
+    const { createReplyParams: _, ...rest } = item.commentRenderer;
+    return { ...item, commentRenderer: rest };
+}
+
+function stripOriginChain(item: any): any {
+    let result = stripCommentToken(item);
+    if (result.originComment) {
+        result = { ...result, originComment: stripOriginChain(result.originComment) };
+    }
+    return result;
+}
+
+export function stripReplyTokens(comments: CommentItem[]): CommentItem[] {
+    return comments.map((c) => stripOriginChain(c) as CommentItem);
+}
+
 export function saveToCache(data: CacheData, meta: CacheMeta): void {
     if (!meta?.url || !meta?.title) return;
 
-    setCacheToIDB(data, meta.url, meta.title);
+    const sanitized = { ...data, comments: stripReplyTokens(data.comments) };
+    setCacheToIDB(sanitized, meta.url, meta.title);
 }
 
 export function updateBadge(type: string, value: string | number): void {

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -75,6 +75,12 @@ export function registerCommentInteractions(
         const openReplyBtn = target.closest('.ycs-open-reply') as HTMLElement | null;
         if (openReplyBtn) {
             handleOpenReply(openReplyBtn, stateAccessor, queryGetter);
+            return;
+        }
+
+        const replyBtn = target.closest('.ycs-reply-btn') as HTMLElement | null;
+        if (replyBtn) {
+            handleReplyClick(replyBtn);
         }
     });
 }
@@ -518,4 +524,115 @@ function handleOpenReply(target: HTMLElement, stateAccessor: CommentStateAccesso
 
     target.innerHTML = String.fromCharCode(8722);
     target.title = 'Close replies to the comment';
+}
+
+function handleReplyClick(target: HTMLElement): void {
+    const commentContainer = target.closest('.ycs-render-comment') as HTMLElement | null;
+    if (!commentContainer) return;
+
+    const createReplyParams = target.dataset.createReplyParams;
+    if (!createReplyParams) return;
+
+    const block = commentContainer.querySelector('.ycs-comment-block') as HTMLElement | null;
+    if (!block) return;
+
+    const existing = block.querySelector('.ycs-reply-form') as HTMLElement | null;
+    if (existing) {
+        if (existing.dataset.sending === 'true') return;
+        existing.remove();
+        return;
+    }
+
+    const form = document.createElement('div');
+    form.className = 'ycs-reply-form';
+
+    const textarea = document.createElement('textarea');
+    textarea.className = 'ycs-reply-textarea';
+    textarea.placeholder = 'Add a reply...';
+    textarea.rows = 3;
+
+    const actions = document.createElement('div');
+    actions.className = 'ycs-reply-actions';
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.className = 'ycs-reply-cancel';
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.type = 'button';
+
+    const sendBtn = document.createElement('button');
+    sendBtn.className = 'ycs-reply-send';
+    sendBtn.textContent = 'Reply';
+    sendBtn.type = 'button';
+    sendBtn.disabled = true;
+
+    const status = document.createElement('div');
+    status.className = 'ycs-reply-status';
+
+    textarea.addEventListener('input', () => {
+        sendBtn.disabled = textarea.value.trim().length === 0;
+    });
+
+    cancelBtn.addEventListener('click', () => {
+        form.remove();
+    });
+
+    sendBtn.addEventListener('click', async () => {
+        const text = textarea.value.trim();
+        if (!text) return;
+
+        sendBtn.disabled = true;
+        textarea.disabled = true;
+        cancelBtn.disabled = true;
+        form.dataset.sending = 'true';
+        status.textContent = 'Sending...';
+        status.className = 'ycs-reply-status';
+
+        try {
+            const { sendCommentReply, canSendReply } = await import('../../utils/innertube/reply');
+
+            const rateCheck = canSendReply();
+            if (!rateCheck.allowed) {
+                status.textContent = `Please wait ${Math.ceil(rateCheck.waitMs / 1000)}s`;
+                status.className = 'ycs-reply-status ycs-reply-error';
+                sendBtn.disabled = false;
+                textarea.disabled = false;
+                cancelBtn.disabled = false;
+                return;
+            }
+
+            const result = await sendCommentReply({
+                createReplyParams,
+                commentText: text,
+                globalContext: window
+            });
+
+            if (result.success) {
+                status.textContent = 'Reply sent!';
+                status.className = 'ycs-reply-status ycs-reply-success';
+                textarea.value = '';
+                sendBtn.disabled = true;
+                setTimeout(() => form.remove(), 2000);
+            } else {
+                status.textContent = result.error || 'Failed to send reply';
+                status.className = 'ycs-reply-status ycs-reply-error';
+                textarea.disabled = false;
+                cancelBtn.disabled = false;
+                sendBtn.disabled = textarea.value.trim().length === 0;
+            }
+        } catch (e) {
+            console.error('[YCS] Reply form error:', e);
+            status.textContent = 'Unexpected error';
+            status.className = 'ycs-reply-status ycs-reply-error';
+            textarea.disabled = false;
+            cancelBtn.disabled = false;
+            sendBtn.disabled = textarea.value.trim().length === 0;
+        } finally {
+            form.dataset.sending = '';
+        }
+    });
+
+    actions.append(cancelBtn, sendBtn);
+    form.append(textarea, actions, status);
+    block.appendChild(form);
+    textarea.focus();
 }

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -696,14 +696,6 @@ function handleReplyClick(target: HTMLElement): void {
             });
 
             if (result.success) {
-                if (result.responseData) {
-                    document.dispatchEvent(
-                        new CustomEvent('ycs-reply-success', {
-                            detail: { responseData: result.responseData }
-                        })
-                    );
-                }
-
                 const parentId = target.dataset.commentId;
                 const safeId = parentId ? safeDomKey(parentId) : undefined;
                 const syntheticEl = createSyntheticReplyElement(text);
@@ -718,6 +710,14 @@ function handleReplyClick(target: HTMLElement): void {
                     commentContainer.appendChild(repliesContainer);
                 }
                 repliesContainer.appendChild(syntheticEl);
+
+                if (result.responseData) {
+                    document.dispatchEvent(
+                        new CustomEvent('ycs-reply-success', {
+                            detail: { responseData: result.responseData }
+                        })
+                    );
+                }
 
                 status.textContent = 'Reply sent!';
                 status.className = 'ycs-reply-status ycs-reply-success';

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -500,6 +500,9 @@ function handleOpenReply(target: HTMLElement, stateAccessor: CommentStateAccesso
         return;
     }
 
+    const syntheticWrap = commentContainer.querySelector('.ycs-synthetic-replies-wrap');
+    if (syntheticWrap) syntheticWrap.remove();
+
     const comments = safeGetComments(stateAccessor);
     const replies = collectRepliesForComment(comments, commentId, 0);
     if (replies.length === 0) {
@@ -524,6 +527,61 @@ function handleOpenReply(target: HTMLElement, stateAccessor: CommentStateAccesso
 
     target.innerHTML = String.fromCharCode(8722);
     target.title = 'Close replies to the comment';
+}
+
+function getLoggedInUserAvatar(): string {
+    const img = document.querySelector('#avatar-btn img') as HTMLImageElement | null;
+    return img?.src || '';
+}
+
+function createSyntheticReplyElement(text: string): HTMLElement {
+    const container = document.createElement('div');
+    container.className = 'ycs-render-comment ycs-synthetic-reply ycs-reply-fade-in';
+    container.style.marginLeft = '56px';
+
+    const left = document.createElement('div');
+    left.className = 'ycs-left';
+
+    const avatarWrapper = document.createElement('div');
+    avatarWrapper.className = 'ycs-render-img ycs-render-img--nested';
+
+    const avatar = document.createElement('img');
+    avatar.className = 'avatar';
+    avatar.alt = 'You';
+    avatar.height = 32;
+    avatar.width = 32;
+    avatar.src = getLoggedInUserAvatar();
+
+    avatarWrapper.appendChild(avatar);
+    left.appendChild(avatarWrapper);
+
+    const block = document.createElement('div');
+    block.className = 'ycs-comment-block ycs-comment-block--nested';
+
+    const header = document.createElement('div');
+    header.className = 'ycs-head-block__dib ycs-head-block ycs-head__title-main';
+
+    const titleSpan = document.createElement('span');
+    titleSpan.className = 'ycs-head__title';
+    titleSpan.textContent = 'You';
+    header.appendChild(titleSpan);
+
+    const meta = document.createElement('div');
+    meta.className = 'ycs-head-block__dib ycs-head-block__lh ycs-time-size';
+
+    const time = document.createElement('span');
+    time.textContent = 'Just now';
+    meta.appendChild(time);
+    header.appendChild(meta);
+
+    const content = document.createElement('div');
+    content.className = 'ycs-comment__main-text';
+    content.textContent = text;
+
+    block.append(header, content);
+    container.append(left, block);
+
+    return container;
 }
 
 function handleReplyClick(target: HTMLElement): void {
@@ -568,8 +626,12 @@ function handleReplyClick(target: HTMLElement): void {
     const status = document.createElement('div');
     status.className = 'ycs-reply-status';
 
+    let countdownActive = false;
+
     textarea.addEventListener('input', () => {
-        sendBtn.disabled = textarea.value.trim().length === 0;
+        if (!countdownActive) {
+            sendBtn.disabled = textarea.value.trim().length === 0;
+        }
     });
 
     cancelBtn.addEventListener('click', () => {
@@ -585,18 +647,45 @@ function handleReplyClick(target: HTMLElement): void {
         cancelBtn.disabled = true;
         form.dataset.sending = 'true';
         status.textContent = 'Sending...';
-        status.className = 'ycs-reply-status';
+        status.className = 'ycs-reply-status ycs-reply-sending';
 
         try {
             const { sendCommentReply, canSendReply } = await import('../../utils/innertube/reply');
 
             const rateCheck = canSendReply();
             if (!rateCheck.allowed) {
-                status.textContent = `Please wait ${Math.ceil(rateCheck.waitMs / 1000)}s`;
-                status.className = 'ycs-reply-status ycs-reply-error';
-                sendBtn.disabled = false;
+                let remaining = Math.ceil(rateCheck.waitMs / 1000);
+                status.textContent = `Please wait ${remaining}s`;
+                status.className = 'ycs-reply-status ycs-reply-countdown';
+                countdownActive = true;
+                sendBtn.disabled = true;
                 textarea.disabled = false;
                 cancelBtn.disabled = false;
+                form.dataset.sending = '';
+
+                const observer = new MutationObserver(() => {
+                    if (!form.isConnected) {
+                        clearInterval(countdownId);
+                        observer.disconnect();
+                    }
+                });
+
+                const countdownId = setInterval(() => {
+                    remaining -= 1;
+                    if (remaining <= 0) {
+                        clearInterval(countdownId);
+                        observer.disconnect();
+                        countdownActive = false;
+                        status.textContent = '';
+                        status.className = 'ycs-reply-status';
+                        sendBtn.disabled = textarea.value.trim().length === 0;
+                    } else {
+                        status.textContent = `Please wait ${remaining}s`;
+                    }
+                }, 1000);
+
+                observer.observe(form.parentElement || document.body, { childList: true });
+
                 return;
             }
 
@@ -607,13 +696,32 @@ function handleReplyClick(target: HTMLElement): void {
             });
 
             if (result.success) {
+                const parentId = target.dataset.commentId;
+                const safeId = parentId ? safeDomKey(parentId) : undefined;
+                const syntheticEl = createSyntheticReplyElement(text);
+
+                let repliesContainer = safeId ? commentContainer.querySelector(`.ycs-com-replies-${safeId}`) : null;
+                if (!repliesContainer) {
+                    repliesContainer = commentContainer.querySelector('.ycs-synthetic-replies-wrap');
+                }
+                if (!repliesContainer) {
+                    repliesContainer = document.createElement('div');
+                    repliesContainer.className = 'ycs-synthetic-replies-wrap';
+                    commentContainer.appendChild(repliesContainer);
+                }
+                repliesContainer.appendChild(syntheticEl);
+
                 status.textContent = 'Reply sent!';
                 status.className = 'ycs-reply-status ycs-reply-success';
                 textarea.value = '';
                 sendBtn.disabled = true;
-                setTimeout(() => form.remove(), 2000);
+                setTimeout(() => form.remove(), 1500);
             } else {
-                status.textContent = result.error || 'Failed to send reply';
+                if (result.error?.includes('expired')) {
+                    status.textContent = 'Token expired \u2014 please reload comments and retry';
+                } else {
+                    status.textContent = result.error || 'Failed to send reply';
+                }
                 status.className = 'ycs-reply-status ycs-reply-error';
                 textarea.disabled = false;
                 cancelBtn.disabled = false;

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -696,6 +696,14 @@ function handleReplyClick(target: HTMLElement): void {
             });
 
             if (result.success) {
+                if (result.responseData) {
+                    document.dispatchEvent(
+                        new CustomEvent('ycs-reply-success', {
+                            detail: { responseData: result.responseData }
+                        })
+                    );
+                }
+
                 const parentId = target.dataset.commentId;
                 const safeId = parentId ? safeDomKey(parentId) : undefined;
                 const syntheticEl = createSyntheticReplyElement(text);

--- a/app/tests/cacheService.test.ts
+++ b/app/tests/cacheService.test.ts
@@ -1,0 +1,98 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+
+import { stripReplyTokens } from '../src/source/web-resources/services/cacheService';
+
+function makeComment(overrides: Record<string, any> = {}): any {
+    return {
+        typeComment: 'C',
+        commentRenderer: {
+            commentId: 'comment-1',
+            authorText: { simpleText: 'User' },
+            contentText: { runs: [{ text: 'Hello' }] },
+            ...overrides
+        }
+    };
+}
+
+function makeReply(originComment: any, overrides: Record<string, any> = {}): any {
+    return {
+        typeComment: 'R',
+        originComment,
+        commentRenderer: {
+            commentId: 'reply-1',
+            authorText: { simpleText: 'Replier' },
+            contentText: { runs: [{ text: 'Reply' }] },
+            ...overrides
+        }
+    };
+}
+
+test('stripReplyTokens removes top-level createReplyParams', () => {
+    const comments = [makeComment({ createReplyParams: 'token-abc' })];
+    const result = stripReplyTokens(comments);
+
+    assert.equal(result[0].commentRenderer.createReplyParams, undefined);
+    assert.equal(result[0].commentRenderer.commentId, 'comment-1');
+    assert.equal(result[0].commentRenderer.authorText.simpleText, 'User');
+});
+
+test('stripReplyTokens removes token from originComment (depth 1)', () => {
+    const parent = makeComment({ createReplyParams: 'parent-token' });
+    const reply = makeReply(parent, { createReplyParams: 'reply-token' });
+    const result = stripReplyTokens([parent, reply]);
+
+    assert.equal(result[0].commentRenderer.createReplyParams, undefined);
+    assert.equal(result[1].commentRenderer.createReplyParams, undefined);
+    assert.equal(result[1].originComment.commentRenderer.createReplyParams, undefined);
+    assert.equal(result[1].originComment.commentRenderer.commentId, 'comment-1');
+});
+
+test('stripReplyTokens removes token from nested originComment chain (depth 2+)', () => {
+    const grandparent = makeComment({ createReplyParams: 'gp-token' });
+    const parent = {
+        ...makeReply(grandparent, { createReplyParams: 'p-token' }),
+        commentRenderer: {
+            ...makeReply(grandparent).commentRenderer,
+            commentId: 'reply-mid',
+            createReplyParams: 'p-token'
+        }
+    };
+    const child = makeReply(parent, { createReplyParams: 'c-token' });
+    child.commentRenderer.commentId = 'reply-deep';
+
+    const result = stripReplyTokens([grandparent, parent, child]);
+
+    assert.equal(result[2].commentRenderer.createReplyParams, undefined);
+    assert.equal(result[2].originComment.commentRenderer.createReplyParams, undefined);
+    assert.equal(result[2].originComment.originComment.commentRenderer.createReplyParams, undefined);
+
+    assert.equal(result[2].originComment.commentRenderer.commentId, 'reply-mid');
+    assert.equal(result[2].originComment.originComment.commentRenderer.commentId, 'comment-1');
+});
+
+test('stripReplyTokens passes through comments without tokens unchanged', () => {
+    const plain = makeComment();
+    const comments = [plain];
+    const result = stripReplyTokens(comments);
+
+    assert.deepEqual(result[0], plain);
+});
+
+test('stripReplyTokens preserves all non-token fields', () => {
+    const comment = makeComment({
+        createReplyParams: 'token-xyz',
+        publishedTimeText: { runs: [{ text: '1 day ago' }] },
+        likeCount: 42,
+        replyCount: 5,
+        verifiedAuthor: true
+    });
+    const result = stripReplyTokens([comment]);
+
+    assert.equal(result[0].commentRenderer.createReplyParams, undefined);
+    assert.equal(result[0].commentRenderer.publishedTimeText.runs[0].text, '1 day ago');
+    assert.equal(result[0].commentRenderer.likeCount, 42);
+    assert.equal(result[0].commentRenderer.replyCount, 5);
+    assert.equal(result[0].commentRenderer.verifiedAuthor, true);
+    assert.equal(result[0].typeComment, 'C');
+});

--- a/app/tests/cacheService.test.ts
+++ b/app/tests/cacheService.test.ts
@@ -79,6 +79,10 @@ test('stripReplyTokens passes through comments without tokens unchanged', () => 
     assert.deepEqual(result[0], plain);
 });
 
+test('stripReplyTokens handles empty array', () => {
+    assert.deepEqual(stripReplyTokens([]), []);
+});
+
 test('stripReplyTokens preserves all non-token fields', () => {
     const comment = makeComment({
         createReplyParams: 'token-xyz',

--- a/app/tests/replyStateInjection.test.ts
+++ b/app/tests/replyStateInjection.test.ts
@@ -84,11 +84,10 @@ test('buildReplyCommentFromResponse extracts createReplyParams for chain replyin
     });
 
     assert.ok(result);
-    assert.ok(
+    assert.equal(
         result.commentRenderer.createReplyParams,
-        'should have createReplyParams for chain replying'
+        'Egtzc25BRUhHblFhdyIaVWd4eHZVeDhRUlVlenRULVhSMTRBYUFCQWcqAggAUAdyMVVneHh2VXg4UVJVZXp0VC1YUjE0QWFBQkFnLkFVUTV3emVUZ2lMQVVSdW12NlVtVWToAQDaAgDiAgQQABgA6AIB'
     );
-    assert.equal(typeof result.commentRenderer.createReplyParams, 'string');
 });
 
 test('buildReplyCommentFromResponse extracts content text', () => {

--- a/app/tests/replyStateInjection.test.ts
+++ b/app/tests/replyStateInjection.test.ts
@@ -1,0 +1,136 @@
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { buildReplyCommentFromResponse } from '../src/source/utils/innertube/comments/pipeline';
+
+const __filename_local = fileURLToPath(import.meta.url);
+const __dirname_local = dirname(__filename_local);
+const fixturePath = resolve(__dirname_local, '../../specs/020-inline-reply/reply_response.json');
+const replyResponse = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+function makeMockOriginComment(overrides: Record<string, any> = {}) {
+    return {
+        typeComment: 'C' as const,
+        replyLevel: 0,
+        commentRenderer: {
+            commentId: 'UgxxvUx8QRUeztT-XR14AaABAg',
+            authorText: { simpleText: 'OriginalAuthor' },
+            contentText: { runs: [{ text: 'Original comment' }] },
+            ...overrides
+        }
+    };
+}
+
+test('buildReplyCommentFromResponse returns a valid CommentItem from reply API response', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: replyResponse,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result, 'should return a non-undefined result');
+    assert.equal(
+        result.commentRenderer.commentId,
+        'UgxxvUx8QRUeztT-XR14AaABAg.AUQ5wzeTgiLAURumv6UmUd'
+    );
+});
+
+test('buildReplyCommentFromResponse sets typeComment to R', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: replyResponse,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result);
+    assert.equal(result.typeComment, 'R');
+});
+
+test('buildReplyCommentFromResponse sets originComment reference', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: replyResponse,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result);
+    assert.equal(result.originComment, origin);
+});
+
+test('buildReplyCommentFromResponse extracts replyLevel from FW data', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: replyResponse,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result);
+    assert.equal(result.replyLevel, 3);
+});
+
+test('buildReplyCommentFromResponse extracts createReplyParams for chain replying', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: replyResponse,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result);
+    assert.ok(
+        result.commentRenderer.createReplyParams,
+        'should have createReplyParams for chain replying'
+    );
+    assert.equal(typeof result.commentRenderer.createReplyParams, 'string');
+});
+
+test('buildReplyCommentFromResponse extracts content text', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: replyResponse,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result);
+    assert.equal(result.commentRenderer.contentText.fullText, 'test6');
+});
+
+test('buildReplyCommentFromResponse falls back replyLevel when FW has no value', () => {
+    const origin = makeMockOriginComment();
+    origin.replyLevel = 2;
+
+    const responseNoReplyLevel = JSON.parse(JSON.stringify(replyResponse));
+    for (const m of responseNoReplyLevel.frameworkUpdates.entityBatchUpdate.mutations) {
+        if (m.payload.commentEntityPayload?.properties) {
+            delete m.payload.commentEntityPayload.properties.replyLevel;
+        }
+    }
+
+    const result = buildReplyCommentFromResponse({
+        response: responseNoReplyLevel,
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.ok(result);
+    assert.equal(result.replyLevel, 3);
+});
+
+test('buildReplyCommentFromResponse returns undefined for malformed response', () => {
+    const origin = makeMockOriginComment();
+    const result = buildReplyCommentFromResponse({
+        response: { garbage: true },
+        originComment: origin,
+        currentVideoId: 'ssnAEHGnQaw'
+    });
+
+    assert.equal(result, undefined);
+});


### PR DESCRIPTION
## Summary

Issue #145 

Add inline reply functionality to YCS comments via Innertube `create_comment_reply` write API. Users can reply to any comment directly from YCS without opening YouTube's native comment section. This feature is opt-in through a new `enableInlineReply` setting and requires YouTube login. Successful replies are injected into state and cache in real time via an event-based pipeline.

## Main Changes

- **Innertube reply API integration**: new `reply.ts` module sends POST to `create_comment_reply` endpoint, with 30-second client-side rate limiting and per-status error handling (401/403/429/400)
- **FW pipeline enhancement**: `getFrameworkUpdatesById()` now indexes `engagementToolbarSurfaceEntityPayload` (4th mutation payload type), enabling `createReplyParams` token extraction from authenticated responses
- **`generateCommentObjectFromFW` extended**: accepts `toolbarSurfaceUpdate` parameter; all 3 call sites (parent comments, reply ViewModels, sub-threads) updated to pass it
- **Legacy format fallback**: `prepareFieldsComment()` also preserves `createReplyParams` from the classic `actionButtons` response path
- **Reply UI**: inline reply form per comment (textarea + Cancel/Reply buttons + status area), handled via delegated click in `commentInteractions.ts`; dynamic import of `reply.ts` for code splitting
- **Synthetic reply preview**: successful replies insert a DOM-only preview element (avatar + "You" + "Just now"); cleaned up when real replies are toggled or comments reloaded
- **Rate limit UX**: live countdown timer when cooldown is active; `MutationObserver` auto-cleans interval if form is removed
- **Opt-in setting**: `enableInlineReply` option in extension settings page with checkbox, description, and reload hint; forces authenticated comment loading (`shouldDisableAuth()` returns `false`)
- **Manifest update**: `reply.*.js` pattern added to `web_accessible_resources` resources for Parcel dynamic import chunks
- **CSS**: full dark mode support for reply form, buttons, status messages, synthetic reply elements, and countdown display
- **Reply state injection**: successful reply dispatches `ycs-reply-success` CustomEvent; `appController.ts` listener calls `buildReplyCommentFromResponse()` to convert reply API response into a `CommentItem` via existing FW pipeline, appends it to state, updates `replyCount` on the origin comment and thread root, refreshes badge count, and persists to cache
- **Cache token stripping**: `stripReplyTokens()` in `cacheService.ts` recursively removes `createReplyParams` from comments and `originComment` chains before writing to IndexedDB, preventing stale tokens from being restored on cache load
- **Tests**: `replyStateInjection.test.ts` validates `buildReplyCommentFromResponse()` output (commentId, typeComment, originComment, replyLevel, createReplyParams, content text, fallback replyLevel, malformed input); `cacheService.test.ts` validates `stripReplyTokens()` across depth levels and edge cases

## Known UX Limitations

- Requires YouTube login; enabling the setting forces authenticated comment loading for all videos
- Not compatible with YouTube Data API mode (Data API responses lack reply tokens)
- 30-second cooldown between reply attempts (enforced at attempt time, not success)
- Successful reply shows a synthetic DOM preview ("You" / "Just now") instantly; actual reply data is injected into state and cache behind the scenes, but the synthetic element is not replaced until comments are reloaded
- Reply tokens (`createReplyParams`) can expire if comments have been loaded for a long time; reload comments to refresh
- Toggling `enableInlineReply` requires reloading comments to take effect

---

New option to opt-in inline reply feature
![CleanShot 2026-03-17 at 18 05 48@2x](https://github.com/user-attachments/assets/9cae2693-ed6a-4b60-b998-340e5b04a73b)

Works with nested replies
![CleanShot 2026-03-16 at 23 40 43@2x](https://github.com/user-attachments/assets/9c9a198f-ae68-4e59-ae8a-3c8a80256c5d)