### PR TITLE
fix(innertube): multi-account auth support via X-Goog-AuthUser

### DIFF
--- a/app/src/source/utils/innertube/core.ts
+++ b/app/src/source/utils/innertube/core.ts
@@ -121,6 +121,17 @@ export async function getParams(globalContext: Window & typeof globalThis, signa
     const authHeader = buildSapSidAuthorizationHeader({ context: globalContext });
     if (authHeader) {
         headers.authorization = authHeader;
+
+        // Multi-account support: tag the active Google session.
+        const sessionIndex = (ytcfgData as PageCfgData | undefined)?.SESSION_INDEX;
+        if (sessionIndex !== undefined && sessionIndex !== null) {
+            headers['x-goog-authuser'] = String(sessionIndex);
+        }
+
+        const delegatedSessionId = (ytcfgData as PageCfgData | undefined)?.DELEGATED_SESSION_ID;
+        if (delegatedSessionId) {
+            headers['x-goog-pageid'] = delegatedSessionId;
+        }
     }
 
     const params: InnertubeRequestParams = {

--- a/app/src/source/utils/innertube/request.ts
+++ b/app/src/source/utils/innertube/request.ts
@@ -17,6 +17,8 @@ export interface YtcfgData {
     INNERTUBE_CONTEXT?: {
         client?: Record<string, unknown>;
     };
+    SESSION_INDEX?: string | number;
+    DELEGATED_SESSION_ID?: string;
 }
 
 export interface BuildInnertubeBodyOptions {
@@ -63,6 +65,20 @@ export function buildInnertubeHeaders(
         const authHeader = buildSapSidAuthorizationHeader({ context: globalContext });
         if (authHeader) {
             headers.authorization = authHeader;
+
+            // Multi-account support: signal which Google account the request targets.
+            // SESSION_INDEX maps to X-Goog-AuthUser (0 = primary, 1 = secondary, etc.)
+            // DELEGATED_SESSION_ID maps to X-Goog-PageId (for brand/channel accounts).
+            // Without these headers, requests on secondary accounts get auth-mismatch errors.
+            const sessionIndex = ytcfgData?.SESSION_INDEX;
+            if (sessionIndex !== undefined && sessionIndex !== null) {
+                headers['x-goog-authuser'] = String(sessionIndex);
+            }
+
+            const delegatedSessionId = ytcfgData?.DELEGATED_SESSION_ID;
+            if (delegatedSessionId) {
+                headers['x-goog-pageid'] = delegatedSessionId;
+            }
         }
     }
 

--- a/app/tests/innertube-request.test.ts
+++ b/app/tests/innertube-request.test.ts
@@ -1,0 +1,138 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import { buildInnertubeHeaders, type YtcfgData } from '../src/source/utils/innertube/request';
+
+/**
+ * Helper: Build a minimal fake Window with cookies so that
+ * buildSapSidAuthorizationHeader() produces a real SAPISIDHASH header.
+ */
+const createFakeWindow = (cookie = 'SAPISID=fake_sapisid_value') =>
+    ({
+        location: { href: 'https://www.youtube.com/watch?v=abc123', protocol: 'https:' },
+        document: { cookie },
+        origin: 'https://www.youtube.com'
+    }) as unknown as Window & typeof globalThis;
+
+const baseYtcfg: YtcfgData = {
+    INNERTUBE_CONTEXT_CLIENT_NAME: '1',
+    INNERTUBE_CONTEXT_CLIENT_VERSION: '2.20240101.00.00'
+};
+
+test('buildInnertubeHeaders: disableAuth=true skips auth and multi-account headers', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 1, DELEGATED_SESSION_ID: 'delegated-abc' },
+        {},
+        createFakeWindow(),
+        { disableAuth: true }
+    );
+
+    assert.strictEqual(headers.authorization, undefined);
+    assert.strictEqual(headers['x-goog-authuser'], undefined);
+    assert.strictEqual(headers['x-goog-pageid'], undefined);
+});
+
+test('buildInnertubeHeaders: no globalContext → no auth and no multi-account headers', () => {
+    const headers = buildInnertubeHeaders({ ...baseYtcfg, SESSION_INDEX: 1 });
+
+    assert.strictEqual(headers.authorization, undefined);
+    assert.strictEqual(headers['x-goog-authuser'], undefined);
+    assert.strictEqual(headers['x-goog-pageid'], undefined);
+});
+
+test('buildInnertubeHeaders: SESSION_INDEX=0 attaches x-goog-authuser: "0"', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 0 },
+        {},
+        createFakeWindow()
+    );
+
+    assert.ok(headers.authorization?.startsWith('SAPISIDHASH'));
+    assert.strictEqual(headers['x-goog-authuser'], '0');
+    assert.strictEqual(headers['x-goog-pageid'], undefined);
+});
+
+test('buildInnertubeHeaders: SESSION_INDEX=1 attaches x-goog-authuser: "1" (secondary account)', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 1 },
+        {},
+        createFakeWindow()
+    );
+
+    assert.ok(headers.authorization?.startsWith('SAPISIDHASH'));
+    assert.strictEqual(headers['x-goog-authuser'], '1');
+});
+
+test('buildInnertubeHeaders: SESSION_INDEX as string "2" is accepted', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: '2' },
+        {},
+        createFakeWindow()
+    );
+
+    assert.strictEqual(headers['x-goog-authuser'], '2');
+});
+
+test('buildInnertubeHeaders: DELEGATED_SESSION_ID attaches x-goog-pageid', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 0, DELEGATED_SESSION_ID: 'delegated-123' },
+        {},
+        createFakeWindow()
+    );
+
+    assert.strictEqual(headers['x-goog-authuser'], '0');
+    assert.strictEqual(headers['x-goog-pageid'], 'delegated-123');
+});
+
+test('buildInnertubeHeaders: SESSION_INDEX undefined → no x-goog-authuser header', () => {
+    const headers = buildInnertubeHeaders(baseYtcfg, {}, createFakeWindow());
+
+    assert.ok(headers.authorization?.startsWith('SAPISIDHASH'));
+    assert.strictEqual(headers['x-goog-authuser'], undefined);
+    assert.strictEqual(headers['x-goog-pageid'], undefined);
+});
+
+test('buildInnertubeHeaders: SESSION_INDEX=null must not produce "null" header', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: null as unknown as undefined },
+        {},
+        createFakeWindow()
+    );
+
+    assert.strictEqual(headers['x-goog-authuser'], undefined);
+});
+
+test('buildInnertubeHeaders: preserves base headers alongside multi-account headers', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 1 },
+        {},
+        createFakeWindow()
+    );
+
+    assert.strictEqual(headers['x-youtube-client-name'], '1');
+    assert.strictEqual(headers['x-youtube-client-version'], '2.20240101.00.00');
+    assert.strictEqual(headers['content-type'], 'application/json');
+    assert.strictEqual(headers['accept'], '*/*');
+    assert.strictEqual(headers['x-goog-authuser'], '1');
+});
+
+test('buildInnertubeHeaders: empty DELEGATED_SESSION_ID is ignored', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 0, DELEGATED_SESSION_ID: '' },
+        {},
+        createFakeWindow()
+    );
+
+    assert.strictEqual(headers['x-goog-pageid'], undefined);
+});
+
+test('buildInnertubeHeaders: no SAPISID cookie → no auth, no multi-account headers', () => {
+    const headers = buildInnertubeHeaders(
+        { ...baseYtcfg, SESSION_INDEX: 1 },
+        {},
+        createFakeWindow('OTHER_COOKIE=value')
+    );
+
+    assert.strictEqual(headers.authorization, undefined);
+    assert.strictEqual(headers['x-goog-authuser'], undefined);
+});


### PR DESCRIPTION
## Summary

Fixes members-only comments/chat loading failure when the user is signed into multiple Google accounts and the account with membership is **not** the primary account (SESSION_INDEX ≠ 0).

### Root cause
YCS never sent `X-Goog-AuthUser` / `X-Goog-PageId` headers when calling Innertube APIs. Without them, YouTube defaults the request to the primary account (`SESSION_INDEX=0`), so any membership-gated endpoint returns HTTP 400 when the active browsing session is a secondary account that actually holds the membership.

### Fix
- Read `SESSION_INDEX` and `DELEGATED_SESSION_ID` from `ytcfg`
- Attach `x-goog-authuser` / `x-goog-pageid` headers alongside `SAPISIDHASH` in both `buildInnertubeHeaders` (Innertube v1) and `getParams` (legacy PBJ / HTML fallback)
- Only attach when an auth header is actually being sent (preserves `disableAuth` behavior for public content)

### Scope
Only one of the two symptoms from #147 is fixed here. The "YouTube Timestamps extension" trigger is an independent issue — that extension installs a declarativeNetRequest rule (`extension/rules.json`) that strips the `Origin` header from all XHR requests to `youtube.com`, which breaks SAPISIDHASH verification for every extension on the page. That has to be fixed upstream in [ris58h/youtube-timestamps](https://github.com/ris58h/youtube-timestamps) and cannot be worked around from YCS's side.

Fixes pc035860/YCS-cont#147 (partial — multi-account case only)

## Test plan

- [x] typecheck clean
- [x] lint clean
- [x] 174 tests pass (11 new unit tests in \`innertube-request.test.ts\`)
- [x] Verified \`x-goog-authuser\` header actually reaches the wire via DevTools Network
- [x] Verified \`ytcfg.data_.SESSION_INDEX\` correctly returns \`"1"\` when browsing under secondary account
- [x] End-to-end verification on members-only content with secondary account (requires member account on non-primary slot — awaiting reporter confirmation)