### PR TITLE
fix(innertube): centralize transcript fallback client versions

### DIFF
--- a/app/src/source/utils/innertube/fallbacks.ts
+++ b/app/src/source/utils/innertube/fallbacks.ts
@@ -1,0 +1,9 @@
+export const WEB_CLIENT_FALLBACK = Object.freeze({
+    clientName: 'WEB',
+    clientVersion: '2.20260120.01.00'
+});
+
+export const ANDROID_CLIENT_FALLBACK = Object.freeze({
+    clientName: 'ANDROID',
+    clientVersion: '21.03.36'
+});

--- a/app/src/source/utils/innertube/transcript.ts
+++ b/app/src/source/utils/innertube/transcript.ts
@@ -3,6 +3,7 @@ import type { TranscriptData, TranscriptTrackInfo } from '../interfaces/i_types'
 import { buildInnertubeBody, buildInnertubeHeaders } from './request';
 import { getInitYtData, getInnertubeApiKey, getPageCfgData, type InnertubeRequestParams } from './core';
 import { buildSapSidAuthorizationHeader } from './authHeaders';
+import { ANDROID_CLIENT_FALLBACK, WEB_CLIENT_FALLBACK } from './fallbacks';
 
 async function findInitYParams(initData: object | [object]): Promise<string | undefined> {
     try {
@@ -185,7 +186,7 @@ async function getTranscriptTrackInfo(
                 buildInnertubeBody({
                     ytcfgData: undefined,
                     videoId,
-                    clientOverride: { clientName: 'ANDROID', clientVersion: '21.03.36', hl, gl },
+                    clientOverride: { ...ANDROID_CLIENT_FALLBACK, hl, gl },
                     extra: { racyCheckOk: true, contentCheckOk: true }
                 })
             )
@@ -221,8 +222,9 @@ async function getTranscriptTrackInfo(
                         ytcfgData: undefined,
                         videoId,
                         clientOverride: {
-                            clientName: 'WEB',
-                            clientVersion: pageCfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION || '2.20240101.00.00',
+                            clientName: WEB_CLIENT_FALLBACK.clientName,
+                            clientVersion:
+                                pageCfgData?.INNERTUBE_CONTEXT_CLIENT_VERSION || WEB_CLIENT_FALLBACK.clientVersion,
                             hl,
                             gl
                         },

--- a/app/tests/innertube-transcript-player.test.ts
+++ b/app/tests/innertube-transcript-player.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import { ANDROID_CLIENT_FALLBACK, WEB_CLIENT_FALLBACK } from '../src/source/utils/innertube/fallbacks';
+import { getTranscriptTracks } from '../src/source/utils/innertube/transcript';
+
+test('getTranscriptTracks uses expected ANDROID and WEB fallback clientVersion', async () => {
+    const globalAny = globalThis as any;
+    const originalWindow = globalAny.window;
+    const originalFetch = globalAny.fetch;
+
+    const requestBodies: Record<string, any>[] = [];
+    let fetchCount = 0;
+
+    try {
+        globalAny.window = {
+            location: {
+                href: 'https://www.youtube.com/watch?v=video123',
+                protocol: 'https:',
+                origin: 'https://www.youtube.com'
+            },
+            navigator: { language: 'en-US' },
+            document: { cookie: 'SAPISID=test_sapisid_value' },
+            ytcfg: {
+                data_: {
+                    INNERTUBE_API_KEY: 'test_api_key',
+                    INNERTUBE_CONTEXT: {
+                        client: {
+                            hl: 'en',
+                            gl: 'US'
+                        }
+                    }
+                }
+            }
+        };
+
+        globalAny.fetch = async (_input: string, init?: RequestInit) => {
+            const bodyText = typeof init?.body === 'string' ? init.body : '{}';
+            requestBodies.push(JSON.parse(bodyText));
+
+            fetchCount += 1;
+            if (fetchCount === 1) {
+                return {
+                    json: async () => ({})
+                } as Response;
+            }
+
+            return {
+                ok: true,
+                json: async () => ({
+                    captions: {
+                        playerCaptionsTracklistRenderer: {
+                            captionTracks: [
+                                {
+                                    languageCode: 'en',
+                                    name: { simpleText: 'English' },
+                                    baseUrl: 'https://example.com/api/timedtext?fmt=srv3'
+                                }
+                            ],
+                            audioTracks: [],
+                            defaultCaptionTrackIndex: 0
+                        }
+                    }
+                })
+            } as Response;
+        };
+
+        const tracks = await getTranscriptTracks(new AbortController().signal);
+
+        assert.ok(tracks);
+        assert.equal(tracks?.length, 1);
+        assert.equal(requestBodies.length, 2);
+        assert.equal(requestBodies[0]?.context?.client?.clientName, 'ANDROID');
+        assert.equal(requestBodies[0]?.context?.client?.clientVersion, ANDROID_CLIENT_FALLBACK.clientVersion);
+        assert.equal(requestBodies[1]?.context?.client?.clientName, 'WEB');
+        assert.equal(requestBodies[1]?.context?.client?.clientVersion, WEB_CLIENT_FALLBACK.clientVersion);
+    } finally {
+        if (originalWindow === undefined) {
+            delete globalAny.window;
+        } else {
+            globalAny.window = originalWindow;
+        }
+
+        if (originalFetch === undefined) {
+            delete globalAny.fetch;
+        } else {
+            globalAny.fetch = originalFetch;
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- Add app/src/source/utils/innertube/fallbacks.ts with shared WEB_CLIENT_FALLBACK / ANDROID_CLIENT_FALLBACK (stable-priority versions).
- Wire transcript.ts player two-stage path (ANDROID → WEB) to use those constants.
- Add innertube-transcript-player.test.ts to lock context.client.clientVersion for both requests.

## Test plan
- npm run typecheck
- npm test
- Manual: load extension, transcript on normal video; optionally age-restricted (WEB fallback).