### PR TITLE
feat(sidebar): add showSidebarToggle option to hide Sidebar/Main toggle button

### DIFF
--- a/app/src/source/config/options.ts
+++ b/app/src/source/config/options.ts
@@ -6,6 +6,7 @@ const options = {
     autoClear: 200,
     hiddenByDefault: false,
     sidebarByDefault: false,
+    showSidebarToggle: true,
     sortTimestamp: false,
     autoExpandReplyContext: false,
     hiddenByDefaultShorts: false,

--- a/app/src/source/content-scripts/style.css
+++ b/app/src/source/content-scripts/style.css
@@ -623,6 +623,10 @@ html[dark] .ycs-origin-trigger {
 .ycs-app.ycs-in-sidebar .ycs-btn-toggle-sidebar.ycs-label-sidebar {
   display: none;
 }
+/* Hide the Sidebar/Main toggle entirely (showSidebarToggle option off) */
+.ycs-app.ycs-hide-sidebar-toggle .ycs-btn-toggle-sidebar {
+  display: none;
+}
 .ycs-app.ycs-in-sidebar {
   margin-bottom: 8px;
 }
@@ -689,6 +693,11 @@ html[dark] .ycs-origin-trigger {
   display: flex;
   justify-content: space-between;
   align-items: center;
+}
+.ycs-app-toggle .ycs-right {
+  display: flex;
+  align-items: center;
+  gap: 2px;
 }
 .ycs-app-toggle .ycs-title {
   margin-top: -3px;

--- a/app/src/source/options/assets/ts/opt_script.ts
+++ b/app/src/source/options/assets/ts/opt_script.ts
@@ -134,6 +134,21 @@ window.onload = async (): Promise<void> => {
             }
         };
 
+        const setRenderShowSidebarToggle = (param: boolean): void => {
+            if (typeof param !== 'boolean') return;
+            (document.getElementById('y_opts_show_sidebar_toggle') as HTMLInputElement).checked = param;
+        };
+
+        const optSetShowSidebarToggle = async (opt: HTMLInputElement): Promise<void> => {
+            try {
+                await chrome.storage.local.set({
+                    showSidebarToggle: opt.checked
+                });
+            } catch (err) {
+                console.error(err);
+            }
+        };
+
         const setRenderHiddenByDefaultShorts = (param: boolean): void => {
             if (typeof param !== 'boolean') return;
 
@@ -812,6 +827,10 @@ window.onload = async (): Promise<void> => {
                         setRenderSidebarByDefault(storageOpts[key]);
                         break;
 
+                    case 'showSidebarToggle':
+                        setRenderShowSidebarToggle(storageOpts[key]);
+                        break;
+
                     case 'enableShortsSupport':
                         setRenderEnableShortsSupport(storageOpts[key]);
                         break;
@@ -905,6 +924,10 @@ window.onload = async (): Promise<void> => {
 
                 case 'y_opts_sidebar_by_default':
                     optSetSidebarByDefault(e.target as HTMLInputElement);
+                    break;
+
+                case 'y_opts_show_sidebar_toggle':
+                    optSetShowSidebarToggle(e.target as HTMLInputElement);
                     break;
 
                 case 'ycs_opts_btn_reset_filters':

--- a/app/src/source/options/options.html
+++ b/app/src/source/options/options.html
@@ -77,6 +77,22 @@
         </div>
 
         <div>
+          <label for="y_opts_show_sidebar_toggle">Show Sidebar/Main toggle button:</label>
+          <input
+            type="checkbox"
+            name="Show Sidebar/Main toggle button"
+            id="y_opts_show_sidebar_toggle"
+            class="ycs_opts_checkbox"
+          />
+          <div class="ycs_description_option ycs_api_desc">
+            <p>
+              Show the Sidebar/Main toggle button on the YCS bar. When off, the placement follows "Sidebar by default"
+              only. Applies to regular video pages only.
+            </p>
+          </div>
+        </div>
+
+        <div>
           <label for="y_opts_sort_timestamp">Sort timestamps by time:</label>
           <input type="checkbox" name="Sort timestamps by time" id="y_opts_sort_timestamp" class="ycs_opts_checkbox" />
           <div class="ycs_description_option ycs_api_desc">

--- a/app/src/source/utils/interfaces/i_types.ts
+++ b/app/src/source/utils/interfaces/i_types.ts
@@ -334,6 +334,7 @@ export interface IYCSOptions {
     hiddenByDefault?: boolean;
     hiddenByDefaultShorts?: boolean;
     sidebarByDefault?: boolean;
+    showSidebarToggle?: boolean;
     enableShortsSupport?: boolean;
     filterButtons?: Array<{ id: string; enabled: boolean }>;
     transcriptLanguage?: string;

--- a/app/src/source/web-resources/appController.ts
+++ b/app/src/source/web-resources/appController.ts
@@ -2718,6 +2718,19 @@ export function initApp(): void {
                     }
                 };
 
+                const optShowSidebarToggle = (opts: IYCSOptions): void => {
+                    try {
+                        const app = document.querySelector('.ycs-app') as HTMLElement | null;
+                        if (!app) return;
+
+                        // Absent key on old profiles means default true
+                        const show = opts.showSidebarToggle !== false;
+                        app.classList.toggle('ycs-hide-sidebar-toggle', !show);
+                    } catch (err) {
+                        console.error(err);
+                    }
+                };
+
                 try {
                     const opts = (e.data.text ?? {}) as IYCSOptions;
 
@@ -2785,6 +2798,10 @@ export function initApp(): void {
 
                             case 'sidebarByDefault':
                                 optSidebarByDefault(opts);
+                                break;
+
+                            case 'showSidebarToggle':
+                                optShowSidebarToggle(opts);
                                 break;
 
                             case 'hiddenByDefaultShorts':


### PR DESCRIPTION
## Summary

Some users only ever use the main-column view, and the "Sidebar" button sits right next to "Show YCS" — easy to hit by mistake, and it moves the whole panel when you do (#159).

This PR adds a new setting, **Show Sidebar/Main toggle button** (on by default), that lets those users remove the button entirely. With the button hidden, panel placement is controlled from the options page via the existing "Sidebar by default" setting.

## Key Changes

- New checkbox in the options page: **Show Sidebar/Main toggle button**, placed right after "Sidebar by default". It is on by default, so nothing changes for existing users until they opt out.
- When turned off, the Sidebar/Main buttons disappear from both the collapsed YCS bar and the expanded header. YCS then always appears where "Sidebar by default" says it should.
- Applies to regular video pages only — Shorts and community post pages never had the toggle.
- Small polish from the same report: a 2px gap between the "Show YCS" button and the sidebar toggle in the collapsed bar, so the two buttons no longer sit flush against each other.
- Changing the setting takes effect on the next page load — YCS reads options when the panel renders, so there is no live toggle on an already-open page.

## Test Plan

- [ ] Default behavior: with the new setting untouched (on), the Sidebar/Main toggle still shows and works as before on a regular video page.
- [ ] Turn the setting off, reload a video page: the toggle is gone from both the collapsed bar and the expanded header.
- [ ] With the setting off and "Sidebar by default" on, YCS mounts in the right sidebar; with "Sidebar by default" off, it stays in the main column.
- [ ] Turn the setting back on, reload: the toggle reappears.
- [ ] Collapsed bar shows a small gap between "Show YCS" and "Sidebar".
- [ ] Existing profile (no stored value for the new key): video pages behave as if the setting were on.

---

<img width="800" alt="CleanShot 2026-07-29 at 23 56 30@2x" src="https://github.com/user-attachments/assets/9bd54626-2c32-44e4-8144-5b4d1a61efd0" />

