### PR TITLE
Add YCS sidebar option

### DIFF
--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -5,6 +5,7 @@ const options = {
     cache: true,
     autoClear: 200,
     hiddenByDefault: false,
+    sidebarByDefault: false,
     sortTimestamp: false,
     autoExpandReplyContext: false,
     hiddenByDefaultShorts: false,

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -529,6 +529,9 @@ html[dark] .ycs-origin-trigger {
 .ycs-app.ycs-in-sidebar .ycs-btn-toggle-sidebar.ycs-label-sidebar {
   display: none;
 }
+.ycs-app.ycs-in-sidebar {
+  margin-bottom: 8px;
+}
 .ycs-search-select {
   float: left;
   width: 107px;
@@ -1074,7 +1077,8 @@ html[dark] .ycs-infobar__search button {
 }
 
 .ycs-compact:not(.ycs-in-sidebar) #ycs_anchor_vmode,
-.ycs-compact:not(.ycs-in-sidebar) #ycs_view_mode {
+.ycs-compact:not(.ycs-in-sidebar) #ycs_view_mode,
+.ycs-compact:not(.ycs-in-sidebar) .ycs_extra_panel {
   display: none;
 }
 
@@ -1402,6 +1406,12 @@ html[dark] .ycs-export-all-comments {
   display: flex;
   flex-direction: column;
   width: 65%;
+}
+
+@media (max-width: 1000px) {
+  .ycs-search-wrap {
+    width: 100%;
+  }
 }
 
 .ycs-compact .ycs-search-wrap {

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -84,14 +84,85 @@ ytd-comments .ycs-app {
   margin-top: 5px;
 }
 
+.ycs-head-search {
+  position: relative;
+  overflow: visible;
+  margin-bottom: 4px;
+}
+
+.ycs_load_all {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  gap: 2px;
+  width: auto;
+  clear: none;
+  margin-left: 0;
+  margin-top: 4px;
+}
+
+.ycs-compact .ycs-head-search {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: baseline;
+  overflow: hidden;
+}
+
+.ycs-compact #ycs_title_information {
+  white-space: nowrap;
+  flex: 1;
+  margin-bottom: 0;
+}
+
+.ycs-compact .ycs_load_all {
+  position: static;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.ycs-compact .ycs_load_all > button {
+  width: auto;
+  min-width: auto;
+  padding: 4px 8px;
+  font-size: 12px;
+  display: block;
+}
+
+#ycs_title_information {
+  display: block;
+  float: none;
+  clear: both;
+}
+
+.ycs_load_all > button {
+  float: none;
+  display: block;
+  box-sizing: border-box;
+  width: 64px;
+  padding: 2px 4px;
+  font-size: 12px;
+  text-align: center;
+  white-space: nowrap;
+}
+
 #ycs-search-total-result {
   font-size: 13px;
-  width: 280px;
   margin: 0;
   padding: 0;
   display: inline-block;
-  margin-left: 15px;
   word-break: break-word;
+}
+
+.ycs-infobar {
+  clear: none;
 }
 
 #ycs_btn_timestamp_viz > svg {
@@ -163,7 +234,7 @@ html[dark] .ycs_btn_load-stop:hover {
   vertical-align: top;
   height: 32px;
   line-height: 1;
-  visibility: hidden; /* toggled by script */
+  display: none; /* toggled by script */
 }
 
 .ycs-search__input:focus {
@@ -245,9 +316,6 @@ html[dark] .ycs-open-reply {
 
 .ycs-open-reply,
 .ycs-comment-link,
-.ycs-open-comment,
-.ycs-open-comment-all,
-.ycs-gotochat-video,
 .ycs-goto-comment-time,
 .ycs-goto-video {
   cursor: pointer;
@@ -449,7 +517,18 @@ html[dark] .ycs-origin-trigger {
   width: 130px;
   display: inline-block;
 }
-
+.ycs-compact #ycs_cmnts,
+.ycs-compact #ycs_cmnts_chat,
+.ycs-compact #ycs_cmnts_video {
+  width: auto;
+}
+/* Sidebar button label toggle */
+.ycs-app:not(.ycs-in-sidebar) .ycs-btn-toggle-sidebar.ycs-label-main {
+  display: none;
+}
+.ycs-app.ycs-in-sidebar .ycs-btn-toggle-sidebar.ycs-label-sidebar {
+  display: none;
+}
 .ycs-search-select {
   float: left;
   width: 107px;
@@ -519,7 +598,7 @@ html[dark] .ycs-origin-trigger {
 }
 
 .ycs-btn-toggle-app {
-  margin-bottom: 1px;
+  margin-bottom: 0;
 }
 .ycs-app.ycs-collapsed .ycs-btn-toggle-app {
   margin-bottom: 0;
@@ -597,20 +676,29 @@ a.ycs-goto-video:visited {
 }
 
 #ycs-desc__search,
-.ycs-infobar__search,
 .ycs-infobar-field {
   display: inline-block;
 }
 
-.ycs-infobar__search button {
-  padding: 1px 4px;
-  margin: 1px 0;
-  font-size: 14px;
-  border: 1px solid #ececec;
+.ycs_infobar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  line-height: 19px;
 }
 
-#ycs-desc__search {
-  margin-right: 20px;
+.ycs-infobar__search {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.ycs-infobar__search button {
+  padding: 1px 4px;
+  font-size: 14px;
+  height: 19px;
+  line-height: 1;
+  border: 1px solid #ececec;
 }
 
 .ycs-search__input {
@@ -765,7 +853,7 @@ html[dark] .ycs-show_more_block:hover {
   justify-content: space-between;
   align-items: baseline;
   max-width: 990px;
-  margin: 8px 0px 8px 8px;
+  margin: 8px 0px 8px 0px;
 }
 
 .ycs-btn-panel > button {
@@ -898,7 +986,7 @@ html[dark] #ycs-search-result::-webkit-scrollbar-thumb:hover {
 
 .ycs_load_wrap,
 .ycs_open_wrap,
-.ycs_save_wrap {
+.ycs_dropdown_wrap {
   display: inline-block;
   margin-right: 2px;
 }
@@ -970,9 +1058,50 @@ html[dark] .ycs-infobar__search button {
   clear: both;
 }
 
+.ycs-compact #ycs-desc__search {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  line-height: 19px;
+}
+
+.ycs-compact .ycs_infobar {
+  display: contents;
+}
+
+.ycs-compact .ycs-infobar__search {
+  display: contents;
+}
+
+.ycs-compact:not(.ycs-in-sidebar) #ycs_anchor_vmode,
+.ycs-compact:not(.ycs-in-sidebar) #ycs_view_mode {
+  display: none;
+}
+
+.ycs-compact .ycs-infobar-field {
+  grid-column: 1;
+}
+
+.ycs-compact #ycs_cmnts,
+.ycs-compact #ycs_cmnts_chat,
+.ycs-compact #ycs_cmnts_video {
+  grid-column: 2;
+}
+
+.ycs-compact .ycs_infobar_btns {
+  grid-column: 3;
+}
+
+.ycs-compact:not(.ycs-in-sidebar) .ycs_language_wrap {
+  display: none;
+}
+
 .ycs_load_wrap,
-.ycs_open_wrap {
+.ycs_open_wrap,
+.ycs_save_wrap,
+.ycs_sort_wrap {
   float: left;
+  line-height: 19px;
 }
 
 .ycs_load_wrap {
@@ -1007,6 +1136,7 @@ html[dark] .ycs-infobar__search button {
   float: right;
   font-weight: bolder;
   cursor: pointer;
+  margin-top: 8px;
 }
 
 html[dark='true'] #ycs_btn_open_modal,
@@ -1177,7 +1307,9 @@ html[dark] .ycs_btn_primary {
 }
 
 #ycs_anchor_vmode {
-  height: 1px;
+  height: 0;
+  width: 0;
+  overflow: hidden;
   display: block;
 }
 
@@ -1187,25 +1319,18 @@ html[dark] .ycs_btn_primary {
 }
 
 #ycs-load-all {
-  display: block;
+  display: inline-block;
   min-width: 64px;
 }
 
 .ycs_btn_load-stop {
   border: 1px solid #ececec;
-  position: absolute;
   min-width: 64px;
   border-top: 0;
   background-color: #f9f9f9;
-  font-size: 12px;
   cursor: pointer;
-  padding: 0px;
+  padding: 6px;
   margin: 0;
-}
-
-html[dark='true'] .ycs_btn_load-stop,
-html[dark] .ycs_btn_load-stop {
-  border-top: 1px solid #181818;
 }
 
 .ycs-com-rp {
@@ -1273,16 +1398,36 @@ html[dark] .ycs-export-all-comments {
   margin-top: 32px;
 }
 
+.ycs-search-wrap {
+  display: flex;
+  flex-direction: column;
+  width: 65%;
+}
+
+.ycs-compact .ycs-search-wrap {
+  width: 100%;
+}
+
+.ycs-search-controls {
+  display: flex;
+  width: 100%;
+}
+
+.ycs-search-controls .ycs-searchbox {
+  flex: 1;
+  width: auto;
+  float: none;
+}
+
 .ycs-ext-search_block {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-items: baseline;
   margin-top: 5px;
 }
 
 .ycs-ext-search_option {
   display: inline-block;
-  margin-left: 15%;
 }
 
 .ycs-ext-search-opts {
@@ -1290,7 +1435,7 @@ html[dark] .ycs-export-all-comments {
 }
 
 .ycs-ext-search_link {
-  font-size: 11px;
+  font-size: 14px;
   font-weight: bold;
   text-decoration: none;
   color: black;
@@ -1305,7 +1450,8 @@ html[dark] .ycs-ext-search_link {
 
 #ycs_title_information {
   position: relative;
-  top: 5px;
+  top: 0;
+  margin-bottom: 8px;
 }
 
 .ycs-chip.ytd-comment-view-model {
@@ -1567,59 +1713,37 @@ html[dark] .ycs-floating-back-button:hover {
    Shorts Mode Customizations
    ======================================== */
 
-.ycs-app.ycs-app--shorts {
+.ycs-compact {
   margin-bottom: 0;
 }
 
-/* Load all and stop buttons on same line */
-.ycs-app--shorts #ycs-load-all {
-  display: inline-block;
-  margin-left: 8px;
-  margin-right: 0;
-}
-
-.ycs-app--shorts .ycs-head-search {
-  overflow: hidden;
-}
-
-.ycs-app--shorts .ycs_btn_load-stop {
-  position: static;
-  display: inline-block;
-  /* Match load-all button styles for alignment */
-  padding: 6px;
+.ycs-compact .ycs_btn_load-stop {
+  padding: 4px 8px;
   margin: 0;
   border: 1px solid #ececec;
   background-color: #f8f8f8;
+  border-top: 1px solid #ececec;
 }
 
-html[dark='true'] .ycs-app--shorts .ycs_btn_load-stop,
-html[dark] .ycs-app--shorts .ycs_btn_load-stop {
+html[dark='true'] .ycs-compact .ycs_btn_load-stop,
+html[dark] .ycs-compact .ycs_btn_load-stop {
   border: 1px solid #303030;
+  border-top: 1px solid #303030;
   background-color: #313131;
   color: #fff;
 }
 
 /* Add spacing between buttons and infobar */
-.ycs-app--shorts .ycs-infobar {
+.ycs-compact .ycs-infobar {
   margin-top: 10px;
 }
 
-.ycs-app--shorts #ycs-search {
+.ycs-compact #ycs-search {
   margin-top: 15px;
 }
 
-/* Hide transcript language selector */
-.ycs-app--shorts .ycs_language_wrap {
-  display: none;
-}
-
-/* Hide extra panel (View Mode button) */
-.ycs-app--shorts .ycs_extra_panel {
-  display: none;
-}
-
 /* Search result container adjustments */
-.ycs-app--shorts #ycs-search-result {
+.ycs-compact #ycs-search-result {
   overflow-y: auto;
   overflow-x: hidden;
   /* max-height will be set dynamically via JS */

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -117,6 +117,21 @@ window.onload = async (): Promise<void> => {
             }
         };
 
+        const setRenderSidebarByDefault = (param: boolean): void => {
+            if (typeof param !== 'boolean') return;
+            (document.getElementById('y_opts_sidebar_by_default') as HTMLInputElement).checked = param;
+        };
+
+        const optSetSidebarByDefault = async (opt: HTMLInputElement): Promise<void> => {
+            try {
+                await chrome.storage.local.set({
+                    sidebarByDefault: opt.checked
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
         const setRenderHiddenByDefaultShorts = (param: boolean): void => {
             if (typeof param !== 'boolean') return;
 
@@ -735,6 +750,10 @@ window.onload = async (): Promise<void> => {
                         setRenderHiddenByDefaultShorts(storageOpts[key]);
                         break;
 
+                    case 'sidebarByDefault':
+                        setRenderSidebarByDefault(storageOpts[key]);
+                        break;
+
                     case 'enableShortsSupport':
                         setRenderEnableShortsSupport(storageOpts[key]);
                         break;
@@ -819,6 +838,10 @@ window.onload = async (): Promise<void> => {
 
                 case 'y_opts_enable_shorts_support':
                     optSetEnableShortsSupport(e.target as HTMLInputElement);
+                    break;
+
+                case 'y_opts_sidebar_by_default':
+                    optSetSidebarByDefault(e.target as HTMLInputElement);
                     break;
 
                 case 'ycs_opts_btn_reset_filters':

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -69,6 +69,14 @@
         </div>
 
         <div>
+          <label for="y_opts_sidebar_by_default">Sidebar by default:</label>
+          <input type="checkbox" name="Sidebar by default" id="y_opts_sidebar_by_default" class="ycs_opts_checkbox" />
+          <div class="ycs_description_option ycs_api_desc">
+            <p>Move the YCS toggle bar to the right sidebar by default. Applies to regular video pages only.</p>
+          </div>
+        </div>
+
+        <div>
           <label for="y_opts_sort_timestamp">Sort timestamps by time:</label>
           <input type="checkbox" name="Sort timestamps by time" id="y_opts_sort_timestamp" class="ycs_opts_checkbox" />
           <div class="ycs_description_option ycs_api_desc">

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -331,6 +331,7 @@ export interface IYCSOptions {
     autoClear?: number;
     hiddenByDefault?: boolean;
     hiddenByDefaultShorts?: boolean;
+    sidebarByDefault?: boolean;
     enableShortsSupport?: boolean;
     filterButtons?: Array<{ id: string; enabled: boolean }>;
     transcriptLanguage?: string;

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { safeUrl } from '../utils/formatting';
-import { randomString, isShortsPage } from '../utils/common';
+import { randomString, isShortsPage, isPostsPage } from '../utils/common';
 import { markTextComment, getPiP } from '../utils/dom';
 import { options } from '../config/options';
 import { buildCommentViewModels, buildChatMessageViewModels, buildTranscriptViewModels } from './viewModels';
@@ -806,9 +806,9 @@ function renderLoadComments(
     }
 
     const nodeTag = document.createElement('div');
-    nodeTag.className = isShortsPage() ? 'ycs-app ycs-app--shorts' : 'ycs-app';
+    nodeTag.className = isShortsPage() ? 'ycs-app ycs-compact' : 'ycs-app';
     nodeTag.innerHTML = `
-        <div class="ycs-app-toggle"><p class="ycs-title ycs-left">YouTube Comment Search <span id="ycs-count-load-collapsed"></span></p><div class="ycs-right"><button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">Show YCS</button></div></div>
+        <div class="ycs-app-toggle"><p class="ycs-title ycs-left">YouTube Comment Search <span id="ycs-count-load-collapsed"></span></p><div class="ycs-right"><button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">Show YCS</button>${isShortsPage() || isPostsPage() ? '' : '<button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-sidebar" type="button" title="Move YCS to the sidebar">Sidebar</button><button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-main" type="button" title="Move YCS back to the main column">Main</button>'}</div></div>
         <div class="ycs-app-main">
             <div class="ycs-head-search">
                 <p class="ycs-title ycs-left" id="ycs_title_information">
@@ -816,6 +816,7 @@ function renderLoadComments(
                 </p>
                 <div class="ycs_load_all ycs-right">
                     <button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">hide YCS</button>
+                    ${isShortsPage() || isPostsPage() ? '' : '<button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-sidebar" type="button" title="Move YCS to the sidebar">Sidebar</button><button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-main" type="button" title="Move YCS back to the main column">Main</button>'}
                     <button id="ycs-load-all" class="ycs-btn-search ycs-title ycs_noselect" name="Load all comments" type="button"
                         title="Load all available comments">
                         Load all
@@ -829,7 +830,7 @@ function renderLoadComments(
             <div class="ycs-title ycs-clear ycs-infobar">
                 <div id="ycs-desc__search">
 
-                    <div>
+                    <div class="ycs_infobar">
                         <p class="ycs-infobar-field"><span id="ycs_status_cmnt">${iconReload()}</span> Comments: </p>
                         <div class="ycs-infobar__search">
                             <span id="ycs_cmnts">0</span>
@@ -869,7 +870,7 @@ function renderLoadComments(
                         </div>
                     </div>
                     <span id="ycs_anchor_vmode" class="ycs-hidden"></span>
-                    <div>
+                    <div class="ycs_infobar">
                         <p class="ycs-infobar-field"><span id="ycs_status_chat">${iconReload()}</span> Chat replay: </p>
                         <div class="ycs-infobar__search">
                             <span id="ycs_cmnts_chat">0</span>
@@ -912,7 +913,7 @@ function renderLoadComments(
                             </div>
                         </div>
                     </div>
-                    <div>
+                    <div class="ycs_infobar">
                         <p class="ycs-infobar-field"><span id="ycs_status_trvideo">${iconReload()}</span> Transcript video: </p>
                         <div class="ycs-infobar__search">
                             <span id="ycs_cmnts_video">0</span>
@@ -1210,21 +1211,23 @@ function renderSearch(node: HTMLElement): void {
 
     node.innerHTML = `
         <div>
-            <div>
-                <div class="ycs-searchbox">
-                    <input title="Write the search query, press Enter or click the button Search."
-                        class="ycs-search__input ycs_noselect" type="text" id="ycs-input-search" placeholder="Search">
-                </div>
-                <select title="Select a search category." name="ycs_search_select"
-                    id="ycs_search_select" class="ycs-btn-search ycs-title ycs-search-select ycs_noselect">
-                    <option value="comments">Comments</option>
-                    <option value="chat">Chat replay</option>
-                    <option value="video">Trpt. video</option>
-                    <option selected value="all">All</option>
-                </select>
-                <button id="ycs_btn_search" class="ycs-btn-search ycs-title ycs_noselect" type="button">
-                    Search
-                </button><button id="ycs_btn_search_clear_text" class="ycs-btn-search ycs-title ycs-search-clear" type="button" title="Clear text">✕</button>
+            <div class="ycs-search-wrap">
+                <span class="ycs-search-controls">
+                    <div class="ycs-searchbox">
+                        <input title="Write the search query, press Enter or click the button Search."
+                            class="ycs-search__input ycs_noselect" type="text" id="ycs-input-search" placeholder="Search">
+                    </div>
+                    <select title="Select a search category." name="ycs_search_select"
+                        id="ycs_search_select" class="ycs-btn-search ycs-title ycs-search-select ycs_noselect">
+                        <option value="comments">Comments</option>
+                        <option value="chat">Chat replay</option>
+                        <option value="video">Trpt. video</option>
+                        <option selected value="all">All</option>
+                    </select>
+                    <button id="ycs_btn_search" class="ycs-btn-search ycs-title ycs_noselect" type="button">
+                        Search
+                    </button><button id="ycs_btn_search_clear_text" class="ycs-btn-search ycs-title ycs-search-clear" type="button" title="Clear text">✕</button>
+                </span>
 
                 <div class="ycs-ext-search_block">
                     <p id="ycs-search-total-result" class="ycs-title"></p>
@@ -1251,9 +1254,8 @@ function renderSearch(node: HTMLElement): void {
                         <a href="https://github.com/sonigy/YCS#extended-search" class="ycs-title ycs-ext-search_link" target="_blank" rel="noopener noreferrer" title="How to use">?</a>
                     </div>
                 </div>
-
-                <button id="ycs_btn_open_modal" class="ycs_noselect" title="FAQ">?</button>
             </div>
+            <button id="ycs_btn_open_modal" class="ycs_noselect" title="FAQ">?</button>
             <div class="ycs-search-result-infobar">
 
                 <div class="ycs-btn-panel ycs_noselect" id="ycs-btn-panel">

--- a/app/src/source/utils/renderView.ts
+++ b/app/src/source/utils/renderView.ts
@@ -762,6 +762,16 @@ function renderLoadComments(
         }
     };
 
+    const sidebarToggleButtons = (): string => {
+        if (isShortsPage() || isPostsPage()) return '';
+        return (
+            '<button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-sidebar" ' +
+            'type="button" title="Move YCS to the sidebar">Sidebar</button>' +
+            '<button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-main" ' +
+            'type="button" title="Move YCS back to the main column">Main</button>'
+        );
+    };
+
     const node = document.querySelector(selector);
 
     // Visibility check and fallback mechanism
@@ -808,7 +818,7 @@ function renderLoadComments(
     const nodeTag = document.createElement('div');
     nodeTag.className = isShortsPage() ? 'ycs-app ycs-compact' : 'ycs-app';
     nodeTag.innerHTML = `
-        <div class="ycs-app-toggle"><p class="ycs-title ycs-left">YouTube Comment Search <span id="ycs-count-load-collapsed"></span></p><div class="ycs-right"><button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">Show YCS</button>${isShortsPage() || isPostsPage() ? '' : '<button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-sidebar" type="button" title="Move YCS to the sidebar">Sidebar</button><button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-main" type="button" title="Move YCS back to the main column">Main</button>'}</div></div>
+        <div class="ycs-app-toggle"><p class="ycs-title ycs-left">YouTube Comment Search <span id="ycs-count-load-collapsed"></span></p><div class="ycs-right"><button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">Show YCS</button>${sidebarToggleButtons()}</div></div>
         <div class="ycs-app-main">
             <div class="ycs-head-search">
                 <p class="ycs-title ycs-left" id="ycs_title_information">
@@ -816,7 +826,7 @@ function renderLoadComments(
                 </p>
                 <div class="ycs_load_all ycs-right">
                     <button class="ycs-btn-toggle-app ycs-btn-search ycs_noselect" type="button">hide YCS</button>
-                    ${isShortsPage() || isPostsPage() ? '' : '<button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-sidebar" type="button" title="Move YCS to the sidebar">Sidebar</button><button class="ycs-btn-toggle-sidebar ycs-btn-search ycs_noselect ycs-label-main" type="button" title="Move YCS back to the main column">Main</button>'}
+                    ${sidebarToggleButtons()}
                     <button id="ycs-load-all" class="ycs-btn-search ycs-title ycs_noselect" name="Load all comments" type="button"
                         title="Load all available comments">
                         Load all

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -401,6 +401,54 @@ export function initApp(): void {
             }
         }
 
+        let sidebarMountParent: HTMLElement | null = null;
+        let sidebarMountNextSibling: ChildNode | null = null;
+
+        const getSidebarMountTarget = (): HTMLElement | null => {
+            return (
+                (document.querySelector('#secondary-inner') as HTMLElement | null) ||
+                (document.querySelector('#secondary') as HTMLElement | null)
+            );
+        };
+
+        const getAppElement = (): HTMLElement | null => document.querySelector('.ycs-app') as HTMLElement | null;
+
+        const moveYcsToSidebar = (): void => {
+            const app = getAppElement();
+            const sidebarTarget = getSidebarMountTarget();
+
+            if (!app || !sidebarTarget) {
+                return;
+            }
+
+            if (!sidebarMountParent) {
+                sidebarMountParent = app.parentElement;
+                sidebarMountNextSibling = app.nextSibling;
+            }
+
+            if (app.parentElement !== sidebarTarget) {
+                sidebarTarget.prepend(app);
+            }
+
+            app.classList.add('ycs-in-sidebar', 'ycs-compact');
+        };
+
+        const restoreYcsFromSidebar = (): void => {
+            const app = getAppElement();
+
+            if (!app || !sidebarMountParent) {
+                return;
+            }
+
+            if (sidebarMountNextSibling && sidebarMountNextSibling.parentNode === sidebarMountParent) {
+                sidebarMountParent.insertBefore(app, sidebarMountNextSibling);
+            } else {
+                sidebarMountParent.appendChild(app);
+            }
+
+            app.classList.remove('ycs-in-sidebar', 'ycs-compact');
+        };
+
         const elSearch = document.getElementById('ycs-search');
         if (elSearch) {
             renderSearch(elSearch);
@@ -458,6 +506,26 @@ export function initApp(): void {
                                         adjustEngagementPanelHeightForShorts();
                                     }, 100);
                                 }
+                            }
+                        },
+                        false
+                    );
+                }
+
+                const sidebarToggles = document.getElementsByClassName('ycs-btn-toggle-sidebar');
+                for (const toggle of Array.from(sidebarToggles)) {
+                    (toggle as HTMLElement).addEventListener(
+                        'click',
+                        () => {
+                            const app = getAppElement();
+                            if (!app) {
+                                return;
+                            }
+
+                            if (app.classList.contains('ycs-in-sidebar')) {
+                                restoreYcsFromSidebar();
+                            } else {
+                                moveYcsToSidebar();
                             }
                         },
                         false
@@ -1129,15 +1197,15 @@ export function initApp(): void {
             eInputSearch.addEventListener('input', () => {
                 const hasText = (eInputSearch as HTMLInputElement).value.trim().length > 0;
                 if (btnSearchClearText) {
-                    (btnSearchClearText as HTMLButtonElement).style.visibility = hasText ? 'visible' : 'hidden';
+                    (btnSearchClearText as HTMLButtonElement).style.display = hasText ? 'inline-block' : 'none';
                 }
             });
         }
 
         // initialize clear-text button visibility
         if (btnSearchClearText) {
-            (btnSearchClearText as HTMLButtonElement).style.visibility =
-                (eInputSearch as HTMLInputElement)?.value?.trim()?.length > 0 ? 'visible' : 'hidden';
+            (btnSearchClearText as HTMLButtonElement).style.display =
+                (eInputSearch as HTMLInputElement)?.value?.trim()?.length > 0 ? 'inline-block' : 'none';
             btnSearchClearText.addEventListener('click', () => {
                 try {
                     if (eInputSearch) {
@@ -1161,7 +1229,7 @@ export function initApp(): void {
                     }
 
                     // hide clear button after clearing
-                    (btnSearchClearText as HTMLButtonElement).style.visibility = 'hidden';
+                    (btnSearchClearText as HTMLButtonElement).style.display = 'none';
                     const btnClear = document.getElementById('ycs_btn_clear') as HTMLButtonElement | null;
                     if (btnClear) {
                         (btnClear as HTMLButtonElement).style.visibility = 'hidden';
@@ -1705,6 +1773,19 @@ export function initApp(): void {
                     }
                 };
 
+                const optSidebarByDefault = (opts: IYCSOptions): void => {
+                    try {
+                        if (!opts.sidebarByDefault || isShortsPage() || isPostsPage()) return;
+
+                        const app = document.querySelector('.ycs-app') as HTMLElement;
+                        if (app && !app.classList.contains('ycs-in-sidebar')) {
+                            moveYcsToSidebar();
+                        }
+                    } catch (err) {
+                        console.error(err);
+                    }
+                };
+
                 try {
                     const opts = (e.data.text ?? {}) as IYCSOptions;
 
@@ -1760,6 +1841,10 @@ export function initApp(): void {
 
                             case 'hiddenByDefault':
                                 optHiddenByDefault(opts);
+                                break;
+
+                            case 'sidebarByDefault':
+                                optSidebarByDefault(opts);
                                 break;
 
                             case 'hiddenByDefaultShorts':

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -440,6 +440,13 @@ export function initApp(): void {
                 return;
             }
 
+            if (!sidebarMountParent.isConnected) {
+                sidebarMountParent = null;
+                sidebarMountNextSibling = null;
+                app.classList.remove('ycs-in-sidebar', 'ycs-compact');
+                return;
+            }
+
             if (sidebarMountNextSibling && sidebarMountNextSibling.parentNode === sidebarMountParent) {
                 sidebarMountParent.insertBefore(app, sidebarMountNextSibling);
             } else {


### PR DESCRIPTION
Adds a sidebar mode for YCS that moves the extension panel into YouTube's sidebar, along with a new option to enable it by default. The reason I created this PR is to allow users to search for comments without using vmode while watching a YT video.

- Sidebar toggle buttons: "Sidebar"/"Main" buttons in both the collapsible header and the head-search area let users move YCS between the main column and sidebar at any time
- Sidebar-by-default option: New option in the options page; when enabled, YCS automatically opens in the sidebar on regular video pages
- The YCS on the sidebar CSS is basically the same as the YT shorts so the class for ytshorts has been changed into a shared class called ycs-compact for both ytshorts and ycs-in-sidebar. 
- Miscellaneous CSS adjustments
 
I haven't tested this on narrow/small screens so there might be some oversight with different screens.