### PR TITLE
feat(reply-expand): add autoExpandReplyContext option with deferred rendering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ Search engines:
 Origin chain (parent-comment context for replies):
 - `app/src/source/web-resources/ui/originChain.ts` — single source of truth for `expandOriginChainFor` and `autoExpandAllRepliesIn`
 - `commentInteractions.ts:handleOpenCommentAll` and `render.ts:renderCommentsResult` are the only callers
+- **DOM scope / review note:** Chain wrappers use document-wide checks and removal (`ycs-com-all-*` via `getElementById` / `querySelectorAll` in `originChain.ts` and `commentInteractions.ts`). That matches the current navigation model: only one YCS search result subtree is active at a time (e.g. `executeSearchBasedOnType` runs `timestampViz` by clearing `#ycs-search-result` in `timestampVizHandler.ts` before chart + `#ycs-timestamp-interval-results`, so “main comment results” and “interval results” are not simultaneously present as sibling panels in normal use).
+- If a future change introduces **two** persistent comment result roots in the same document with the same reply key, scope origin-chain existence/removal to each result container (or disambiguate ids); treat that as an explicit product/architecture change, not an assumed regression from the current branch.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,8 +190,8 @@ Do not merge these semantics.
 - `renderComment` paginates results into batches (200 per batch) with a `Show more` button.
 - Any per-batch post-processing (highlights, auto-expand, decorations) MUST be wired through the `postBatchHook?: (batchRoot: HTMLElement) => void` option, NOT called once on the static target.
 - A hook called on the parent target only covers the initial 200 items; later show-more clicks silently skip post-processing.
-- Post-batch work that touches many DOM nodes (creating children per item) MUST chunk itself via `requestIdleCallback` / `setTimeout` to avoid freezing the main thread — 200 items doing synchronous `renderComment` per item = long task ≈ 1–2s. Run first chunk synchronously for first-paint, yield the rest. Always stale-guard with `element.isConnected` because users can re-filter while chunks are queued.
-- `originChain.ts:autoExpandAllRepliesIn` is the reference example (chunk size 20, idle scheduler with `setTimeout` fallback).
+- Post-batch work that touches many DOM nodes (creating children per item) MUST chunk itself AND defer the entire loop — even a synchronous "first chunk for first paint" blocks the filter click's paint. Use `requestAnimationFrame` for every chunk, keep chunk size small (≈5). Always stale-guard with `element.isConnected` because users can re-filter while chunks are queued.
+- `originChain.ts:autoExpandAllRepliesIn` is the reference example (chunk size 5, rAF scheduler with `setTimeout` fallback, fully deferred).
 
 ### 9) `--experimental-strip-types` rejects mixed value + type imports
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,10 @@ Search engines:
 - `app/src/source/web-resources/search/chatSearch.ts`
 - `app/src/source/web-resources/search/transcriptSearch.ts`
 
+Origin chain (parent-comment context for replies):
+- `app/src/source/web-resources/ui/originChain.ts` — single source of truth for `expandOriginChainFor` and `autoExpandAllRepliesIn`
+- `commentInteractions.ts:handleOpenCommentAll` and `render.ts:renderCommentsResult` are the only callers
+
 ---
 
 ## Philosophy and Conventions
@@ -181,6 +185,20 @@ Do not merge these semantics.
 - Native comments should remain hidden while intent is active.
 - Only restore when search text is cleared and no filter remains active (or YCS is collapsed/cleaned up).
 
+### 8) `renderComment` post-batch work goes through `postBatchHook`
+
+- `renderComment` paginates results into batches (200 per batch) with a `Show more` button.
+- Any per-batch post-processing (highlights, auto-expand, decorations) MUST be wired through the `postBatchHook?: (batchRoot: HTMLElement) => void` option, NOT called once on the static target.
+- A hook called on the parent target only covers the initial 200 items; later show-more clicks silently skip post-processing.
+- Post-batch work that touches many DOM nodes (creating children per item) MUST chunk itself via `requestIdleCallback` / `setTimeout` to avoid freezing the main thread — 200 items doing synchronous `renderComment` per item = long task ≈ 1–2s. Run first chunk synchronously for first-paint, yield the rest. Always stale-guard with `element.isConnected` because users can re-filter while chunks are queued.
+- `originChain.ts:autoExpandAllRepliesIn` is the reference example (chunk size 20, idle scheduler with `setTimeout` fallback).
+
+### 9) `--experimental-strip-types` rejects mixed value + type imports
+
+- The test loader (`tests/ts-loader.mjs` + Node `--experimental-strip-types`) cannot strip type-only names from a regular `import { foo, FooType }` statement.
+- New TS files MUST split: `import { foo } from './x'; import type { FooType } from './x';`
+- Symptom: `SyntaxError: The requested module './x' does not provide an export named 'FooType'` when running `npm test`.
+
 Canonical behavior baseline doc:
 - `app/docs/filter-search-behavior-regression-spec.md`
 
@@ -225,6 +243,12 @@ Canonical behavior baseline doc:
 - Primary: ANDROID client (no auth, works for most videos)
 - Fallback: WEB client with SAPISIDHASH auth + racyCheckOk/contentCheckOk (for age-restricted)
 - AbortError is rethrown in both stages to respect cancellation
+
+5. Reply origin chain auto-expand is opt-in via `autoExpandReplyContext` option
+- New file `app/src/source/web-resources/ui/originChain.ts` owns expand logic
+- `renderComment` gained a `postBatchHook` option for per-batch post-processing
+- Default off — when enabled, parent comment chain is auto-rendered above each reply on initial render and after every Show more click
+- jsdom is now a devDep for DOM-based tests; first such test is `tests/autoExpandReplyContext.test.ts`
 
 ---
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -24,6 +24,7 @@
       "devDependencies": {
         "@types/chrome": "^0.0.193",
         "@types/crypto-js": "^4.2.2",
+        "@types/jsdom": "^28.0.1",
         "@types/mark.js": "^8.11.6",
         "@typescript-eslint/eslint-plugin": "^5.6.0",
         "@typescript-eslint/parser": "^5.6.0",
@@ -32,6 +33,7 @@
         "eslint": "^8.4.1",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
+        "jsdom": "^29.0.2",
         "lint-staged": "^16.2.4",
         "parcel": "^2.0.1",
         "parcel-reporter-static-files-copy": "^1.3.4",
@@ -41,6 +43,198 @@
       },
       "engines": {
         "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
+      "integrity": "sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.9.tgz",
+      "integrity": "sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -104,6 +298,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2343,6 +2555,19 @@
         "@types/sizzle": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2360,6 +2585,23 @@
         "@types/jquery": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/semver": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
@@ -2371,6 +2613,13 @@
       "version": "2.3.10",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.10.tgz",
       "integrity": "sha512-TC0dmN0K8YcWEAEfiPi5gJP14eJe30TTGjkvek3iM/1NdHHsdCA/Td6GvNndMOo/iSnIsZ4HuuhrYPDAmbxzww==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2775,6 +3024,16 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3108,6 +3367,34 @@
       "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3125,6 +3412,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -3265,6 +3559,19 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -3973,6 +4280,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -4223,6 +4543,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4276,6 +4603,60 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/json-buffer": {
@@ -4772,6 +5153,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -4787,6 +5178,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -5215,6 +5613,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5389,6 +5800,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5514,6 +5935,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5619,6 +6053,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ssf": {
@@ -5728,6 +6172,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -5757,6 +6208,26 @@
         "tlds": "bin.js"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5768,6 +6239,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -5840,6 +6337,23 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.8.tgz",
+      "integrity": "sha512-YqWg3ldzJEZ5NXBSIs+FJwgx1/c71Noi9dDfz6CWh32MvnrPmBxqOUsZM6PyY7P16/TU8jVyNlIU3LSsJ3PcUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -5919,12 +6433,60 @@
         "node": ">= 4"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/weak-lru-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz",
       "integrity": "sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6097,6 +6659,23 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yaml": {
       "version": "2.8.1",

--- a/app/package.json
+++ b/app/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@types/chrome": "^0.0.193",
     "@types/crypto-js": "^4.2.2",
+    "@types/jsdom": "^28.0.1",
     "@types/mark.js": "^8.11.6",
     "@typescript-eslint/eslint-plugin": "^5.6.0",
     "@typescript-eslint/parser": "^5.6.0",
@@ -66,6 +67,7 @@
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
+    "jsdom": "^29.0.2",
     "lint-staged": "^16.2.4",
     "parcel": "^2.0.1",
     "parcel-reporter-static-files-copy": "^1.3.4",

--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -6,6 +6,7 @@ const options = {
     autoClear: 200,
     hiddenByDefault: false,
     sortTimestamp: false,
+    autoExpandReplyContext: false,
     hiddenByDefaultShorts: false,
     enableShortsSupport: true,
     transcriptLanguage: '',

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -103,6 +103,20 @@ window.onload = async (): Promise<void> => {
             (document.getElementById('y_opts_sort_timestamp') as HTMLInputElement).checked = param;
         };
 
+        const setRenderAutoExpandReplyContext = (param: unknown): void => {
+            (document.getElementById('y_opts_auto_expand_reply_context') as HTMLInputElement).checked = !!param;
+        };
+
+        const optSetAutoExpandReplyContext = async (opt: HTMLInputElement): Promise<void> => {
+            try {
+                await chrome.storage.local.set({
+                    autoExpandReplyContext: opt.checked
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
         const setRenderHiddenByDefaultShorts = (param: boolean): void => {
             if (typeof param !== 'boolean') return;
 
@@ -713,6 +727,10 @@ window.onload = async (): Promise<void> => {
                         setRenderSortTimestampOpt(storageOpts[key]);
                         break;
 
+                    case 'autoExpandReplyContext':
+                        setRenderAutoExpandReplyContext(storageOpts[key]);
+                        break;
+
                     case 'hiddenByDefaultShorts':
                         setRenderHiddenByDefaultShorts(storageOpts[key]);
                         break;
@@ -789,6 +807,10 @@ window.onload = async (): Promise<void> => {
 
                 case 'y_opts_sort_timestamp':
                     optSetSortTimestamp(e.target as HTMLInputElement);
+                    break;
+
+                case 'y_opts_auto_expand_reply_context':
+                    optSetAutoExpandReplyContext(e.target as HTMLInputElement);
                     break;
 
                 case 'y_opts_hidden_by_default_shorts':

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -76,6 +76,19 @@
           </div>
         </div>
 
+        <div>
+          <label for="y_opts_auto_expand_reply_context">Expand reply context by default:</label>
+          <input
+            type="checkbox"
+            name="Expand reply context by default"
+            id="y_opts_auto_expand_reply_context"
+            class="ycs_opts_checkbox"
+          />
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Automatically show parent comment chain for reply results. Changes take effect on next search.</p>
+          </div>
+        </div>
+
         <div class="ycs_group" id="ycs-shorts-group">
           <div>
             <label for="y_opts_enable_shorts_support">Enable YouTube Shorts support:</label>

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -85,7 +85,9 @@
             class="ycs_opts_checkbox"
           />
           <div class="ycs_description_option ycs_api_desc">
-            <p>Automatically show parent comment chain for reply results. Changes take effect on next search.</p>
+            <p>
+              Automatically show parent comment chain for reply results. Reload the page after changing this option.
+            </p>
           </div>
         </div>
 

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -337,6 +337,7 @@ export interface IYCSOptions {
     youtubeApiKey?: string; // Empty = use Innertube; Filled = use YouTube Data API (storage only)
     hasYoutubeApiKey?: boolean; // Flag exposed to web page (API key never exposed)
     youtubeApiEnabled?: boolean; // Enable YouTube Data API (default: true, requires API key)
+    autoExpandReplyContext?: boolean; // Auto-expand parent comment chain for reply results
 }
 
 // =============================================================================

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -29,6 +29,8 @@ interface RenderCommentOptions {
     hideExpandUp?: boolean;
     /** Force 24px avatars for nested display. Default: false */
     forceSmallAvatar?: boolean;
+    /** Post-batch hook invoked after each batch (initial + show-more) is appended */
+    postBatchHook?: (batchRoot: HTMLElement) => void;
 }
 
 // Debug mode configuration
@@ -503,7 +505,8 @@ function renderComment(el: string | HTMLElement, data: any, options: RenderComme
         querySearch,
         resetReplyLevel = true,
         hideExpandUp = false,
-        forceSmallAvatar = false
+        forceSmallAvatar = false,
+        postBatchHook
     } = options;
 
     if (!el) return;
@@ -563,6 +566,8 @@ function renderComment(el: string | HTMLElement, data: any, options: RenderComme
                 markTextComment(`.${batchClass}`, querySearch);
             }
 
+            postBatchHook?.(batchWrapper);
+
             currentPos = nextEnd;
 
             if (currentPos >= models.length) {
@@ -576,6 +581,8 @@ function renderComment(el: string | HTMLElement, data: any, options: RenderComme
     if (querySearch) {
         markTextComment(el, querySearch);
     }
+
+    postBatchHook?.(wrapper);
 }
 
 function renderCommentChat(selector: string, data: any, querySearch?: string): void {

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -4,10 +4,8 @@ import { safeUrl } from '../utils/formatting';
 import { randomString, isShortsPage } from '../utils/common';
 import { markTextComment, getPiP } from '../utils/dom';
 import { options } from '../config/options';
-import {
-    buildCommentViewModels,
-    buildChatMessageViewModels,
-    buildTranscriptViewModels,
+import { buildCommentViewModels, buildChatMessageViewModels, buildTranscriptViewModels } from './viewModels';
+import type {
     CommentViewModel,
     ChatMessageViewModel,
     TranscriptViewModel,

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -1414,20 +1414,18 @@ export function initApp(): void {
             const context = buildSearchContext();
             const result = runCommentsSearch(query, param, state, context);
 
-            renderCommentsResult(selector, result);
+            const stateAccessor = {
+                getComments: () => getComments(state)
+            };
+
+            renderCommentsResult(selector, result, { stateAccessor });
 
             state = setSearchCount(state, 'comments', result.total);
 
             const commentsContainer = document.getElementById('ycs_wrap_comments');
 
             if (commentsContainer instanceof HTMLElement) {
-                registerCommentInteractions(
-                    commentsContainer,
-                    {
-                        getComments: () => getComments(state)
-                    },
-                    () => query
-                );
+                registerCommentInteractions(commentsContainer, stateAccessor, () => query);
             }
 
             return result;
@@ -1675,6 +1673,14 @@ export function initApp(): void {
                     }
                 };
 
+                const optAutoExpandReplyContext = (value: boolean): void => {
+                    try {
+                        GlobalStore.autoExpandReplyContext = value;
+                    } catch (err) {
+                        console.error(err);
+                    }
+                };
+
                 const optHiddenByDefault = (opts: IYCSOptions): void => {
                     try {
                         const app = document.querySelector('.ycs-app') as HTMLElement;
@@ -1746,6 +1752,10 @@ export function initApp(): void {
 
                             case 'sortTimestamp':
                                 optSortTimestamp(Boolean(opts.sortTimestamp));
+                                break;
+
+                            case 'autoExpandReplyContext':
+                                optAutoExpandReplyContext(Boolean(opts.autoExpandReplyContext));
                                 break;
 
                             case 'hiddenByDefault':

--- a/app/src/source/web-resources/features/timestampVizHandler.ts
+++ b/app/src/source/web-resources/features/timestampVizHandler.ts
@@ -163,8 +163,12 @@ export function createTimestampVizHandler(deps: TimestampVizDeps): () => void {
                             buttonStates: {}
                         };
 
+                        const stateAccessor = {
+                            getComments: () => state.getComments()
+                        };
+
                         // Render results
-                        renderCommentsResult('#ycs-timestamp-interval-results', searchResult);
+                        renderCommentsResult('#ycs-timestamp-interval-results', searchResult, { stateAccessor });
 
                         // Update statistics display with the interval summary
                         callbacks.updateTotalResultDisplay(searchResult.summary);
@@ -172,13 +176,7 @@ export function createTimestampVizHandler(deps: TimestampVizDeps): () => void {
                         // Register comment interactions for the new results
                         const resultsContainer = document.getElementById('ycs-timestamp-interval-results');
                         if (resultsContainer) {
-                            registerCommentInteractions(
-                                resultsContainer,
-                                {
-                                    getComments: () => state.getComments()
-                                },
-                                () => query.trim()
-                            );
+                            registerCommentInteractions(resultsContainer, stateAccessor, () => query.trim());
                         }
 
                         // Scroll to results and show floating button

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -1,15 +1,21 @@
 import { removeNodeList, navigateVideoToTimestamp } from '../../utils/dom';
 import { iconCollapse, iconExpand, iconCurve } from '../../utils/icons';
-import { ICommentsFuseResult } from '../../utils/interfaces/i_types';
+import type { ICommentsFuseResult } from '../../utils/interfaces/i_types';
 import { renderComment } from '../../utils/renderView';
+import {
+    expandOriginChainFor,
+    safeGetComments,
+    resolveQuery,
+    safeDomKey,
+    parseRefId,
+    resolveRefIndex,
+    resolveCurrentComment
+} from './originChain';
+import type { CommentStateAccessor, QueryGetter } from './originChain';
+
+export type { CommentStateAccessor, QueryGetter };
 
 type CommentCollection = Array<Record<string, any>>;
-
-export interface CommentStateAccessor {
-    getComments(): CommentCollection;
-}
-
-export type QueryGetter = () => string;
 
 // === Scroll Position Lock Helpers ===
 
@@ -79,67 +85,6 @@ export function registerCommentInteractions(
     });
 }
 
-function safeGetComments(stateAccessor: CommentStateAccessor): CommentCollection {
-    try {
-        const comments = stateAccessor.getComments();
-        return Array.isArray(comments) ? comments : [];
-    } catch (error) {
-        console.error(error);
-        return [];
-    }
-}
-
-function resolveQuery(queryGetter: QueryGetter): string {
-    try {
-        const value = queryGetter?.();
-        return typeof value === 'string' ? value : '';
-    } catch (error) {
-        console.error(error);
-        return '';
-    }
-}
-
-function safeDomKey(value: string): string {
-    return value.replace(/[^\w-]/g, '_');
-}
-
-function parseRefId(target: HTMLElement): number | null {
-    const raw = target.getAttribute('id');
-    if (!raw) return null;
-    const refId = Number.parseInt(raw, 10);
-    return Number.isFinite(refId) ? refId : null;
-}
-
-function findCommentByIndex(comments: CommentCollection, refId: number): Record<string, any> | undefined {
-    return comments.find((item) => Number.parseInt(String((item as any)?._index ?? ''), 10) === refId);
-}
-
-function resolveCommentId(entry: Record<string, any> | undefined): string | undefined {
-    if (!entry) return undefined;
-    return (
-        (entry as any)?.commentRenderer?.commentId ||
-        (entry as any)?.commentId ||
-        (entry as any)?.id ||
-        (entry as any)?.commentKey
-    );
-}
-
-function buildCommentIdMap(comments: CommentCollection): Map<string, Record<string, any>> {
-    const map = new Map<string, Record<string, any>>();
-    for (const entry of comments) {
-        const id = resolveCommentId(entry);
-        if (id) {
-            map.set(id, entry);
-        }
-    }
-    return map;
-}
-
-function resolveRefIndex(entry: Record<string, any> | undefined, fallback = 0): number {
-    const originIndex = Number.parseInt(String((entry as any)?._index ?? ''), 10);
-    return Number.isFinite(originIndex) ? originIndex : fallback;
-}
-
 function buildOriginResult(
     originComment: Record<string, any> | undefined,
     refId: number | null
@@ -157,14 +102,6 @@ function createOriginWrapper(key: string): HTMLDivElement {
     wrap.id = `ycs-com-${key}`;
     wrap.className = `ycs-com-${key} ycs-origin-wrap`;
     wrap.dataset.ycsOrigin = 'parent';
-    return wrap;
-}
-
-function createOriginChainWrapper(key: string): HTMLDivElement {
-    const wrap = document.createElement('div');
-    wrap.id = `ycs-com-all-${key}`;
-    wrap.className = `ycs-com-all-${key} ycs-origin-chain`;
-    wrap.dataset.ycsOrigin = 'chain';
     return wrap;
 }
 
@@ -260,36 +197,6 @@ function collapseOriginChain(
     toggle.title = 'Open all parent comments to root.';
 }
 
-function resolveCurrentComment(
-    comments: CommentCollection,
-    commentId: string | undefined,
-    refId: number | null
-): Record<string, any> | undefined {
-    if (commentId) {
-        const map = buildCommentIdMap(comments);
-        const found = map.get(commentId);
-        if (found) return found;
-    }
-    return refId !== null ? findCommentByIndex(comments, refId) : undefined;
-}
-
-function collectAncestorChain(current: Record<string, any> | undefined): Record<string, any>[] {
-    const chain: Record<string, any>[] = [];
-    const seen = new Set<string>();
-    let node = current;
-    while (node?.originComment) {
-        const parent = node.originComment as Record<string, any>;
-        const id = resolveCommentId(parent);
-        if (id) {
-            if (seen.has(id)) break;
-            seen.add(id);
-        }
-        chain.push(parent);
-        node = parent;
-    }
-    return chain.reverse();
-}
-
 function handleOpenComment(target: HTMLElement, stateAccessor: CommentStateAccessor, queryGetter: QueryGetter): void {
     const refId = parseRefId(target);
     const commentId = target.dataset.commentId;
@@ -369,47 +276,15 @@ function handleOpenCommentAll(
         return;
     }
 
-    const comments = safeGetComments(stateAccessor);
-    const current = resolveCurrentComment(comments, commentId, refId);
-    const ancestors = collectAncestorChain(current);
-    if (ancestors.length === 0) return;
-
-    const query = resolveQuery(queryGetter);
-    const wrap = createOriginChainWrapper(key);
-
-    // Get source's current marginLeft to position origin chain relative to it
-    const computedStyle = window.getComputedStyle(commentContainer);
-    const sourceMarginLeft = parseFloat(computedStyle.marginLeft) || 0;
-    const EXTRA_OFFSET = 16;
-    wrap.style.marginLeft = `${sourceMarginLeft + EXTRA_OFFSET}px`;
-    wrap.style.paddingLeft = '12px'; // Space for border-left
-
-    commentContainer.insertAdjacentElement('beforebegin', wrap);
-
-    const results: ICommentsFuseResult[] = ancestors.map((ancestor, index) => ({
-        item: { ...ancestor, replyLevel: index } as any,
-        refIndex: resolveRefIndex(ancestor, refId ?? 0)
-    }));
-    renderComment(wrap, results, {
-        querySearch: query,
-        resetReplyLevel: false,
-        hideExpandUp: true,
-        forceSmallAvatar: true
-    });
-
-    // Add arrow element at chain bottom pointing to source
-    const arrow = document.createElement('div');
-    arrow.className = 'ycs-origin-chain-arrow';
-    wrap.appendChild(arrow);
-
-    // Mark source as origin trigger (for styling only, no margin change)
-    commentContainer.classList.add('ycs-origin-trigger');
+    const expanded = expandOriginChainFor(commentContainer, { stateAccessor, queryGetter });
 
     // === Scroll Position Lock ===
     restoreScrollPosition(commentContainer, scrollContainer, yBefore);
 
-    target.innerHTML = iconExpand();
-    target.title = 'Close all parent comments.';
+    if (expanded) {
+        target.innerHTML = iconExpand();
+        target.title = 'Close all parent comments.';
+    }
 }
 
 function handleGotoChatVideo(event: Event): void {

--- a/app/src/source/web-resources/ui/commentInteractions.ts
+++ b/app/src/source/web-resources/ui/commentInteractions.ts
@@ -13,8 +13,6 @@ import {
 } from './originChain';
 import type { CommentStateAccessor, QueryGetter } from './originChain';
 
-export type { CommentStateAccessor, QueryGetter };
-
 type CommentCollection = Array<Record<string, any>>;
 
 // === Scroll Position Lock Helpers ===
@@ -339,7 +337,7 @@ function collectRepliesForComment(
 
 function createRepliesContainer(commentContainer: HTMLElement, commentId: string): HTMLDivElement {
     const wrapper = document.createElement('div');
-    const safeId = commentId.replace(/[^\w-]/g, '_');
+    const safeId = safeDomKey(commentId);
     wrapper.id = `ycs-com-replies-${safeId}`;
 
     // Check parent avatar size to align vertical line (border-left)
@@ -360,7 +358,7 @@ function handleOpenReply(target: HTMLElement, stateAccessor: CommentStateAccesso
     const commentContainer = target.closest('.ycs-render-comment') as HTMLElement | null;
     if (!commentContainer) return;
 
-    const safeId = commentId.replace(/[^\w-]/g, '_');
+    const safeId = safeDomKey(commentId);
     const existingReplies = commentContainer.querySelector(`.ycs-com-replies-${safeId}`);
     if (existingReplies) {
         existingReplies.remove();

--- a/app/src/source/web-resources/ui/originChain.ts
+++ b/app/src/source/web-resources/ui/originChain.ts
@@ -170,17 +170,17 @@ export function expandOriginChainFor(container: HTMLElement, deps: OriginChainDe
     return true;
 }
 
-const AUTO_EXPAND_CHUNK_SIZE = 20;
+const AUTO_EXPAND_CHUNK_SIZE = 5;
 
-type IdleScheduler = (callback: () => void) => void;
+type FrameScheduler = (callback: () => void) => void;
 
-const scheduleIdleChunk: IdleScheduler = (callback) => {
+const scheduleNextFrame: FrameScheduler = (callback) => {
     const win = typeof window !== 'undefined' ? (window as any) : undefined;
-    if (win && typeof win.requestIdleCallback === 'function') {
-        win.requestIdleCallback(callback, { timeout: 200 });
+    if (win && typeof win.requestAnimationFrame === 'function') {
+        win.requestAnimationFrame(callback);
         return;
     }
-    setTimeout(callback, 0);
+    setTimeout(callback, 16);
 };
 
 export function autoExpandAllRepliesIn(root: HTMLElement, deps: OriginChainDeps): void {
@@ -212,11 +212,13 @@ export function autoExpandAllRepliesIn(root: HTMLElement, deps: OriginChainDeps)
         cursor = end;
 
         if (cursor < buttons.length) {
-            scheduleIdleChunk(processNextChunk);
+            scheduleNextFrame(processNextChunk);
         }
     };
 
-    // First chunk runs synchronously so initial viewport expands without flicker.
-    // Remaining chunks yield to the main thread to prevent freezes on large result sets.
-    processNextChunk();
+    // Fully deferred: the current frame paints the search results first, then
+    // origin chains fill in progressively on subsequent animation frames. This
+    // keeps the UI responsive on large result sets — filter clicks no longer
+    // block while hundreds of ancestor renders run inline.
+    scheduleNextFrame(processNextChunk);
 }

--- a/app/src/source/web-resources/ui/originChain.ts
+++ b/app/src/source/web-resources/ui/originChain.ts
@@ -1,0 +1,18 @@
+export interface CommentStateAccessor {
+    getComments(): Array<Record<string, any>>;
+}
+
+export type QueryGetter = () => string;
+
+export interface OriginChainDeps {
+    stateAccessor: CommentStateAccessor;
+    queryGetter: QueryGetter;
+}
+
+export function expandOriginChainFor(_container: HTMLElement, _deps: OriginChainDeps): boolean {
+    return false;
+}
+
+export function autoExpandAllRepliesIn(_root: HTMLElement, _deps: OriginChainDeps): void {
+    return;
+}

--- a/app/src/source/web-resources/ui/originChain.ts
+++ b/app/src/source/web-resources/ui/originChain.ts
@@ -1,5 +1,12 @@
+import { GlobalStore } from '../../utils/common';
+import { iconExpand } from '../../utils/icons';
+import type { ICommentsFuseResult } from '../../utils/interfaces/i_types';
+import { renderComment } from '../../utils/renderView';
+
+type CommentCollection = Array<Record<string, any>>;
+
 export interface CommentStateAccessor {
-    getComments(): Array<Record<string, any>>;
+    getComments(): CommentCollection;
 }
 
 export type QueryGetter = () => string;
@@ -9,10 +16,175 @@ export interface OriginChainDeps {
     queryGetter: QueryGetter;
 }
 
-export function expandOriginChainFor(_container: HTMLElement, _deps: OriginChainDeps): boolean {
-    return false;
+export function safeGetComments(stateAccessor: CommentStateAccessor): CommentCollection {
+    try {
+        const comments = stateAccessor.getComments();
+        return Array.isArray(comments) ? comments : [];
+    } catch (error) {
+        console.error(error);
+        return [];
+    }
 }
 
-export function autoExpandAllRepliesIn(_root: HTMLElement, _deps: OriginChainDeps): void {
-    return;
+export function resolveQuery(queryGetter: QueryGetter): string {
+    try {
+        const value = queryGetter?.();
+        return typeof value === 'string' ? value : '';
+    } catch (error) {
+        console.error(error);
+        return '';
+    }
+}
+
+export function safeDomKey(value: string): string {
+    return value.replace(/[^\w-]/g, '_');
+}
+
+export function parseRefId(target: HTMLElement): number | null {
+    const raw = target.getAttribute('id');
+    if (!raw) return null;
+    const refId = Number.parseInt(raw, 10);
+    return Number.isFinite(refId) ? refId : null;
+}
+
+export function findCommentByIndex(comments: CommentCollection, refId: number): Record<string, any> | undefined {
+    return comments.find((item) => Number.parseInt(String((item as any)?._index ?? ''), 10) === refId);
+}
+
+export function resolveCommentId(entry: Record<string, any> | undefined): string | undefined {
+    if (!entry) return undefined;
+    return (
+        (entry as any)?.commentRenderer?.commentId ||
+        (entry as any)?.commentId ||
+        (entry as any)?.id ||
+        (entry as any)?.commentKey
+    );
+}
+
+export function buildCommentIdMap(comments: CommentCollection): Map<string, Record<string, any>> {
+    const map = new Map<string, Record<string, any>>();
+    for (const entry of comments) {
+        const id = resolveCommentId(entry);
+        if (id) {
+            map.set(id, entry);
+        }
+    }
+    return map;
+}
+
+export function resolveRefIndex(entry: Record<string, any> | undefined, fallback = 0): number {
+    const originIndex = Number.parseInt(String((entry as any)?._index ?? ''), 10);
+    return Number.isFinite(originIndex) ? originIndex : fallback;
+}
+
+export function resolveCurrentComment(
+    comments: CommentCollection,
+    commentId: string | undefined,
+    refId: number | null
+): Record<string, any> | undefined {
+    if (commentId) {
+        const map = buildCommentIdMap(comments);
+        const found = map.get(commentId);
+        if (found) return found;
+    }
+    return refId !== null ? findCommentByIndex(comments, refId) : undefined;
+}
+
+export function collectAncestorChain(current: Record<string, any> | undefined): Record<string, any>[] {
+    const chain: Record<string, any>[] = [];
+    const seen = new Set<string>();
+    let node = current;
+    while (node?.originComment) {
+        const parent = node.originComment as Record<string, any>;
+        const id = resolveCommentId(parent);
+        if (id) {
+            if (seen.has(id)) break;
+            seen.add(id);
+        }
+        chain.push(parent);
+        node = parent;
+    }
+    return chain.reverse();
+}
+
+export function createOriginChainWrapper(key: string): HTMLDivElement {
+    const wrap = document.createElement('div');
+    wrap.id = `ycs-com-all-${key}`;
+    wrap.className = `ycs-com-all-${key} ycs-origin-chain`;
+    wrap.dataset.ycsOrigin = 'chain';
+    return wrap;
+}
+
+function readMarginLeftPx(element: HTMLElement): number {
+    try {
+        const computedStyle = window.getComputedStyle(element);
+        const value = parseFloat(computedStyle.marginLeft);
+        return Number.isFinite(value) ? value : 0;
+    } catch {
+        return 0;
+    }
+}
+
+export function expandOriginChainFor(container: HTMLElement, deps: OriginChainDeps): boolean {
+    const button = container.querySelector<HTMLElement>('.ycs-open-comment-all');
+    const refId = button ? parseRefId(button) : null;
+    const commentId = button?.dataset.commentId;
+    if (refId === null && !commentId) return false;
+
+    const key = commentId ? safeDomKey(commentId) : `idx-${refId ?? 0}`;
+
+    if (document.getElementById(`ycs-com-all-${key}`)) return false;
+
+    const comments = safeGetComments(deps.stateAccessor);
+    const current = resolveCurrentComment(comments, commentId, refId);
+    const ancestors = collectAncestorChain(current);
+    if (ancestors.length === 0) return false;
+
+    const query = resolveQuery(deps.queryGetter);
+    const wrap = createOriginChainWrapper(key);
+
+    const sourceMarginLeft = readMarginLeftPx(container);
+    const EXTRA_OFFSET = 16;
+    wrap.style.marginLeft = `${sourceMarginLeft + EXTRA_OFFSET}px`;
+    wrap.style.paddingLeft = '12px';
+
+    container.insertAdjacentElement('beforebegin', wrap);
+
+    const results: ICommentsFuseResult[] = ancestors.map((ancestor, index) => ({
+        item: { ...ancestor, replyLevel: index } as any,
+        refIndex: resolveRefIndex(ancestor, refId ?? 0)
+    }));
+    renderComment(wrap, results, {
+        querySearch: query,
+        resetReplyLevel: false,
+        hideExpandUp: true,
+        forceSmallAvatar: true
+    });
+
+    const arrow = document.createElement('div');
+    arrow.className = 'ycs-origin-chain-arrow';
+    wrap.appendChild(arrow);
+
+    container.classList.add('ycs-origin-trigger');
+
+    return true;
+}
+
+export function autoExpandAllRepliesIn(root: HTMLElement, deps: OriginChainDeps): void {
+    if (!(GlobalStore as any).autoExpandReplyContext) return;
+
+    const buttons = Array.from(root.querySelectorAll<HTMLElement>('.ycs-open-comment-all'));
+    const seen = new Set<HTMLElement>();
+
+    for (const btn of buttons) {
+        const container = btn.closest<HTMLElement>('.ycs-render-comment');
+        if (!container || seen.has(container)) continue;
+        seen.add(container);
+
+        const expanded = expandOriginChainFor(container, deps);
+        if (expanded) {
+            btn.innerHTML = iconExpand();
+            btn.title = 'Close all parent comments.';
+        }
+    }
 }

--- a/app/src/source/web-resources/ui/originChain.ts
+++ b/app/src/source/web-resources/ui/originChain.ts
@@ -170,21 +170,53 @@ export function expandOriginChainFor(container: HTMLElement, deps: OriginChainDe
     return true;
 }
 
+const AUTO_EXPAND_CHUNK_SIZE = 20;
+
+type IdleScheduler = (callback: () => void) => void;
+
+const scheduleIdleChunk: IdleScheduler = (callback) => {
+    const win = typeof window !== 'undefined' ? (window as any) : undefined;
+    if (win && typeof win.requestIdleCallback === 'function') {
+        win.requestIdleCallback(callback, { timeout: 200 });
+        return;
+    }
+    setTimeout(callback, 0);
+};
+
 export function autoExpandAllRepliesIn(root: HTMLElement, deps: OriginChainDeps): void {
     if (!(GlobalStore as any).autoExpandReplyContext) return;
 
     const buttons = Array.from(root.querySelectorAll<HTMLElement>('.ycs-open-comment-all'));
+    if (buttons.length === 0) return;
+
     const seen = new Set<HTMLElement>();
+    let cursor = 0;
 
-    for (const btn of buttons) {
-        const container = btn.closest<HTMLElement>('.ycs-render-comment');
-        if (!container || seen.has(container)) continue;
-        seen.add(container);
+    const processNextChunk = (): void => {
+        const end = Math.min(cursor + AUTO_EXPAND_CHUNK_SIZE, buttons.length);
+        for (let i = cursor; i < end; i += 1) {
+            const btn = buttons[i];
+            // Stale guard: button from a previous search that has been cleared
+            if (!btn.isConnected) continue;
 
-        const expanded = expandOriginChainFor(container, deps);
-        if (expanded) {
-            btn.innerHTML = iconExpand();
-            btn.title = 'Close all parent comments.';
+            const container = btn.closest<HTMLElement>('.ycs-render-comment');
+            if (!container || !container.isConnected || seen.has(container)) continue;
+            seen.add(container);
+
+            const expanded = expandOriginChainFor(container, deps);
+            if (expanded) {
+                btn.innerHTML = iconExpand();
+                btn.title = 'Close all parent comments.';
+            }
         }
-    }
+        cursor = end;
+
+        if (cursor < buttons.length) {
+            scheduleIdleChunk(processNextChunk);
+        }
+    };
+
+    // First chunk runs synchronously so initial viewport expands without flicker.
+    // Remaining chunks yield to the main thread to prevent freezes on large result sets.
+    processNextChunk();
 }

--- a/app/src/source/web-resources/ui/originChain.ts
+++ b/app/src/source/web-resources/ui/originChain.ts
@@ -47,11 +47,11 @@ export function parseRefId(target: HTMLElement): number | null {
     return Number.isFinite(refId) ? refId : null;
 }
 
-export function findCommentByIndex(comments: CommentCollection, refId: number): Record<string, any> | undefined {
+function findCommentByIndex(comments: CommentCollection, refId: number): Record<string, any> | undefined {
     return comments.find((item) => Number.parseInt(String((item as any)?._index ?? ''), 10) === refId);
 }
 
-export function resolveCommentId(entry: Record<string, any> | undefined): string | undefined {
+function resolveCommentId(entry: Record<string, any> | undefined): string | undefined {
     if (!entry) return undefined;
     return (
         (entry as any)?.commentRenderer?.commentId ||
@@ -61,7 +61,7 @@ export function resolveCommentId(entry: Record<string, any> | undefined): string
     );
 }
 
-export function buildCommentIdMap(comments: CommentCollection): Map<string, Record<string, any>> {
+function buildCommentIdMap(comments: CommentCollection): Map<string, Record<string, any>> {
     const map = new Map<string, Record<string, any>>();
     for (const entry of comments) {
         const id = resolveCommentId(entry);
@@ -90,7 +90,7 @@ export function resolveCurrentComment(
     return refId !== null ? findCommentByIndex(comments, refId) : undefined;
 }
 
-export function collectAncestorChain(current: Record<string, any> | undefined): Record<string, any>[] {
+function collectAncestorChain(current: Record<string, any> | undefined): Record<string, any>[] {
     const chain: Record<string, any>[] = [];
     const seen = new Set<string>();
     let node = current;
@@ -107,7 +107,7 @@ export function collectAncestorChain(current: Record<string, any> | undefined): 
     return chain.reverse();
 }
 
-export function createOriginChainWrapper(key: string): HTMLDivElement {
+function createOriginChainWrapper(key: string): HTMLDivElement {
     const wrap = document.createElement('div');
     wrap.id = `ycs-com-all-${key}`;
     wrap.className = `ycs-com-all-${key} ycs-origin-chain`;

--- a/app/src/source/web-resources/ui/render.ts
+++ b/app/src/source/web-resources/ui/render.ts
@@ -80,14 +80,20 @@ export function renderCommentsResult(
     if (!target) return;
 
     if (result.results.length > 0) {
-        renderComment(selector, result.results, { querySearch: result.query });
+        const stateAccessor = deps?.stateAccessor;
+        const postBatchHook = stateAccessor
+            ? (batchRoot: HTMLElement) => {
+                  autoExpandAllRepliesIn(batchRoot, {
+                      stateAccessor,
+                      queryGetter: () => result.query
+                  });
+              }
+            : undefined;
 
-        if (deps?.stateAccessor) {
-            autoExpandAllRepliesIn(target, {
-                stateAccessor: deps.stateAccessor,
-                queryGetter: () => result.query
-            });
-        }
+        renderComment(selector, result.results, {
+            querySearch: result.query,
+            postBatchHook
+        });
     }
 
     applyButtonStates(result.buttonStates);

--- a/app/src/source/web-resources/ui/render.ts
+++ b/app/src/source/web-resources/ui/render.ts
@@ -1,8 +1,10 @@
 import { iconSortDown, iconSortUp } from '../../utils/icons';
 import { renderComment, renderCommentChat, renderCommentTrVideo } from '../../utils/renderView';
-import { CommentsSearchResult } from '../search/commentsSearch';
-import { ChatSearchResult } from '../search/chatSearch';
-import { TranscriptSearchResult } from '../search/transcriptSearch';
+import type { CommentsSearchResult } from '../search/commentsSearch';
+import type { ChatSearchResult } from '../search/chatSearch';
+import type { TranscriptSearchResult } from '../search/transcriptSearch';
+import { autoExpandAllRepliesIn } from './originChain';
+import type { CommentStateAccessor } from './originChain';
 
 const BUTTON_LABELS: Record<string, string> = {
     ycs_btn_links: 'Links',
@@ -69,12 +71,23 @@ function clearTarget(selector: string): HTMLElement | null {
     return target;
 }
 
-export function renderCommentsResult(selector: string, result: CommentsSearchResult): void {
+export function renderCommentsResult(
+    selector: string,
+    result: CommentsSearchResult,
+    deps?: { stateAccessor: CommentStateAccessor }
+): void {
     const target = clearTarget(selector);
     if (!target) return;
 
     if (result.results.length > 0) {
         renderComment(selector, result.results, { querySearch: result.query });
+
+        if (deps?.stateAccessor) {
+            autoExpandAllRepliesIn(target, {
+                stateAccessor: deps.stateAccessor,
+                queryGetter: () => result.query
+            });
+        }
     }
 
     applyButtonStates(result.buttonStates);

--- a/app/tests/autoExpandReplyContext.test.ts
+++ b/app/tests/autoExpandReplyContext.test.ts
@@ -1,0 +1,254 @@
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>');
+(globalThis as any).document = dom.window.document;
+(globalThis as any).window = dom.window;
+(globalThis as any).HTMLElement = dom.window.HTMLElement;
+(globalThis as any).Element = dom.window.Element;
+(globalThis as any).Node = dom.window.Node;
+(globalThis as any).DocumentFragment = dom.window.DocumentFragment;
+
+import {
+    expandOriginChainFor,
+    autoExpandAllRepliesIn,
+    type CommentStateAccessor,
+    type OriginChainDeps
+} from '../src/source/web-resources/ui/originChain';
+import { GlobalStore } from '../src/source/utils/common';
+
+function buildParentComment(id: string, text: string): Record<string, any> {
+    return {
+        _index: 0,
+        typeComment: 'C',
+        commentId: id,
+        commentRenderer: {
+            commentId: id,
+            contentText: { simpleText: text },
+            authorText: { simpleText: 'parent_author' },
+            publishedTimeText: { runs: [{ text: '2d ago' }] }
+        }
+    };
+}
+
+function buildReplyComment(
+    id: string,
+    text: string,
+    parent: Record<string, any>,
+    index: number
+): Record<string, any> {
+    return {
+        _index: index,
+        typeComment: 'R',
+        commentId: id,
+        commentRenderer: {
+            commentId: id,
+            contentText: { simpleText: text },
+            authorText: { simpleText: 'replier' },
+            publishedTimeText: { runs: [{ text: '1d ago' }] }
+        },
+        originComment: parent
+    };
+}
+
+function buildReplyContainer(commentId: string, refIndex: number): HTMLElement {
+    const container = document.createElement('div');
+    container.id = `ycs-number-comment-${refIndex}`;
+    container.className = 'ycs-render-comment';
+
+    const button = document.createElement('button');
+    button.id = String(refIndex);
+    button.className = 'ycs-open-comment-all';
+    button.innerHTML = '\u25B2';
+    button.dataset.commentId = commentId;
+    container.appendChild(button);
+
+    return container;
+}
+
+function buildDeps(comments: Array<Record<string, any>>, query = ''): OriginChainDeps {
+    const stateAccessor: CommentStateAccessor = {
+        getComments: () => comments
+    };
+    return {
+        stateAccessor,
+        queryGetter: () => query
+    };
+}
+
+function resetGlobalStore(): void {
+    (GlobalStore as any).autoExpandReplyContext = false;
+}
+
+function setupRoot(): HTMLElement {
+    const root = document.createElement('div');
+    root.id = 'ycs_search_results';
+    document.body.appendChild(root);
+    return root;
+}
+
+function teardownRoot(root: HTMLElement): void {
+    root.remove();
+    resetGlobalStore();
+}
+
+test('Case A: GlobalStore.autoExpandReplyContext = false → hook short-circuits', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent = buildParentComment('c1', 'parent text');
+        const reply = buildReplyComment('c1r1', 'reply text', parent, 1);
+        const container = buildReplyContainer('c1r1', 1);
+        root.appendChild(container);
+
+        (GlobalStore as any).autoExpandReplyContext = false;
+        autoExpandAllRepliesIn(root, buildDeps([reply]));
+
+        const wrapper = root.querySelector('[id^="ycs-com-all-"]');
+        assert.equal(wrapper, null, 'expected no origin chain wrapper when option is false');
+        const button = container.querySelector('.ycs-open-comment-all') as HTMLElement;
+        assert.equal(button.innerHTML, '\u25B2', 'expected button icon unchanged');
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case B: option=true with originComment → auto expand wrapper inserted', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent = buildParentComment('c1', 'parent text');
+        const reply = buildReplyComment('c1r1', 'reply text', parent, 1);
+        const container = buildReplyContainer('c1r1', 1);
+        root.appendChild(container);
+
+        (GlobalStore as any).autoExpandReplyContext = true;
+        autoExpandAllRepliesIn(root, buildDeps([reply]));
+
+        const wrapper = root.querySelector('#ycs-com-all-c1r1');
+        assert.equal(wrapper !== null, true, 'expected origin chain wrapper to exist');
+
+        const wrapperContent = wrapper?.querySelector('.ycs-render-comment');
+        assert.equal(
+            wrapperContent !== null && wrapperContent !== undefined,
+            true,
+            'expected wrapper to contain rendered parent comment node, not be empty shell'
+        );
+
+        const triggerHasClass = container.classList.contains('ycs-origin-trigger');
+        assert.equal(triggerHasClass, true, 'expected reply container to have ycs-origin-trigger class');
+
+        const button = container.querySelector('.ycs-open-comment-all') as HTMLElement;
+        assert.equal(
+            button.title,
+            'Close all parent comments.',
+            'expected button title to switch to close hint'
+        );
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case C: idempotent — calling autoExpandAllRepliesIn twice inserts wrapper only once', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent = buildParentComment('c1', 'parent text');
+        const reply = buildReplyComment('c1r1', 'reply text', parent, 1);
+        const container = buildReplyContainer('c1r1', 1);
+        root.appendChild(container);
+
+        (GlobalStore as any).autoExpandReplyContext = true;
+        const deps = buildDeps([reply]);
+        autoExpandAllRepliesIn(root, deps);
+        autoExpandAllRepliesIn(root, deps);
+
+        const wrappers = root.querySelectorAll('#ycs-com-all-c1r1');
+        assert.equal(wrappers.length, 1, 'expected exactly one origin chain wrapper after double call');
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case D: expandOriginChainFor returns false when ancestors are empty', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const orphan = buildReplyComment('c1r1', 'reply text', null as any, 1);
+        delete orphan.originComment;
+        const container = buildReplyContainer('c1r1', 1);
+        root.appendChild(container);
+
+        const result = expandOriginChainFor(container, buildDeps([orphan]));
+        assert.equal(result, false, 'expected expandOriginChainFor to return false for empty ancestors');
+
+        const wrapper = root.querySelector('#ycs-com-all-c1r1');
+        assert.equal(wrapper, null, 'expected no wrapper inserted when ancestors empty');
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case E: multiple replies all expand independently', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent1 = buildParentComment('c1', 'parent1');
+        const parent2 = buildParentComment('c2', 'parent2');
+        const reply1 = buildReplyComment('c1r1', 'reply1', parent1, 1);
+        const reply2 = buildReplyComment('c1r2', 'reply2', parent1, 2);
+        const reply3 = buildReplyComment('c2r1', 'reply3', parent2, 3);
+
+        const container1 = buildReplyContainer('c1r1', 1);
+        const container2 = buildReplyContainer('c1r2', 2);
+        const container3 = buildReplyContainer('c2r1', 3);
+        root.appendChild(container1);
+        root.appendChild(container2);
+        root.appendChild(container3);
+
+        (GlobalStore as any).autoExpandReplyContext = true;
+        autoExpandAllRepliesIn(root, buildDeps([reply1, reply2, reply3]));
+
+        assert.equal(root.querySelector('#ycs-com-all-c1r1') !== null, true, 'reply1 wrapper exists');
+        assert.equal(root.querySelector('#ycs-com-all-c1r2') !== null, true, 'reply2 wrapper exists');
+        assert.equal(root.querySelector('#ycs-com-all-c2r1') !== null, true, 'reply3 wrapper exists');
+
+        for (const c of [container1, container2, container3]) {
+            const btn = c.querySelector('.ycs-open-comment-all') as HTMLElement;
+            assert.equal(
+                btn.title,
+                'Close all parent comments.',
+                'each button should switch title after auto-expand'
+            );
+        }
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case F: expandOriginChainFor sets ycs-origin-trigger class on success', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent = buildParentComment('c1', 'parent text');
+        const reply = buildReplyComment('c1r1', 'reply text', parent, 1);
+        const container = buildReplyContainer('c1r1', 1);
+        root.appendChild(container);
+
+        const result = expandOriginChainFor(container, buildDeps([reply]));
+        assert.equal(result, true, 'expected expandOriginChainFor to return true on success');
+        assert.equal(
+            container.classList.contains('ycs-origin-trigger'),
+            true,
+            'expected ycs-origin-trigger class on container'
+        );
+        assert.equal(
+            root.querySelector('#ycs-com-all-c1r1') !== null,
+            true,
+            'expected wrapper to be inserted'
+        );
+    } finally {
+        teardownRoot(root);
+    }
+});

--- a/app/tests/autoExpandReplyContext.test.ts
+++ b/app/tests/autoExpandReplyContext.test.ts
@@ -290,6 +290,41 @@ test('Case H: renderComment invokes postBatchHook again on show-more click', () 
     }
 });
 
+test('Case J: autoExpandAllRepliesIn chunks work — first AUTO_EXPAND_CHUNK_SIZE items expand synchronously, rest defer', async () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        // 30 replies > AUTO_EXPAND_CHUNK_SIZE (20) so chunking path is exercised
+        const replies: Array<Record<string, any>> = [];
+        for (let i = 1; i <= 30; i += 1) {
+            const parent = buildParentComment(`c${i}`, `p${i}`);
+            replies.push(buildReplyComment(`c${i}r1`, `r${i}`, parent, i));
+            root.appendChild(buildReplyContainer(`c${i}r1`, i));
+        }
+
+        (GlobalStore as any).autoExpandReplyContext = true;
+        autoExpandAllRepliesIn(root, buildDeps(replies));
+
+        const syncWrappers = root.querySelectorAll('[id^="ycs-com-all-"]').length;
+        assert.equal(
+            syncWrappers,
+            20,
+            `expected first chunk (20) to expand synchronously so main thread yields, got ${syncWrappers}`
+        );
+
+        await new Promise((resolve) => setTimeout(resolve, 30));
+
+        const asyncWrappers = root.querySelectorAll('[id^="ycs-com-all-"]').length;
+        assert.equal(
+            asyncWrappers,
+            30,
+            `expected remaining chunk to expand after yielding, got ${asyncWrappers}`
+        );
+    } finally {
+        teardownRoot(root);
+    }
+});
+
 test('Case I: renderComment + postBatchHook wiring auto-expands replies end-to-end', () => {
     resetGlobalStore();
     const root = setupRoot();

--- a/app/tests/autoExpandReplyContext.test.ts
+++ b/app/tests/autoExpandReplyContext.test.ts
@@ -82,6 +82,10 @@ function resetGlobalStore(): void {
     (GlobalStore as any).autoExpandReplyContext = false;
 }
 
+function flushFrames(ms = 100): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function setupRoot(): HTMLElement {
     const root = document.createElement('div');
     root.id = 'ycs_search_results';
@@ -115,7 +119,7 @@ test('Case A: GlobalStore.autoExpandReplyContext = false → hook short-circuits
     }
 });
 
-test('Case B: option=true with originComment → auto expand wrapper inserted', () => {
+test('Case B: option=true with originComment → auto expand wrapper inserted', async () => {
     resetGlobalStore();
     const root = setupRoot();
     try {
@@ -126,6 +130,7 @@ test('Case B: option=true with originComment → auto expand wrapper inserted', 
 
         (GlobalStore as any).autoExpandReplyContext = true;
         autoExpandAllRepliesIn(root, buildDeps([reply]));
+        await flushFrames();
 
         const wrapper = root.querySelector('#ycs-com-all-c1r1');
         assert.equal(wrapper !== null, true, 'expected origin chain wrapper to exist');
@@ -151,7 +156,7 @@ test('Case B: option=true with originComment → auto expand wrapper inserted', 
     }
 });
 
-test('Case C: idempotent — calling autoExpandAllRepliesIn twice inserts wrapper only once', () => {
+test('Case C: idempotent — calling autoExpandAllRepliesIn twice inserts wrapper only once', async () => {
     resetGlobalStore();
     const root = setupRoot();
     try {
@@ -164,6 +169,7 @@ test('Case C: idempotent — calling autoExpandAllRepliesIn twice inserts wrappe
         const deps = buildDeps([reply]);
         autoExpandAllRepliesIn(root, deps);
         autoExpandAllRepliesIn(root, deps);
+        await flushFrames();
 
         const wrappers = root.querySelectorAll('#ycs-com-all-c1r1');
         assert.equal(wrappers.length, 1, 'expected exactly one origin chain wrapper after double call');
@@ -191,7 +197,7 @@ test('Case D: expandOriginChainFor returns false when ancestors are empty', () =
     }
 });
 
-test('Case E: multiple replies all expand independently', () => {
+test('Case E: multiple replies all expand independently', async () => {
     resetGlobalStore();
     const root = setupRoot();
     try {
@@ -210,6 +216,7 @@ test('Case E: multiple replies all expand independently', () => {
 
         (GlobalStore as any).autoExpandReplyContext = true;
         autoExpandAllRepliesIn(root, buildDeps([reply1, reply2, reply3]));
+        await flushFrames();
 
         assert.equal(root.querySelector('#ycs-com-all-c1r1') !== null, true, 'reply1 wrapper exists');
         assert.equal(root.querySelector('#ycs-com-all-c1r2') !== null, true, 'reply2 wrapper exists');
@@ -290,13 +297,12 @@ test('Case H: renderComment invokes postBatchHook again on show-more click', () 
     }
 });
 
-test('Case J: autoExpandAllRepliesIn chunks work — first AUTO_EXPAND_CHUNK_SIZE items expand synchronously, rest defer', async () => {
+test('Case J: autoExpandAllRepliesIn defers all work to next frames and completes across chunks', async () => {
     resetGlobalStore();
     const root = setupRoot();
     try {
-        // 30 replies > AUTO_EXPAND_CHUNK_SIZE (20) so chunking path is exercised
         const replies: Array<Record<string, any>> = [];
-        for (let i = 1; i <= 30; i += 1) {
+        for (let i = 1; i <= 12; i += 1) {
             const parent = buildParentComment(`c${i}`, `p${i}`);
             replies.push(buildReplyComment(`c${i}r1`, `r${i}`, parent, i));
             root.appendChild(buildReplyContainer(`c${i}r1`, i));
@@ -305,27 +311,27 @@ test('Case J: autoExpandAllRepliesIn chunks work — first AUTO_EXPAND_CHUNK_SIZ
         (GlobalStore as any).autoExpandReplyContext = true;
         autoExpandAllRepliesIn(root, buildDeps(replies));
 
-        const syncWrappers = root.querySelectorAll('[id^="ycs-com-all-"]').length;
+        const immediateWrappers = root.querySelectorAll('[id^="ycs-com-all-"]').length;
         assert.equal(
-            syncWrappers,
-            20,
-            `expected first chunk (20) to expand synchronously so main thread yields, got ${syncWrappers}`
+            immediateWrappers,
+            0,
+            `expected 0 wrappers synchronously so filter click paints before expand work starts, got ${immediateWrappers}`
         );
 
-        await new Promise((resolve) => setTimeout(resolve, 30));
+        await flushFrames(200);
 
-        const asyncWrappers = root.querySelectorAll('[id^="ycs-com-all-"]').length;
+        const finalWrappers = root.querySelectorAll('[id^="ycs-com-all-"]').length;
         assert.equal(
-            asyncWrappers,
-            30,
-            `expected remaining chunk to expand after yielding, got ${asyncWrappers}`
+            finalWrappers,
+            12,
+            `expected all 12 wrappers after frames flush, got ${finalWrappers}`
         );
     } finally {
         teardownRoot(root);
     }
 });
 
-test('Case I: renderComment + postBatchHook wiring auto-expands replies end-to-end', () => {
+test('Case I: renderComment + postBatchHook wiring auto-expands replies end-to-end', async () => {
     resetGlobalStore();
     const root = setupRoot();
     try {
@@ -344,6 +350,7 @@ test('Case I: renderComment + postBatchHook wiring auto-expands replies end-to-e
                 });
             }
         });
+        await flushFrames();
 
         const wrapper = root.querySelector('#ycs-com-all-c1r1');
         assert.equal(

--- a/app/tests/autoExpandReplyContext.test.ts
+++ b/app/tests/autoExpandReplyContext.test.ts
@@ -16,6 +16,7 @@ import {
     type CommentStateAccessor,
     type OriginChainDeps
 } from '../src/source/web-resources/ui/originChain';
+import { renderComment } from '../src/source/utils/renderView';
 import { GlobalStore } from '../src/source/utils/common';
 
 function buildParentComment(id: string, text: string): Record<string, any> {
@@ -222,6 +223,68 @@ test('Case E: multiple replies all expand independently', () => {
                 'each button should switch title after auto-expand'
             );
         }
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case G: renderComment invokes postBatchHook with batch wrapper after initial render', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent = buildParentComment('c1', 'parent text');
+        const reply = buildReplyComment('c1r1', 'reply text', parent, 1);
+
+        const hookCalls: HTMLElement[] = [];
+        const spy = (batchRoot: HTMLElement): void => {
+            hookCalls.push(batchRoot);
+        };
+
+        renderComment(root, [{ item: reply, refIndex: 1 }], {
+            querySearch: '',
+            postBatchHook: spy
+        });
+
+        assert.equal(hookCalls.length, 1, 'expected postBatchHook to be called once for initial batch');
+        assert.equal(hookCalls[0].id, 'ycs_wrap_comments', 'expected hook to receive ycs_wrap_comments wrapper');
+    } finally {
+        teardownRoot(root);
+    }
+});
+
+test('Case H: renderComment invokes postBatchHook again on show-more click', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const replies: Array<{ item: Record<string, any>; refIndex: number }> = [];
+        for (let i = 1; i <= 250; i += 1) {
+            const parent = buildParentComment(`c${i}`, `parent${i}`);
+            replies.push({ item: buildReplyComment(`c${i}r1`, `reply${i}`, parent, i), refIndex: i });
+        }
+
+        const hookCalls: HTMLElement[] = [];
+        const spy = (batchRoot: HTMLElement): void => {
+            hookCalls.push(batchRoot);
+        };
+
+        renderComment(root, replies, {
+            querySearch: '',
+            postBatchHook: spy
+        });
+
+        assert.equal(hookCalls.length, 1, 'expected one hook call after initial batch (200 items)');
+
+        const showMore = root.querySelector('#ycs_search_show_more') as HTMLElement;
+        assert.equal(showMore !== null, true, 'expected show-more button to exist when results exceed batch size');
+
+        showMore.click();
+
+        assert.equal(hookCalls.length, 2, 'expected second hook call after show-more click');
+        assert.equal(
+            hookCalls[1].id !== 'ycs_wrap_comments',
+            true,
+            'expected second hook to receive a fresh batch wrapper, not the main wrapper'
+        );
     } finally {
         teardownRoot(root);
     }

--- a/app/tests/autoExpandReplyContext.test.ts
+++ b/app/tests/autoExpandReplyContext.test.ts
@@ -290,6 +290,37 @@ test('Case H: renderComment invokes postBatchHook again on show-more click', () 
     }
 });
 
+test('Case I: renderComment + postBatchHook wiring auto-expands replies end-to-end', () => {
+    resetGlobalStore();
+    const root = setupRoot();
+    try {
+        const parent = buildParentComment('c1', 'parent text');
+        const reply = buildReplyComment('c1r1', 'reply text', parent, 1);
+        const stateAccessor: CommentStateAccessor = { getComments: () => [reply] };
+
+        (GlobalStore as any).autoExpandReplyContext = true;
+
+        renderComment(root, [{ item: reply, refIndex: 1 }], {
+            querySearch: '',
+            postBatchHook: (batchRoot: HTMLElement) => {
+                autoExpandAllRepliesIn(batchRoot, {
+                    stateAccessor,
+                    queryGetter: () => ''
+                });
+            }
+        });
+
+        const wrapper = root.querySelector('#ycs-com-all-c1r1');
+        assert.equal(
+            wrapper !== null,
+            true,
+            'expected origin chain wrapper after end-to-end renderComment + postBatchHook + autoExpandAllRepliesIn'
+        );
+    } finally {
+        teardownRoot(root);
+    }
+});
+
 test('Case F: expandOriginChainFor sets ycs-origin-trigger class on success', () => {
     resetGlobalStore();
     const root = setupRoot();


### PR DESCRIPTION
## Summary

Adds a new opt-in user setting `autoExpandReplyContext` that automatically expands the parent comment chain for every reply shown in search results, so users no longer need to click the collapse arrow on each reply to see its context.

The feature defaults to off. When enabled, search results paint first with collapsed buttons, then origin chains fill in progressively across animation frames so the main thread stays responsive on large result sets.

## Main Changes

### New `originChain` module

- Extracts origin-chain DOM logic into a single source of truth (`originChain.ts`), avoiding a circular dependency between `renderView` and `commentInteractions`.
- Exports `expandOriginChainFor(container, deps)` and `autoExpandAllRepliesIn(root, deps)`.
- `handleOpenCommentAll` now delegates the expand work to `expandOriginChainFor`, keeping its scroll-lock and icon/title toggle semantics intact.

### `renderComment` `postBatchHook`

- `renderComment` gains an optional `postBatchHook?: (batchRoot: HTMLElement) => void` invoked after every batch is appended (initial render and each Show more click).
- `renderCommentsResult` is the sole injection point, so `chat` and `transcript` render paths stay structurally isolated and unaffected.
- `handleOpenCommentAll` deliberately does not pass the hook when it calls `renderComment` internally, which guarantees no recursion.

### Fully deferred auto-expand

- `autoExpandAllRepliesIn` schedules all work through `requestAnimationFrame` (with a `setTimeout` fallback), chunk size 5, fully deferred — no synchronous first chunk.
- Each chunk stale-guards with `Element.isConnected` so queued chunks from a previous search silently skip cleared DOM.
- Trade-off: when enabled, users see collapsed buttons paint first, then origin chains progressively reveal over subsequent frames; the main thread no longer freezes on filter clicks with large result sets.

### New user option

- `autoExpandReplyContext` (boolean, default `false`) added to option defaults, `IYCSOptions`, options page markup, `opt_script`, and the `YCS_OPTIONS` handler in `appController`.
- Options page copy reminds the user to reload the page after toggling the setting, since `GlobalStore` is synced at page load only.

### Call-site cleanups

- `runCommentsPipeline` in `appController` now shares a single `stateAccessor` between `renderCommentsResult` and `registerCommentInteractions`.
- `timestampVizHandler` adopts the same shared-accessor pattern so its `renderCommentsResult` call gets auto-expand support.
- Two leftover inline `/[^\w-]/g` regexes in `commentInteractions` are replaced with the shared `safeDomKey` helper.

### Test infrastructure

- Adds `jsdom` and `@types/jsdom` as dev dependencies for DOM-based tests.
- `autoExpandReplyContext.test.ts` introduces 10 cases covering short-circuit behavior, idempotency, multi-reply expansion, end-to-end `postBatchHook` wiring, show-more batches, and the fully-deferred chunking contract.

### Docs

- `CLAUDE.md` gains gotcha #8 documenting the `postBatchHook` chunking and stale-guard rule, plus gotcha #9 on the `import type` requirement for the Node type-stripping loader.

---

## Screenshots

Options page checkbox
<img src=https://github.com/user-attachments/assets/25c5c691-b499-4b45-a433-0e9e4f985fc6  width=500>

Before: filter click with autoExpand off (baseline)
<img src=https://github.com/user-attachments/assets/1e72cb44-16e7-4952-83be-da08870c1b7d  width=600>

After: filter click with autoExpand on — collapsed buttons paint first, origin chains fill in across frames
<img src=https://github.com/user-attachments/assets/4a8dee6b-7a32-4e71-b33d-9d9a151e40e1  width=600>
